### PR TITLE
Multiple examples can be specified by line number.

### DIFF
--- a/features/command_line/example_name_option.feature
+++ b/features/command_line/example_name_option.feature
@@ -9,6 +9,9 @@ Feature: --example option
   This allows you to run a single uniquely named example, all examples with
   similar names, all the examples in a uniquely named group, etc, etc.
 
+  This option may be specified multiple times.  Multiple patterns are OR-d
+  together.
+
   Background:
     Given a file named "first_spec.rb" with:
       """
@@ -84,3 +87,11 @@ Feature: --example option
   Scenario: Object#method
     When I run `rspec . --example 'Array#length'`
     Then the examples should all pass
+
+  Scenario: multiple patterns
+    When I run `rspec . --format doc --example 'first example in first group' --example 'second example in second group'`
+    Then the examples should all pass
+    And the output should contain "first example in first group"
+    And the output should contain "second example in second group"
+    But the output should not contain "second example in first group"
+    And the output should not contain "third group"

--- a/features/command_line/line_number_appended_to_path.feature
+++ b/features/command_line/line_number_appended_to_path.feature
@@ -1,6 +1,6 @@
 Feature: line number appended to file path
 
-  To run a single example or group, you can append the line number to the path, e.g.
+  To run one or more examples or groups, you can append the line number to the path, e.g.
 
       rspec path/to/example_spec.rb:37
   
@@ -25,6 +25,15 @@ Feature: line number appended to file path
         
         end
 
+      end
+      """
+    And a file named "example2_spec.rb" with:
+      """
+      describe "yet another group" do
+        it "first example in second file" do
+        end
+        it "second example in second file" do
+        end
       end
       """
 
@@ -104,3 +113,28 @@ Feature: line number appended to file path
     And the output should contain "second example in outer group"
     But the output should not contain "first example in outer group"
     And the output should not contain "example in nested group"
+
+  Scenario: specified multiple times for different files
+    When I run `rspec example_spec.rb:7 example2_spec.rb:4 --format doc`
+    Then the examples should all pass
+    And the output should contain "second example in outer group"
+    And the output should contain "second example in second file"
+    But the output should not contain "first example in outer group"
+    And the output should not contain "nested group"
+    And the output should not contain "first example in second file"
+
+  Scenario: specified multiple times for the same file with multiple arguments
+    When I run `rspec example_spec.rb:7 example_spec.rb:11 --format doc`
+    Then the examples should all pass
+    And the output should contain "second example in outer group"
+    And the output should contain "nested group"
+    But the output should not contain "first example in outer group"
+    And the output should not contain "second file"
+
+  Scenario: specified multiple times for the same file with a single argument
+    When I run `rspec example_spec.rb:7:11 --format doc`
+    Then the examples should all pass
+    And the output should contain "second example in outer group"
+    And the output should contain "nested group"
+    But the output should not contain "first example in outer group"
+    And the output should not contain "second file"

--- a/features/command_line/line_number_option.feature
+++ b/features/command_line/line_number_option.feature
@@ -1,8 +1,10 @@
 Feature: --line_number option
 
-  To run a single example or group, you can use the --line_number option:
+  To run a examples or groups by line numbers, one can use the --line_number option:
 
       rspec path/to/example_spec.rb --line_number 37
+
+  This option can be specified multiple times.
 
   Scenario: standard examples
     Given a file named "example_spec.rb" with:
@@ -18,13 +20,24 @@ Feature: --line_number option
         it "should be < 10" do
           9.should be < 10
         end
