### PR TITLE
Add hook scope aliases `:example` and `:group`

### DIFF
--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -142,7 +142,18 @@ module RSpec
           options = scope
           scope = :each
         end
-        return scope, options
+        return normalized_scope_for(scope), options
+      end
+
+      def scope_aliases
+        @scope_aliases ||= {
+          :example => :each,
+          :group => :all,
+        }
+      end
+
+      def normalized_scope_for(scope)
+        scope_aliases[scope] || scope
       end
     end
   end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -244,6 +244,50 @@ module RSpec::Core
     end
 
     describe "#before, after, and around hooks" do
+      describe "scope aliasing" do
+        it "aliases the `:group` hook scope to `:all`" do
+          group = ExampleGroup.describe
+          order = []
+          group.before(:group) { order << 1 }
+          group.example("example") {}
+
+          group.hooks[:before][:all].run_all(group)
+          order.should == [1]
+        end
+
+        it "aliases the `:example` hook scope to `:each`" do
+          group = ExampleGroup.describe
+          order = []
+          group.before(:example) { order << 1 }
+          group.example("example") {}
+
+          group.hooks[:before][:each].run_all(group)
+          order.should == [1]
+        end
+
+        it "should work with `before`" do
+          group = ExampleGroup.describe
+          order = []
+          group.before(:group) { order << 1 }
+          group.before(:example) { order << 2 }
+          group.example("example") {}
+
+          group.run
+          order.should == [1, 2]
+        end
+
+        it "should work with `after`" do
+          group = ExampleGroup.describe
+          order = []
+          group.after(:example) { order << 1 }
+          group.after(:group) { order << 2 }
+
+          group.example("example") {}
+
+          group.run
+          order.should == [1, 2]
+        end
+      end
 
       it "runs the before alls in order" do
         group = ExampleGroup.describe


### PR DESCRIPTION
As per [a discussion on the mailing list](http://groups.google.com/group/rspec/browse_thread/thread/26ea96043f46b3b6), Evgeniy Dolzhenko suggested that if we were going to have aliases, it would be optimal to have a change that introduced the aliases of `:example`, and `:group`, to parallel the existing `:suite` alias.

Here is a change that does this.
