### PR TITLE
Add ":any" as a hook scope alias for ":all"

### DIFF
--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -142,7 +142,17 @@ module RSpec
           options = scope
           scope = :each
         end
-        return scope, options
+        return normalized_scope_for(scope), options
+      end
+
+      def scope_aliases
+        @scope_aliases ||= {
+          :any => :all
+        }
+      end
+
+      def normalized_scope_for(scope)
+        scope_aliases[scope] || scope
       end
     end
   end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -244,6 +244,17 @@ module RSpec::Core
     end
 
     describe "#before, after, and around hooks" do
+      describe "scope aliasing" do
+        it "aliases the `:any` hook scope to `:all`" do
+          group = ExampleGroup.describe
+          order = []
+          group.before(:any) { order << 1 }
+          group.example("example") {}
+
+          group.hooks[:before][:all].run_all(group)
+          order.should == [1]
+        end
+      end
 
       it "runs the before alls in order" do
         group = ExampleGroup.describe


### PR DESCRIPTION
As per a discussion on the mailing list, David suggested it might be useful to alias ":all" to ":any" for before/after hooks. Here is a patch that does that.
