### PR TITLE
rdoc task is broken in beta22

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ require "yaml"
 
 require "rake/rdoctask"
 require "rspec/core/rake_task"
+require "rspec/core/version"
 require "cucumber/rake/task"
 
 RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
The rdoc task is broken in beta22 due to RSpec::Core::Version::STRING not being defined. This happens because rspec/core/rake_task isn't pulling in version. I've fixed this by explicitly pulling in version in the Rakefile, since it didn't make sense to me for the rake_task to provide the version, but perhaps you have a different opinion about this.
