### PR TITLE
Make specs independent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,13 @@ gem "rr"
 gem "flexmock"
 gem "nokogiri"
 gem "syntax"
+
 gem "rspec-core", :path => "."
-gem "rspec-expectations", :path => "../rspec-expectations"
-gem "rspec-mocks", :path => "../rspec-mocks"
+%w[rspec-expectations rspec-mocks].each do |dependency|
+  path = "../#{dependency}"
+  gem dependency, :path => (path if File.exist?(path))
+end
+
 unless RUBY_PLATFORM == "java"
   case RUBY_VERSION
   when /^1.9.2/


### PR DESCRIPTION
No need to check out the dependent projects, just the one someone is working on.
And in case simultanouse work is done on both checkout is still supported.
