### PR TITLE
Fix before(:all) error handling so that it fails examples in nested groups, too.

### DIFF
--- a/features/hooks/before_and_after_hooks.feature
+++ b/features/hooks/before_and_after_hooks.feature
@@ -114,15 +114,33 @@ Feature: before and after hooks
         after(:all) do
           puts "after all ran"
         end
+
+        describe "nested group" do
+          it "fails this third example" do
+          end
+
+          it "fails this fourth example" do
+          end
+
+          describe "yet another level deep" do
+            it "fails this last example" do
+            end
+          end
+        end
       end
       """
     When I run "rspec ./before_all_spec.rb --format documentation"
-    Then the output should contain "2 examples, 2 failures"
+    Then the output should contain "5 examples, 5 failures"
     And the output should contain:
       """
       an error in before(:all)
         fails this example (FAILED - 1)
         fails this example, too (FAILED - 2)
+        nested group
+          fails this third example (FAILED - 3)
+          fails this fourth example (FAILED - 4)
+          yet another level deep
+            fails this last example (FAILED - 5)
       after all ran
       """
 
@@ -132,6 +150,8 @@ Feature: before and after hooks
       """
       an error in before(:all)
         fails this example, too (FAILED - 1)
+        nested group
+          yet another level deep
       after all ran
       """
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -227,6 +227,12 @@ module RSpec
 
       def self.fail_filtered_examples(exception, reporter)
         filtered_examples.each { |example| example.fail_fast(reporter, exception) }
+
+        children.each do |child|
+          reporter.example_group_started(child)
+          child.fail_filtered_examples(exception, reporter)
+          reporter.example_group_finished(child)
+        end
       end
 
       def self.run_examples(instance, reporter)

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -336,6 +336,23 @@ module RSpec::Core
         example.metadata[:execution_result][:exception_encountered].message.should == "error in before all"
       end
 
+      it "treats an error in before(:all) as a failure for a spec in a nested group" do
+        example = nil
+        group = ExampleGroup.describe do
+          before(:all) { raise "error in before all" }
+
+          describe "nested" do
+            example = it("equality") { 1.should == 2}
+          end
+        end
+        group.run_all
+
+        example.metadata.should_not be_nil
+        example.metadata[:execution_result].should_not be_nil
+        example.metadata[:execution_result][:exception_encountered].should_not be_nil
+        example.metadata[:execution_result][:exception_encountered].message.should == "error in before all"
+      end
+
       it "has no 'running example' within before(:all)" do
         group = ExampleGroup.describe
         running_example = :none


### PR DESCRIPTION
For one of my projects, I had a spec like this:

<pre>
describe SomeClass do
  before(:all) { ... }

  describe "#some_method" do
    it "does something" do
    end
  end
end
</pre>


My `before(:all)` hook started to raise an exception.  However, RSpec 2 apparently ignored the error.  The `it "does something"` spec wasn't even run or counted, and no error was reported.  I only noticed something was amiss because the example count suddenly dropped by a couple hundred even though I hadn't removed any.

The existing code handled the case of examples being in the same group as the failing `before(:all)` hook, but did not handle the case of examples being in a sub-group of the group with the failing `before(:all)` hook.  The child specs were simply being ignored.

My commit fixes this.
