### PR TITLE
Unless Debugger.start has been called, there's no stack trace when we stop

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -240,6 +240,7 @@ module RSpec
         return unless bool
         begin
           require 'ruby-debug'
+          Debugger.start
         rescue LoadError
           raise <<-EOM
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -516,7 +516,10 @@ module RSpec::Core
     describe "#debug=true" do
       it "requires 'ruby-debug'" do
         config.should_receive(:require).with('ruby-debug')
+        Object.const_set("Debugger", debugger = mock("Debugger"))
+        debugger.should_receive(:start)
         config.debug = true
+        Object.send(:remove_const, :Debugger)
       end
     end
 


### PR DESCRIPTION
When the debugger is requested with -d/--debug, ruby-debug is loaded, but when a call to 'debugger' is hit,
only the current method is known "stack trace may be incomplete". This fixes that by calling Debugger.start,
so the full stack trace is always available.
