### PR TITLE
Add -Ilib to default rcov_opts

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -135,7 +135,7 @@ module RSpec
                             cmd_parts << "bundle exec" if bundler
                             cmd_parts << runner
                             if rcov
-                              cmd_parts << ["-Ispec", rcov_opts]
+                              cmd_parts << ["-Ispec", "-Ilib", rcov_opts]
                             else
                               cmd_parts << rspec_opts
                             end

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -77,10 +77,11 @@ module RSpec::Core
           spec_command.should =~ /rcov.*--exclude "mocks"/
         end
 
-        it "ensures that -Ispec is in the resulting command" do
+        it "ensures that -Ispec and -Ilib are in the resulting command" do
           task.rcov = true
           task.rcov_opts = '--exclude "mocks"'
           spec_command.should =~ /rcov.*-Ispec/
+          spec_command.should =~ /rcov.*-Ilib/
         end
       end
     end


### PR DESCRIPTION
I'm always happy to have this line in my Rakefile:

```
RSpec::Core::RakeTask.new('rspec')
```

But when I want to add a rcov task like this:

```
RSpec::Core::RakeTask.new('rcov') do |t| t.rcov = true end
```

It won't work. Because 'lib' is not in `$:` - rcov won't search there until you tell it to.

IMO, if a Rakefile contains the `rspec` task as showed above, the `rcov` task that only tweaked the `rcov` property should be work out of box. So I suggest to add `-Ilib` to the default options for the runner `rcov`, because the `rspec` runner will search there by default.

Thanks.
