### PR TITLE
Tag filtering with Spork on

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -39,6 +39,11 @@ module RSpec
         argv << "--line_number"  << options[:line_number]             if options[:line_number]
         argv << "--options"      << options[:custom_options_file]     if options[:custom_options_file]
         argv << "--example"      << options[:full_description].source if options[:full_description]
+        if options[:filter]
+          options[:filter].each_pair do |k, v|
+            argv << "--tag" << k.to_s
+          end
+        end
         if options[:formatters]
           options[:formatters].each do |pair|
             argv << "--format" << pair[0]
@@ -107,7 +112,7 @@ module RSpec
         config_string = options_file_as_erb_string(path)
         config_string.split(/\n+/).map {|l| l.split}.flatten
       end
-      
+
       def options_file_as_erb_string(path)
         require 'erb'
         ERB.new(IO.read(path)).result(binding)

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -205,6 +205,19 @@ describe RSpec::Core::ConfigurationOptions do
       config_options_object(*%w[--options custom.opts]).drb_argv.should include("--options", "custom.opts")
     end
 
+    context "with tags" do
+      it "includes the tags" do
+        coo = config_options_object("--tag", "tag")
+        coo.drb_argv.should eq(["--tag", "tag"])
+      end
+
+      it "leaves tags intact" do
+        coo = config_options_object("--tag", "tag")
+        coo.drb_argv
+        coo.options[:filter].should eq( {:tag=>true} )
+      end
+    end
+
     context "with formatters" do
       it "includes the formatters" do
         coo = config_options_object("--format", "d")


### PR DESCRIPTION
When trying to run RSpec with the tag option

```
rspec spec --tag mytag
```

Spork doesn't receive the filter option. I had to modify ConfigurationOptions#drb_argv to include

```
if options[:filter]
  options[:filter].each_pair do |k, v|
    argv << "--tag" << k.to_s
  end
end
```
