### PR TITLE
Let methods called in before :all are cached for all examples including nested

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -38,6 +38,7 @@ module RSpec
       add_setting :tty
       add_setting :treat_symbols_as_metadata_keys_with_true_values, :default => false
       add_setting :expecting_with_rspec
+      add_setting :before_all_instance_variables_excluded, :default => [ '@__memoized' ]
 
       CONDITIONAL_FILTERS = {
         :if     => lambda { |value, metadata| metadata.has_key?(:if) && !value },

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -191,6 +191,7 @@ module RSpec
       def self.store_before_all_ivars(example_group_instance)
         return if example_group_instance.instance_variables.empty?
         example_group_instance.instance_variables.each { |ivar| 
+          next if RSpec.configuration.before_all_instance_variables_excluded.include?(ivar)
           before_all_ivars[ivar] = example_group_instance.instance_variable_get(ivar)
         }
       end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -758,6 +758,34 @@ module RSpec::Core
       end
     end
 
+    describe "let method called in before :all" do
+      let(:counter) do
+        Class.new do
+          def initialize
+            @count = 0
+          end
+          def count
+            @count += 1
+          end
+        end.new
+      end
+      
+      before :all do
+        counter.count.should == 1
+      end
+
+      it "should not propagate memoized values to examples" do
+        counter.count.should == 1
+      end
+
+      describe "in a nested group" do
+        let(:counter) { 'redefined' }
+
+        it "can be redefined" do
+           counter.should == 'redefined'
+        end
+      end
+    end
 
     describe "#top_level_description" do
       it "returns the description from the outermost example group" do

--- a/spec/rspec/core/let_spec.rb
+++ b/spec/rspec/core/let_spec.rb
@@ -20,6 +20,14 @@ describe "#let" do
     counter.count.should == 1
     counter.count.should == 2
   end
+
+  describe "in nested a group" do
+    let(:counter) { 'redefined' }
+
+    it "can be redefined" do
+      counter.should == 'redefined'
+    end
+  end
 end
 
 describe "#let!" do


### PR DESCRIPTION
If you call a let method in a before :all, the @__memoized ivar is stored and set in all examples. This mostly becomes a problem when you have a nested group with a let of the same name which defines it. In this case it  cannot change the value as the @__memoized ivar from the before :all is already initialized.

The commit includes the failing specs and extra one for completeness on the let_spec.rb.

I have added the filter for the @__memoized ivar as a config option. I don't know whether this is overkill. Can be convinced to just use a static string comparison also.

Thanks
Adam
