### PR TITLE
Fixing Issue #338

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |c|
   c.filter_run_excluding :ruby => lambda {|version|
     case version.to_s
     when "!jruby"
-      RUBY_ENGINE != "jruby"
+      RUBY_ENGINE == "jruby"
     when /^> (.*)/
       !(RUBY_VERSION.to_s > $1)
     else


### PR DESCRIPTION
drb_command_line_spec.rb is currently failing on JRuby 1.6.0 because the 
    describe "::DRbCommandLine", :ruby => "!jruby"
directive isn't respected. Changing these lines in spec_helper.rb
    when "!jruby"
      RUBY_ENGINE != "jruby"
to
    when "!jruby"
      RUBY_ENGINE == "jruby"
fixes it.
