### PR TITLE
current_indentation

### DIFF
--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -15,7 +15,7 @@ module RSpec
           super(example_group)
 
           output.puts if @group_level == 0
-          output.puts "#{'  ' * @group_level}#{example_group.description}"
+          output.puts "#{current_indentation}#{example_group.description}"
 
           @group_level += 1
         end


### PR DESCRIPTION
In `example_group_started` in the documentation formatter, the `group_description` is indented using `'  ' * @group_level`, which is exactly what the `current_indentation` method does, so I decided to use that instead. 
