### PR TITLE
Fix for --example so that it is not double-escaped when running tests over DRb

### DIFF
--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -41,7 +41,7 @@ describe RSpec::Core::ConfigurationOptions do
       config.should_receive(:add_formatter).ordered
       opts.configure(config)
     end
-    
+
     it "merges the :exclusion_filter option with the default exclusion_filter" do
       opts = config_options_object(*%w[--tag ~slow])
       config = RSpec::Core::Configuration.new
@@ -221,6 +221,15 @@ describe RSpec::Core::ConfigurationOptions do
 
     it "includes --options" do
       config_options_object(*%w[--options custom.opts]).drb_argv.should include("--options", "custom.opts")
+    end
+
+    context "with --example" do
+      it "includes --example" do
+        config_options_object(*%w[--example foo]).drb_argv.should include("--example", "foo")
+      end
+      it "unescapes characters which were escaped upon storing --example originally" do
+        config_options_object("--example", "foo\\ bar").drb_argv.should include("--example", "foo bar")
+      end
     end
 
     context "with tags" do


### PR DESCRIPTION
I found a little unexpected bug with the escaping behavior of --example. Basically, if you're running RSpec over DRb, and you run a command like

```
rspec spec/whatever_spec.rb --example "foo bar"
```

you'll get an error like

```
No examples matched {:full_description=>/(?-mix:foo\\\ bar)/}.
```

The issue is that the first time the options are parsed, --example is escaped, so RSpec ends up with a regex like `/foo\ bar/`. The options then get passed to the RSpec server over DRb, but before that happens, --example is stringified again, simply by getting the `source` of the regex. Unfortunately `/foo\ bar/.source` is not "foo bar", it's "foo\\ bar", so that's what get passed along.

I've fixed this by stripping any backslashes that appear in the --example group prior to being passed on. We do have to make the assumption that any backslashes that do appear were inserted by RSpec and aren't intentional, but I think that's a fair assumption.
