### PR TITLE
[doc] Add do for its method documentation

### DIFF
--- a/lib/rspec/core/subject.rb
+++ b/lib/rspec/core/subject.rb
@@ -86,7 +86,7 @@ module RSpec
         # with dots, the result is as though you concatenated that +String+
         # onto the subject in an expression.
         #   
-        #   describe Person 
+        #   describe Person do
         #     let(:person) do
         #       person = Person.new
         #       person.phone_numbers << "555-1212"


### PR DESCRIPTION
I noticed a missing do in the documentation. Here's a commit to add it.