-        
+
+        it "should be 3 squared" do
+          9.should be 3*3
+        end
+
       end
       """
     When I run `rspec example_spec.rb --line_number 5 --format doc`
     Then the examples should all pass
-    Then the output should contain "should be > 8"
+    And the output should contain "should be > 8"
     But the output should not contain "should be < 10"
+    And the output should not contain "should be 3*3"
+
+    When I run `rspec example_spec.rb --line_number 5 --line_number 9 --format doc`
+    Then the examples should all pass
+    And the output should contain "should be > 8"
+    And the output should contain "should be < 10"
+    But the output should not contain "should be 3*3"
 
   Scenario: one liner
     Given a file named "example_spec.rb" with:

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -29,7 +29,6 @@ module RSpec
         argv << "--backtrace"    if options[:full_backtrace]
         argv << "--tty"          if options[:tty]
         argv << "--fail-fast"    if options[:fail_fast]
-        argv << "--line_number"  << options[:line_number]             if options[:line_number]
         argv << "--options"      << options[:custom_options_file]     if options[:custom_options_file]
         if options[:full_description]
           # The argument to --example is regexp-escaped before being stuffed
@@ -37,6 +36,9 @@ module RSpec
           # Hence, merely grabbing the source of this regexp will retain the
           # backslashes, so we must remove them.
           argv << "--example" << options[:full_description].source.delete('\\')
+        end
+        if options[:line_numbers]
+          argv += options[:line_numbers].inject([]){|a,l| a << "--line_number" << l}
         end
         if options[:filter]
           options[:filter].each_pair do |k, v|

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -40,8 +40,14 @@ module RSpec::Core
           options[:debug] = true
         end
 
-        parser.on('-e', '--example STRING', "Run examples whose full nested names include STRING") do |o|
-          options[:full_description] = Regexp.compile(Regexp.escape(o))
+        parser.on('-e', '--example PATTERN', "Run examples whose full descriptions match this pattern.",
+                "May be specified multiple times.",
+                "(PATTERN is compiled into a Ruby regular expression)") do |o|
+          if current_pattern = options[:full_description]
+            options[:full_description] = Regexp.union(current_pattern, Regexp.compile( Regexp.escape(o)))
+          else
+            options[:full_description] = Regexp.compile(Regexp.escape(o))
+          end
         end
 
         parser.on('-f', '--format FORMATTER', 'Choose a formatter',
@@ -73,8 +79,8 @@ module RSpec::Core
           options[:libs] << dir
         end
 
-        parser.on('-l', '--line_number LINE', 'Specify the line number of a single example to run') do |o|
-          options[:line_number] = o
+        parser.on('-l', '--line_number LINE', 'Specify the line number of an example to run.  May be specified multiple times.') do |o|
+          (options[:line_numbers] ||= []) << o
         end
 
         parser.on('-O', '--options PATH', 'Specify the path to an options file') do |path|

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -103,8 +103,13 @@ describe RSpec::Core::ConfigurationOptions do
 
   describe '--line_number' do
     it "sets :line_number" do
-      parse_options('-l','3').should include(:line_number => '3')
-      parse_options('--line_number','3').should include(:line_number => '3')
+      parse_options('-l','3').should include(:line_numbers => ['3'])
+      parse_options('--line_number','3').should include(:line_numbers => ['3'])
+    end
+
+    it "can be specified multiple times" do
+      parse_options('-l','3', '-l', '6').should include(:line_numbers => ['3', '6'])
+      parse_options('--line_number','3', '--line_number', '6').should include(:line_numbers => ['3', '6'])
     end
   end
 
@@ -112,6 +117,11 @@ describe RSpec::Core::ConfigurationOptions do
     it "sets :full_description" do
       parse_options('--example','foo').should include(:full_description => /foo/)
       parse_options('-e','bar').should include(:full_description => /bar/)
+    end
+
+    it "can be specified multiple times" do
+      parse_options('--example','foo', '--example', 'bar').should include(:full_description => /(?-mix:foo)|(?-mix:bar)/)
+      parse_options('-e','bar', '-e', 'baz').should include(:full_description => /(?-mix:bar)|(?-mix:baz)/)
     end
   end
 
@@ -286,8 +296,8 @@ describe RSpec::Core::ConfigurationOptions do
 
     context "--drb specified in ARGV" do
       it "renders all the original arguments except --drb" do
-        config_options_object(*%w[ --drb --color --format s --line_number 1 --example pattern --profile --backtrace -I path/a -I path/b --require path/c --require path/d]).
-          drb_argv.should eq(%w[ --color --profile --backtrace --line_number 1 --example pattern --format s -I path/a -I path/b --require path/c --require path/d])
+        config_options_object(*%w[ --drb --color --format s --example pattern --line_number 1 --profile --backtrace -I path/a -I path/b --require path/c --require path/d]).
+          drb_argv.should eq(%w[ --color --profile --backtrace --example pattern --line_number 1 --format s -I path/a -I path/b --require path/c --require path/d])
       end
     end
 
@@ -295,8 +305,8 @@ describe RSpec::Core::ConfigurationOptions do
       it "renders all the original arguments except --drb" do
         File.stub(:exist?) { true }
         IO.stub(:read) { "--drb --color" }
-        config_options_object(*%w[ --tty --format s --line_number 1 --example pattern --profile --backtrace ]).
-          drb_argv.should eq(%w[ --color --profile --backtrace --tty --line_number 1 --example pattern --format s])
+        config_options_object(*%w[ --tty --format s --example pattern --line_number 1 --profile --backtrace ]).
+          drb_argv.should eq(%w[ --color --profile --backtrace --tty --example pattern --line_number 1 --format s])
       end
     end
 
@@ -304,8 +314,8 @@ describe RSpec::Core::ConfigurationOptions do
       it "renders all the original arguments except --drb" do
         File.stub(:exist?) { true }
         IO.stub(:read) { "--drb --color" }
-        config_options_object(*%w[ --drb --format s --line_number 1 --example pattern --profile --backtrace]).
-          drb_argv.should eq(%w[ --color --profile --backtrace --line_number 1 --example pattern --format s])
+        config_options_object(*%w[ --drb --format s --example pattern --line_number 1 --profile --backtrace]).
+          drb_argv.should eq(%w[ --color --profile --backtrace --example pattern --line_number 1 --format s])
       end
     end
 
@@ -313,8 +323,8 @@ describe RSpec::Core::ConfigurationOptions do
       it "renders all the original arguments except --drb and --options" do
         File.stub(:exist?) { true }
         IO.stub(:read) { "--drb --color" }
-        config_options_object(*%w[ --drb --format s --line_number 1 --example pattern --profile --backtrace]).
-          drb_argv.should eq(%w[ --color --profile --backtrace --line_number 1 --example pattern --format s ])
+        config_options_object(*%w[ --drb --format s --example pattern --line_number 1 --profile --backtrace]).
+          drb_argv.should eq(%w[ --color --profile --backtrace --example pattern --line_number 1 --format s ])
       end
     end
   end
@@ -348,7 +358,7 @@ describe RSpec::Core::ConfigurationOptions do
       ENV["SPEC_OPTS"] = "--debug"
       options = parse_options("--drb")
       options[:color_enabled].should be_true
-      options[:line_number].should eq("37")
+      options[:line_numbers].should eq(["37"])
       options[:debug].should be_true
       options[:drb].should be_true
     end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -216,9 +216,9 @@ module RSpec::Core
     end
 
     describe "path with line number" do
-      it "assigns the line number as the filter" do
+      it "assigns the line number as a location filter" do
         config.files_or_directories_to_run = "path/to/a_spec.rb:37"
-        config.filter.should == {:line_number => 37}
+        config.filter.should == {:locations => {File.expand_path("path/to/a_spec.rb") => [37]}}
       end
     end
 
@@ -228,11 +228,37 @@ module RSpec::Core
         config.full_description = "foo"
         config.filter.should_not have_key(:focused)
       end
+    end
 
-      it "assigns the example name as the filter on description" do
-        config.full_description = "foo"
-        config.filter.should == {:full_description => /foo/}
+    context "with line number" do
+
+      it "assigns the file and line number as a location filter" do
+        config.files_or_directories_to_run = "path/to/a_spec.rb:37"
+        config.filter.should == {:locations => {File.expand_path("path/to/a_spec.rb") => [37]}}
       end
+
+      it "assigns multiple files with line numbers as location filters" do
+        config.files_or_directories_to_run = "path/to/a_spec.rb:37", "other_spec.rb:44"
+        config.filter.should == {:locations => {File.expand_path("path/to/a_spec.rb") => [37],
+                                                File.expand_path("other_spec.rb") => [44]}}
+      end
+
+      it "assigns files with multiple line numbers as location filters" do
+        config.files_or_directories_to_run = "path/to/a_spec.rb:37", "path/to/a_spec.rb:44"
+        config.filter.should == {:locations => {File.expand_path("path/to/a_spec.rb") => [37, 44]}}
+      end
+    end
+
+    context "with multiple line numbers" do
+      it "assigns the file and line numbers as a location filter" do
+        config.files_or_directories_to_run = "path/to/a_spec.rb:1:3:5:7"
+        config.filter.should == {:locations => {File.expand_path("path/to/a_spec.rb") => [1,3,5,7]}}
+      end
+    end
+
+    it "assigns the example name as the filter on description" do
+      config.full_description = "foo"
+      config.filter.should == {:full_description => /foo/}
     end
     
     describe "#default_path" do
@@ -499,11 +525,11 @@ module RSpec::Core
         config.filter[:filter2].should == false
       end
 
-      it "warns if :line_number is already a filter" do
-        config.filter_run :line_number => 100
+      it "warns if :line_numbers is already a filter" do
+        config.filter_run :line_numbers => [100]
         config.should_receive(:warn).with(
           "Filtering by {:focus=>true} is not possible since you " \
-          "are already filtering by {:line_number=>100}"
+          "are already filtering by {:line_numbers=>[100]}"
         )
         config.filter_run :focus => true
       end
@@ -587,24 +613,24 @@ module RSpec::Core
       end
     end
 
-    describe "#line_number=" do
+    describe "line_numbers=" do
       before { config.stub(:warn) }
 
-      it "sets the line number" do
-        config.line_number = '37'
-        config.filter.should == {:line_number => 37}
+      it "sets the line numbers" do
+        config.line_numbers = ['37']
+        config.filter.should == {:line_numbers => [37]}
       end
 
       it "overrides :focused" do
         config.filter_run :focused => true
-        config.line_number = '37'
-        config.filter.should == {:line_number => 37}
+        config.line_numbers = ['37']
+        config.filter.should == {:line_numbers => [37]}
       end
 
       it "prevents :focused" do
-        config.line_number = '37'
+        config.line_numbers = ['37']
         config.filter_run :focused => true
-        config.filter.should == {:line_number => 37}
+        config.filter.should == {:line_numbers => [37]}
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,7 @@ RSpec.configure do |c|
       !(RUBY_VERSION.to_s =~ /^#{version.to_s}/)
     end
   }
+  c.alias_it_should_behave_like_to 'it_has_behavior'
   c.around do |example|
     sandboxed { example.run }
   end


### PR DESCRIPTION
This would allow things like

  rspec --line_number 3 --line_number 7

which would match examples defined on lines 3 and 7.

The particular reason why I want this is I'm working on an autotest style that will only invoke examples I've modified since the last write to the file, which may of course include more than one example.

Thanks in advance for your time.
