### PR TITLE
--fail-fast command line option

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -99,16 +99,20 @@ module RSpec::Core
         parser.on('--autotest') do |o|
           options[:autotest] = true
         end
-        
+
+        parser.on('--fail-fast', 'Use the fail_fast option to tell RSpec to abort the run on first failure.') do |o|
+          options[:fail_fast] = true
+        end
+
         parser.on('-t', '--tag TAG[:VALUE]', 'Run examples with the specified tag',
                 'To exclude examples, add ~ before the tag (e.g. ~slow)',
                 '(TAG is always converted to a symbol)') do |tag|
           filter_type = tag.start_with?('~') ? :exclusion_filter : :filter
-          
+
           name,value = tag.gsub(/^(~@|~|@)/, '').split(':')
           name = name.to_sym
           value = true if value.nil?
-          
+
           options[filter_type] ||= {}
           options[filter_type][name] = value
         end

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -215,6 +215,12 @@ describe RSpec::Core::ConfigurationOptions do
     end
   end
 
+  describe "--fail-fast" do
+    it "sets fail_fast on config" do
+      options_from_args("--fail-fast").should include(:fail_fast => true)
+    end
+  end
+
   describe "options file (override)" do
     let(:config) { OpenStruct.new }
 


### PR DESCRIPTION
After planning on working on a patch for a feature like it myself, I found the `fail_fast` option today. It works great, but the only thing I was missing was command line support for it. 

I added the `--fail-fast` option. What do you think? :)
