### PR TITLE
assign 'let()' or other accessor value as a subject

### DIFF
--- a/lib/rspec/core/subject.rb
+++ b/lib/rspec/core/subject.rb
@@ -147,9 +147,26 @@ module RSpec
         #     it { should_not be_overdrawn }
         #   end
         #
+        #   or
+        #
+        #   describe CheckingAccount, "with $50" do
+        #     let(:checking_account) { CheckingAccount.new(:amount => 50, :currency => :USD) }
+        #     subject :checking_account
+        #
+        #     it { should have_a_balance_of(50, :USD) }
+        #     it { should_not be_overdrawn }
+        #   end
+        #
         # See +ExampleMethods#should+ for more information about this approach.
-        def subject(&block)
-          block ? @explicit_subject_block = block : explicit_subject || implicit_subject
+        def subject(accessor = nil, &block)
+          if accessor
+            warn('both accessor and block specified.') if block_given?
+            subject { send(accessor) }
+          elsif block_given?
+            @explicit_subject_block = block
+          else
+            explicit_subject || implicit_subject
+          end
         end
 
         attr_reader :explicit_subject_block # :nodoc:

--- a/spec/rspec/core/subject_spec.rb
+++ b/spec/rspec/core/subject_spec.rb
@@ -60,6 +60,21 @@ module RSpec::Core
         end
       end
 
+      describe "defined by accessor" do
+        let(:group) do
+          ExampleGroup.describe do
+            let(:one) { 1 }
+            subject :one
+            it { should eq(1) }
+            it { subject.succ.should == 2 }
+          end
+        end
+
+        it "should set accessor's return value as a subject" do
+          group.run.should be_true
+        end
+      end
+
       describe "defined in a top level group" do
         let(:group) do
           ExampleGroup.describe do


### PR DESCRIPTION
Hi, thanks to nice testing framework.I use rspec every day.

I have a small feature request.
This patch extend subject() to use accessor return value (especially defined by let() ).

I know that's already usable by writing :

``` ruby
let(:var) { "some value" }
subject { var }
```

additional syntax by the patch:

``` ruby
let(:var) { "some value" }
subject :var
```

This helps to express 'I use let value as a subject' more clealy, does'nt it?
