### PR TITLE
Support for tags on CLI

### DIFF
--- a/features/command_line/tag.feature
+++ b/features/command_line/tag.feature
@@ -1,0 +1,74 @@
+Feature: tag option
+
+  Use the --tag (or -t) option to filter the examples to be run by tag.
+  
+  The tag can be a simple name or a name:value pair. In the first case,
+  examples with :name => true will be filtered. In the second case, examples
+  with :name => value will be filtered, where value is always a string.
+  In both cases, name is converted to a symbol.
+  
+  Tags can also be used to exclude examples by adding a ~ before the tag.
+  For example ~tag will exclude all examples marked with :tag => true and
+  ~tag:value will exclude all examples marked with :tag => value.
+  
+  To be compatible with the Cucumber syntax, tags can optionally start with
+  a @, that will be ignored.
+
+  Background:
+    Given a file named "tagged_spec.rb" with:
+      """
+      describe "group with tagged specs" do
+        it "example I'm working now", :focus => true do; end
+        it "special example", :type => 'special' do; end
+        it "slow example", :skip => true do; end
+        it "ordinary example", :speed => 'slow' do; end
+        it "untagged example" do; end
+      end
+      """
+
+  Scenario: filter examples with non-existent tag
+    When I run "rspec . --tag mytag"
+    And the output should contain "0 examples, 0 failures"
+
+  Scenario: filter examples with a simple tag
+    When I run "rspec . --tag focus"
+    Then the output should contain "Run filtered using {:focus=>true}"
+    And the output should contain "1 example, 0 failures"
+
+  Scenario: filter examples with a simple tag and @
+    When I run "rspec . --tag @focus"
+    Then the output should contain "Run filtered using {:focus=>true}"
+    Then the output should contain "1 example, 0 failures"
+
+  Scenario: filter examples with a name:value tag
+    When I run "rspec . --tag type:special"
+    Then the output should contain:
+      """
+      Run filtered using {:type=>"special"}
+      """
+    And the output should contain "1 example, 0 failures"
+  
+  Scenario: filter examples with a name:value tag and @
+    When I run "rspec . --tag @type:special"
+    Then the output should contain:
+      """
+      Run filtered using {:type=>"special"}
+      """
+    And the output should contain "1 example, 0 failures"
+  
+  Scenario: exclude examples with a simple tag
+    When I run "rspec . --tag ~skip"
+    Then the output should contain "4 examples, 0 failures"
+
+  Scenario: exclude examples with a simple tag and @
+    When I run "rspec . --tag ~@skip"
+    Then the output should contain "4 examples, 0 failures"
+    
+  Scenario: exclude examples with a name:value tag
+    When I run "rspec . --tag ~speed:slow"
+    Then the output should contain "4 examples, 0 failures"
+  
+  Scenario: exclude examples with a name:value tag and @
+    When I run "rspec . --tag ~@speed:slow"
+    Then the output should contain "4 examples, 0 failures"
+

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -99,6 +99,19 @@ module RSpec::Core
         parser.on('--autotest') do |o|
           options[:autotest] = true
         end
+        
+        parser.on('-t', '--tag TAG[:VALUE]', 'Run examples with the specified tag',
+                'To exclude examples, add ~ before the tag (e.g. ~slow)',
+                '(TAG is always converted to a symbol)') do |tag|
+          filter_type = tag.start_with?('~') ? :exclusion_filter : :filter
+          
+          name,value = tag.gsub(/^(~@|~|@)/, '').split(':')
+          name = name.to_sym
+          value = true if value.nil?
+          
+          options[filter_type] ||= {}
+          options[filter_type][name] = value
+        end
       end
     end
   end


### PR DESCRIPTION
Filters are one of my favorite things on RSpec 2, specially because I don't use Cucumber. But is very cumbersome always have to set `filter_run_including` and `filter_run_excluding` on the spec_helper file, so I implemented a simple support for tags on the CLI.
It is just a subset of the described by David in http://github.com/rspec/rspec-core/issues/#issue/37 (actually just the section "keys and/or key/value pairs"), but I think it covers most cases. To see exactly what was implemented, refer to the Cucumber feature http://github.com/lailsonbm/rspec-core/blob/b4501b6d5e9d7ddc930d5d4cec05f1cc0d201897/features/command_line/tag.feature.
