### PR TITLE
adding metadata to examples with implicit descriptions doesn't work

### DIFF
--- a/features/filtering/exclusion_filters.feature
+++ b/features/filtering/exclusion_filters.feature
@@ -24,6 +24,28 @@ Feature: exclusion filters
     Then the output should contain "does one thing"
     And the output should not contain "does another thing"
 
+  @wip
+  Scenario: exclude implicit examples
+  Given a file named "spec/sample_spec.rb" with:
+    """
+    RSpec.configure do |c|
+      # declare an exclusion filter
+      c.filter_run_excluding :broken => true
+    end
+
+    describe "something" do
+      it "does one thing" do
+      end
+
+      # An example with an implicit description
+      it(:broken => true) { should == true}
+    end
+    """
+  When I run "rspec ./spec/sample_spec.rb --format doc"
+  Then the output should contain "does one thing"
+  And the output should not contain "brokentrue"
+
+
   Scenario: exclude a group
     Given a file named "spec/sample_spec.rb" with:
       """


### PR DESCRIPTION
Hi guys, 

I've added an failing feature. I would like to be able to add metadata as follows:

```
 it(:meta_data => :true) { should have(10).items }
```

This doesn't work however, because the first argument is always used as description. Do you agree that it should work? And got any pointers where to start implementing it?

Of topic, really great piece of work and I like your book :)

Cheers,
Jeroen
