### PR TITLE
Calling super.inherited in ExampleGroup

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -20,6 +20,7 @@ module RSpec
       end
 
       def self.inherited(klass)
+        super
         RSpec::Core::Runner.autorun
         world.example_groups << klass if klass.top_level?
       end


### PR DESCRIPTION
Heya,
Rspec1 used to call super.inherited in ExampleGroup.  Rspec2 doesn't, which is causing problems for me as I currently use an activesupport class_inheritable_accessor to add some custom behaviour to groups, and it relies on Class.inherit being called.

Any chance of something like the attached commit?

Cheers,
-Jonathan
