### PR TITLE
Please allow passing :caller into Metadata to make life easier for extensions

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -32,7 +32,7 @@ module RSpec
         self[:example_group][:full_description] = full_description_from(*args)
 
         self[:example_group][:block] = user_metadata.delete(:example_group_block)
-        self[:example_group][:file_path], self[:example_group][:line_number] = file_and_line_number_from(caller)
+        self[:example_group][:file_path], self[:example_group][:line_number] = file_and_line_number_from(user_metadata.delete(:caller) || caller)
         self[:example_group][:location] = location_from(self[:example_group])
 
         update(user_metadata)
@@ -68,7 +68,7 @@ EOM
         store(:description, description.to_s)
         store(:full_description, "#{self[:example_group][:full_description]} #{self[:description]}")
         store(:execution_result, {})
-        self[:file_path], self[:line_number] = file_and_line_number_from(caller)
+        self[:file_path], self[:line_number] = file_and_line_number_from(options.delete(:caller) || caller)
         self[:location] = location_from(self)
         update(options)
       end

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -13,6 +13,12 @@ module RSpec
             end.to raise_error(/:#{key} is not allowed/)
           end
         end
+        
+        it "uses :caller if passed as part of the user metadata" do
+          m = Metadata.new
+          m.process('group', :caller => ['example_file:42'])
+          m[:example_group][:location].should == 'example_file:42'
+        end
       end
 
       describe "description" do
@@ -198,6 +204,11 @@ module RSpec
 
         it "extracts location from caller" do
           mfe[:location].should == "#{__FILE__}:#{line_number}"
+        end
+        
+        it "uses :caller if passed as an option" do
+          example_metadata = metadata.for_example('example description', {:caller => ['example_file:42']})
+          example_metadata[:location].should == 'example_file:42'
         end
 
         it "merges arbitrary options" do


### PR DESCRIPTION
A recent change to rspec-core broke rspec-unit in a rather ugly way.  This pull request would put things right without losing the benefits of the earlier change.

rspec/rspec-core@f78ff619e5e07dc099646444b08d7654516f9666 changed the way location metadata is discovered.  Part of that change meant that the caller trace is no longer passed into Metadata from outside.  I agree that it shouldn't be required, but it would be very helpful it it _could_ be passed in from outside.

The fix in rspec-unit is fairly ugly, and that leads me to suspect that it may make other kinds of RSpec extensions more difficult.

glv/rspec-unit@851160bc2cc8b53fd19b7b1c3a69a854a8267e61 shows what I had to do to rspec-unit to deal with this.  In test_case.rb, I have to let RSpec set all the metadata for examples and example groups, and then override :file_path, :line_number, and :location.  And I have to do that by calling two private methods on ExampleGroup (#file_and_line_number_from and #location_from).  Yuck.

This pull requests allows callers of ExampleGroup.set_it_up and Example.new to _optionally_ pass in the caller trace.
