### PR TITLE
RSpec doesn't work at ruby 1.9.3 because Enumerable#reject will return Array instance only

### DIFF
--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -51,7 +51,9 @@ module RSpec
 
       class HookCollection < Array
         def find_hooks_for(group)
-          dup.reject {|hook| !hook.options_apply?(group)}
+          a = dup
+          a.reject! {|hook| !hook.options_apply?(group)}
+          a
         end
       end
 


### PR DESCRIPTION
rspec won't run at next release, because at [r30148 and #4136](http://redmine.ruby-lang.org/issues/show/4136) of ruby.

```
% ruby -ve "class Foo < Array;end; p Foo.new(0,1).reject(&:zero?).class"
ruby 1.9.2p0 (2010-08-18 revision 29036) [x86_64-darwin10.4.0]
Foo
```

but at ruby-trunk,

```
% ruby -ve "class Foo < Array;end; p Foo.new(0,1).reject(&:zero?).class"
ruby 1.9.3dev (2010-12-22 trunk 30290) [x86_64-darwin10.4.0]
Array
```

RSpec works well after merge this patch.
