### PR TITLE
Fix indentation warnings; Closes #352

### DIFF
--- a/lib/rspec/core/metadata_hash_builder.rb
+++ b/lib/rspec/core/metadata_hash_builder.rb
@@ -87,7 +87,7 @@ a string such as "#method_name" to remove this warning.
 
 NOTICE
           end
-        end
       end
+    end
   end
 end


### PR DESCRIPTION
I also ran the rest of rspec-core through `ruby -cw` and the only remaining warnings were in the Cucumber features and the specs, so they shouldn't affect runtime.
