### PR TITLE
Before all config hook bug

### DIFF
--- a/features/hooks/filtering.feature
+++ b/features/hooks/filtering.feature
@@ -127,9 +127,15 @@ Feature: Global Hook Filtering
         it("example 1") { }
         it("example 2") { }
       end
+
+      describe "group 3" do
+        describe "subgroup 1", :foo => :bar do
+          it("example 1") { }
+        end
+      end
       """
     When I run "rspec filter_before_all_hooks_spec.rb --format documentation"
-    Then the output should contain "4 examples, 0 failures"
+    Then the output should contain "5 examples, 0 failures"
     And the output should contain:
       """
       group 1
@@ -140,6 +146,11 @@ Feature: Global Hook Filtering
       In hook
         example 1
         example 2
+
+      group 3
+        subgroup 1
+      In hook
+          example 1
       """
 
   Scenario: Filter after(:all) hooks using arbitrary metadata
@@ -158,9 +169,15 @@ Feature: Global Hook Filtering
         it("example 1") { }
         it("example 2") { }
       end
+
+      describe "group 3" do
+        describe "subgroup 1", :foo => :bar do
+          it("example 1") { }
+        end
+      end
       """
     When I run "rspec filter_after_all_hooks_spec.rb --format documentation"
-    Then the output should contain "4 examples, 0 failures"
+    Then the output should contain "5 examples, 0 failures"
     And the output should contain:
       """
       group 1
@@ -170,5 +187,10 @@ Feature: Global Hook Filtering
       group 2
         example 1
         example 2
+      In hook
+
+      group 3
+        subgroup 1
+          example 1
       In hook
       """

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -172,7 +172,7 @@ module RSpec
       def self.eval_before_alls(example_group_instance)
         return if descendant_filtered_examples.empty?
         assign_before_all_ivars(superclass.before_all_ivars, example_group_instance)
-        world.run_hook_filtered(:before, :all, self, example_group_instance) if top_level?
+        world.run_hook_filtered(:before, :all, self, example_group_instance)
         run_hook!(:before, :all, example_group_instance)
         store_before_all_ivars(example_group_instance)
       end
@@ -212,7 +212,7 @@ An error occurred in an after(:all) hook.
         EOS
         end
 
-        world.run_hook_filtered(:after, :all, self, example_group_instance) if top_level?
+        world.run_hook_filtered(:after, :all, self, example_group_instance)
       end
 
       def self.around_hooks_for(example)

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -53,6 +53,10 @@ module RSpec
         def find_hooks_for(example_or_group)
           self.class.new(select {|hook| hook.options_apply?(example_or_group)})
         end
+
+        def without_hooks_for(example_or_group)
+          self.class.new(reject {|hook| hook.options_apply?(example_or_group)})
+        end
       end
 
       class BeforeHooks < HookCollection
@@ -117,7 +121,18 @@ module RSpec
       end
 
       def find_hook(hook, scope, example_group_class, example = nil)
-        hooks[hook][scope].find_hooks_for(example || example_group_class)
+        found_hooks = hooks[hook][scope].find_hooks_for(example || example_group_class)
+
+        # ensure we don't re-run :all hooks that were applied to any of the parent groups
+        if scope == :all
+          super_klass = example_group_class.superclass
+          while super_klass != RSpec::Core::ExampleGroup
+            found_hooks = found_hooks.without_hooks_for(super_klass)
+            super_klass = super_klass.superclass
+          end
+        end
+
+        found_hooks
       end
 
     private

--- a/spec/rspec/core/hooks_filtering_spec.rb
+++ b/spec/rspec/core/hooks_filtering_spec.rb
@@ -67,6 +67,55 @@ module RSpec::Core
         ]
       end
 
+      it "runs before|after :all hooks on matching nested example groups" do
+        filters = []
+        RSpec.configure do |c|
+          c.before(:all, :match => true) { filters << :before_all }
+          c.after(:all, :match => true)  { filters << :after_all }
+        end
+
+        example_1_filters = example_2_filters = nil
+
+        group = ExampleGroup.describe "group" do
+          it("example 1") { example_1_filters = filters.dup }
+          describe "subgroup", :match => true do
+            it("example 2") { example_2_filters = filters.dup }
+          end
+        end
+        group.run
+
+        example_1_filters.should be_empty
+        example_2_filters.should == [:before_all]
+        filters.should == [:before_all, :after_all]
+      end
+
+      it "runs before|after :all hooks only on the highest level group that matches the filter" do
+        filters = []
+        RSpec.configure do |c|
+          c.before(:all, :match => true) { filters << :before_all }
+          c.after(:all, :match => true)  { filters << :after_all }
+        end
+
+        example_1_filters = example_2_filters = example_3_filters = nil
+
+        group = ExampleGroup.describe "group", :match => true do
+          it("example 1") { example_1_filters = filters.dup }
+          describe "subgroup", :match => true do
+            it("example 2") { example_2_filters = filters.dup }
+            describe "sub-subgroup", :match => true do
+              it("example 3") { example_3_filters = filters.dup }
+            end
+          end
+        end
+        group.run
+
+        example_1_filters.should == [:before_all]
+        example_2_filters.should == [:before_all]
+        example_3_filters.should == [:before_all]
+
+        filters.should == [:before_all, :after_all]
+      end
+
       it "should not be ran if the filter doesn't match the example group's filter" do
         filters = []
         RSpec.configure do |c|


### PR DESCRIPTION
This fixes a bug I found with filtered `:all` hooks defined in the `RSpec.configure` block.
