### PR TITLE
Loosen test by not checking for order of elements. Using inclusion check instead.

### DIFF
--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -150,11 +150,11 @@ module RSpec::Core
       end
 
       it "escapes the quotes" do
-        @task.__send__(:files_to_run).should eq([
-          File.join(@tmp_dir, "first_spec.rb"),
-          File.join(@tmp_dir, "second_\\\"spec.rb"),
-          File.join(@tmp_dir, "third_\\'spec.rb") 
-        ])
+      	[File.join(@tmp_dir, "first_spec.rb"),
+         File.join(@tmp_dir, "second_\\\"spec.rb"),
+         File.join(@tmp_dir, "third_\\'spec.rb")].each do |path| 
+	   @task.__send__(:files_to_run).should include(path)
+         end
       end
     end
   end


### PR DESCRIPTION
The issue that this patch resolves is here: https://github.com/rspec/rspec-core/issues/issue/272

I pulled down master and noticed the test failing when I ran 'rake'. I hope my changes are helpful.
