### PR TITLE
Optparse output bug fix

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -52,7 +52,7 @@ module RSpec::Core
         end
 
         parser.on('-o', '--out FILE', 'output to a file instead of STDOUT') do |o|
-          options[:output_stream] = File.new(o)
+          options[:output_stream] = File.open(o,'w')
         end
 
         parser.on_tail('-h', '--help', "You're looking at it.") do

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -25,13 +25,13 @@ module RSpec::Core
     end
 
     it "parses output stream from --out" do
-      File.should_receive(:new).with("foo.txt").and_return(output_file)
+      File.should_receive(:open).with("foo.txt",'w').and_return(output_file)
       options = Parser.parse!(%w[--out foo.txt])
       options.should eq( {:output_stream=>output_file} )
     end
 
     it "parses output stream from -o" do
-      File.should_receive(:new).with("foo.txt").and_return(output_file)
+      File.should_receive(:open).with("foo.txt",'w').and_return(output_file)
       options = Parser.parse!(%w[-o foo.txt])
       options.should eq( {:output_stream=>output_file} )
     end


### PR DESCRIPTION
After running
    rspec --out foo.txt
I get the following message:
    lib/rspec/core/formatters/base_text_formatter.rb:10:in `message': private method`puts' called for "foo.txt":String (NoMethodError)
