### PR TITLE
Allow tag exclusion filtering when using drb

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -39,6 +39,11 @@ module RSpec
             argv << "--tag" << k.to_s
           end
         end
+        if options[:exclusion_filter]
+          options[:exclusion_filter].each_pair do |k, v|
+            argv << "--tag" << "~#{k.to_s}"
+          end
+        end
         if options[:formatters]
           options[:formatters].each do |pair|
             argv << "--format" << pair[0]

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -224,15 +224,26 @@ describe RSpec::Core::ConfigurationOptions do
     end
 
     context "with tags" do
-      it "includes the tags" do
+      it "includes the inclusion tags" do
         coo = config_options_object("--tag", "tag")
         coo.drb_argv.should eq(["--tag", "tag"])
       end
 
-      it "leaves tags intact" do
+      it "leaves inclusion tags intact" do
         coo = config_options_object("--tag", "tag")
         coo.drb_argv
         coo.options[:filter].should eq( {:tag=>true} )
+      end
+
+      it "includes the exclusion tags" do
+        coo = config_options_object("--tag", "~tag")
+        coo.drb_argv.should eq(["--tag", "~tag"])
+      end
+
+      it "leaves exclusion tags intact" do
+        coo = config_options_object("--tag", "~tag")
+        coo.drb_argv
+        coo.options[:exclusion_filter].should eq( {:tag=>true} )
       end
     end
 


### PR DESCRIPTION
This patch allow to use tag **exculsion** filtering when using drb

```
rspec spec --tag ~tag
```
