### PR TITLE
Add autotest-fsevent to bundle when ruby platform is darwin.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,11 @@ gem "syntax"
 gem "relish", "~> 0.0.3"
 gem "guard-rspec"
 gem "growl"
-gem "autotest-fsevent"
+
+if RUBY_PLATFORM =~ /darwin/
+  gem "autotest-fsevent"
+end
+
 gem "autotest-growl"
 
 gem "ruby-debug", :platforms => :ruby_18


### PR DESCRIPTION
I had to add this for bundler to install completely. I'm on linux and as you guys know autotest-fsevent only works on mac os x.
