### PR TITLE
Fix gemfile for 192

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "http://rubygems.org"
-gemspec "rspec-core.gemspec"
 
 %w[rspec-core rspec-expectations rspec-mocks].each do |lib|
   gem lib, :path => File.expand_path("../../#{lib}", __FILE__)


### PR DESCRIPTION
The `gemspec` call was causing an error on ruby 1.9.2:

<pre>
ruby-1.9.2-p0 ➜  rspec-core git:(if_and_unless_metadata) rake spec --trace
(in /Users/mmarston/code/rspec-dev/repos/rspec-core)
rake aborted!
can't convert Symbol into Integer
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/bundler-1.0.0/lib/bundler/dsl.rb:24:in `[]'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/bundler-1.0.0/lib/bundler/dsl.rb:24:in `gemspec'
/Users/mmarston/code/rspec-dev/repos/rspec-core/Gemfile:2:in `build'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/bundler-1.0.0/lib/bundler/definition.rb:19:in `instance_eval'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/bundler-1.0.0/lib/bundler/definition.rb:19:in `build'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/bundler-1.0.0/lib/bundler.rb:128:in `definition'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/bundler-1.0.0/lib/bundler.rb:116:in `load'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/bundler-1.0.0/lib/bundler.rb:100:in `setup'
/Users/mmarston/code/rspec-dev/repos/rspec-core/Rakefile:2:in `<top (required)>'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:2383:in `load'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:2383:in `raw_load_rakefile'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:2017:in `block in load_rakefile'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:2016:in `load_rakefile'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:2000:in `block in run'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:2068:in `standard_exception_handling'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/lib/rake.rb:1998:in `run'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/gems/rake-0.8.7/bin/rake:31:in `<top (required)>'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/bin/rake:19:in `load'
/Users/mmarston/.rvm/gems/ruby-1.9.2-p0/bin/rake:19:in `<main>'
</pre>


I'm also not sure what you were intending by adding the call to `gemspec`: this basically adds the development and runtime dependencies from your gemspec to the Gemfile, but the gemspec currently doesn't have any.
