### PR TITLE
before/after(:all) hook filtering fix

### DIFF
--- a/features/filtering/exclusion_filters.feature
+++ b/features/filtering/exclusion_filters.feature
@@ -77,3 +77,34 @@ Feature: exclusion filters
     And  the output should contain "0 examples, 0 failures"
     And  the output should not contain "group 1"
     And  the output should not contain "group 2"
+
+  Scenario: before/after(:all) hook in excluded example group
+    Given a file named "spec/before_after_all_exclusion_filter_spec.rb" with:
+      """
+      RSpec.configure do |c|
+        c.filter_run_excluding :broken => true
+      end
+
+      describe "group 1" do
+        before(:all) { puts "before all in focused group" }
+        after(:all)  { puts "after all in focused group"  }
+
+        it "group 1 example" do
+        end
+      end
+
+      describe "group 2", :broken => true do
+        before(:all) { puts "before all in unfocused group" }
+        after(:all)  { puts "after all in unfocused group"  }
+
+        context "context 1" do
+          it "group 2 context 1 example 1" do
+          end
+        end
+      end
+      """
+    When I run "rspec ./spec/before_after_all_exclusion_filter_spec.rb"
+    Then the output should contain "before all in focused group"
+     And the output should contain "after all in focused group"
+     And the output should not contain "before all in unfocused group"
+     And the output should not contain "after all in unfocused group"

--- a/features/filtering/inclusion_filters.feature
+++ b/features/filtering/inclusion_filters.feature
@@ -72,3 +72,33 @@ Feature: inclusion filters
     And  the output should contain "group 2 example 1"
     And  the output should contain "3 examples, 0 failures"
 
+  Scenario: before/after(:all) hook in unmatched example group
+    Given a file named "spec/before_after_all_inclusion_filter_spec.rb" with:
+      """
+      RSpec.configure do |c|
+        c.filter_run :focus => true
+      end
+
+      describe "group 1", :focus => true do
+        before(:all) { puts "before all in focused group" }
+        after(:all)  { puts "after all in focused group"  }
+
+        it "group 1 example" do
+        end
+      end
+
+      describe "group 2" do
+        before(:all) { puts "before all in unfocused group" }
+        after(:all)  { puts "after all in unfocused group"  }
+
+        context "context 1" do
+          it "group 2 context 1 example 1" do
+          end
+        end
+      end
+      """
+    When I run "rspec ./spec/before_after_all_inclusion_filter_spec.rb"
+    Then the output should contain "before all in focused group"
+     And the output should contain "after all in focused group"
+     And the output should not contain "before all in unfocused group"
+     And the output should not contain "after all in unfocused group"

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -97,6 +97,10 @@ module RSpec
         @descendant_filtered_examples ||= filtered_examples + children.collect{|c| c.descendant_filtered_examples}
       end
 
+      def self.any_descendant_filtered_examples?
+        descendant_filtered_examples.flatten.any?
+      end
+
       def self.metadata
         @metadata if defined?(@metadata)
       end
@@ -168,7 +172,7 @@ module RSpec
       end
 
       def self.eval_before_alls(example_group_instance)
-        return if descendant_filtered_examples.empty?
+        return unless any_descendant_filtered_examples?
         assign_before_all_ivars(superclass.before_all_ivars, example_group_instance)
         world.run_hook_filtered(:before, :all, self, example_group_instance) if top_level?
         run_hook!(:before, :all, example_group_instance)
@@ -193,7 +197,7 @@ module RSpec
       end
 
       def self.eval_after_alls(example_group_instance)
-        return if descendant_filtered_examples.empty?
+        return unless any_descendant_filtered_examples?
         assign_before_all_ivars(before_all_ivars, example_group_instance)
         run_hook!(:after, :all, example_group_instance)
         world.run_hook_filtered(:after, :all, self, example_group_instance) if top_level?

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -260,6 +260,37 @@ module RSpec::Core
         order.should == [3,2,1]
       end
 
+      it "only runs before/after(:all) hooks from example groups that have specs that run" do
+        hooks_run = []
+
+        RSpec.configure do |c|
+          c.filter_run :focus => true
+        end
+
+        unfiltered_group = ExampleGroup.describe "unfiltered" do
+          before(:all) { hooks_run << :unfiltered_before_all }
+          after(:all)  { hooks_run << :unfiltered_after_all  }
+
+          context "a subcontext" do
+            it("has an example") { }
+          end
+        end
+
+        filtered_group = ExampleGroup.describe "filtered", :focus => true do
+          before(:all) { hooks_run << :filtered_before_all }
+          after(:all)  { hooks_run << :filtered_after_all  }
+
+          context "a subcontext" do
+            it("has an example") { }
+          end
+        end
+
+        unfiltered_group.run_all
+        filtered_group.run_all
+
+        hooks_run.should == [:filtered_before_all, :filtered_after_all]
+      end
+
       it "runs before_all_defined_in_config, before all, before each, example, after each, after all, after_all_defined_in_config in that order" do
         order = []
 


### PR DESCRIPTION
This commit fixes a bug with before/after(:all) hooks being run for example groups that have been excluded from running the an inclusion/exclusion filter.
