### PR TITLE
Be more explicit about passing a block

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -93,11 +93,11 @@ module RSpec
         end
       end
 
-      def with_around_hooks
+      def with_around_hooks(&block)
         if around_hooks.empty?
           yield
         else
-          @example_group_class.eval_around_eachs(self, Procsy.new(metadata)).call
+          @example_group_class.eval_around_eachs(self, Procsy.new(metadata, &block)).call
         end
       end
 


### PR DESCRIPTION
JRuby 1.6.0 is not likely to support the previous bit of Proc.new magic; see http://jira.codehaus.org/browse/JRUBY-5420
