### PR TITLE
Make Kernel#method_missing override less naughty

### DIFF
--- a/lib/rspec/core/extensions/kernel.rb
+++ b/lib/rspec/core/extensions/kernel.rb
@@ -2,6 +2,8 @@ module Kernel
 
   private
 
+  alias_method :method_missing_without_debugger_stuff, :method_missing
+
   def method_missing(m, *a)
     if m.to_s == 'debugger'
       begin
@@ -19,7 +21,7 @@ To use the debugger statement, you must install ruby-debug.
 EOM
       end
     else
-      super
+      method_missing_without_debugger_stuff(m, *a)
     end
   end
 end


### PR DESCRIPTION
I filed an issue about it. Not sure if there's a way to relate these after the fact. We'll see.
