### PR TITLE
Pass DRb exit status to invoking process

### DIFF
--- a/lib/rspec/core/drb_command_line.rb
+++ b/lib/rspec/core/drb_command_line.rb
@@ -11,18 +11,12 @@ module RSpec
 
       def run(err, out)
         begin
-          begin
-            DRb.start_service("druby://localhost:0")
-          rescue SocketError, Errno::EADDRNOTAVAIL
-            DRb.start_service("druby://:0")
-          end
-          spec_server = DRbObject.new_with_uri("druby://127.0.0.1:#{drb_port}")
-          spec_server.run(@options.drb_argv, err, out)
-          true
-        rescue DRb::DRbConnError
-          err.puts "No DRb server is running. Running in local process instead ..."
-          false
+          DRb.start_service("druby://localhost:0")
+        rescue SocketError, Errno::EADDRNOTAVAIL
+          DRb.start_service("druby://:0")
         end
+        spec_server = DRbObject.new_with_uri("druby://127.0.0.1:#{drb_port}")
+        spec_server.run(@options.drb_argv, err, out)
       end
     end
   end

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -42,7 +42,12 @@ module RSpec
         options.parse_options
 
         if options.options[:drb]
-          run_over_drb(options, err, out) || run_in_process(options, err, out)
+          begin
+            run_over_drb(options, err, out)
+          rescue DRb::DRbConnError
+            err.puts "No DRb server is running. Running in local process instead ..."
+            run_in_process(options, err, out)
+          end
         else
           run_in_process(options, err, out)
         end


### PR DESCRIPTION
Hi,

Here's a small patch that causes rspec to exit with a nonzero exit status if any specs fail during a DRb run.
