### PR TITLE
Add the reporter= attr_writer to RSpec::Core::Configuration

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -182,7 +182,7 @@ module RSpec
 
       # Sets the expectation framework module(s).
       #
-      # +frameworks+ can be :rspec, :stdlib, or both 
+      # +frameworks+ can be :rspec, :stdlib, or both
       #
       # Given :rspec, configures rspec/expectations.
       # Given :stdlib, configures test/unit/assertions
@@ -262,7 +262,7 @@ EOM
         filter_run({ :full_description => /#{description}/ }, true)
       end
 
-      attr_writer :formatter_class
+      attr_writer :formatter_class, :reporter
 
       def formatter_class
         @formatter_class ||= begin

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -395,6 +395,14 @@ module RSpec::Core
 
     end
 
+    describe 'reporter=' do
+      it 'sets the reporter' do
+        reporter_class = Class.new
+        config.reporter = reporter_class
+        config.reporter.should == reporter_class
+      end
+    end
+
     describe "#filter_run" do
       it "sets the filter" do
         config.filter_run :focus => true


### PR DESCRIPTION
I added `reporter` to the `attr_writer` list in `RSpec::Core::Configuration` to make it possible to use your own Reporter. :)
