### PR TITLE
Subject blocks called multiple times for a single example

### DIFF
--- a/features/subject/explicit_subject.feature
+++ b/features/subject/explicit_subject.feature
@@ -60,3 +60,19 @@ Feature: explicit subject
       """
     When I run "rspec helper_subject_spec.rb"
     Then the output should contain "1 example, 0 failures"
+
+  Scenario: invoke subject block at most once per example
+    Given a file named "nil_subject_spec.rb" with:
+      """
+      describe Array do
+        describe "[]" do
+          context "with index out of bounds" do
+            before { Array.should_receive(:one_two_three).once.and_return([1,2,3]) }
+            subject { Array.one_two_three[42] }
+            it { should be_nil }
+          end
+        end
+      end
+      """
+    When I run "rspec nil_subject_spec.rb"
+    Then the output should contain "1 example, 0 failures"

--- a/lib/rspec/core/subject.rb
+++ b/lib/rspec/core/subject.rb
@@ -28,7 +28,11 @@ module RSpec
         #     end
         #   end
         def subject
-          @original_subject ||= instance_eval(&self.class.subject)
+          if defined?(@original_subject)
+            @original_subject
+          else
+            @original_subject = instance_eval(&self.class.subject)
+          end
         end
 
         begin
@@ -86,7 +90,7 @@ module RSpec
         # The attribute can be a +Symbol+ or a +String+. Given a +String+
         # with dots, the result is as though you concatenated that +String+
         # onto the subject in an expression.
-        #   
+        #
         #   describe Person do
         #     subject do
         #       Person.new.tap do |person|


### PR DESCRIPTION
I ran into an issue where my explicit subject blocks were called multiple times. This caused my expectations set up with mocks to fail because through the subject block a stubbed method was also called multiple times.

I investigated the cause of this and it became clear that the subject block was only called multiple times if its return value was either `nil` or `false`. Caching the return value of the subject block should handle these cases as well.

Attached is a pull request with a scenario and a fix for this issue.
