### PR TITLE
Rspec-core with Rubinius leave hanging rbx process on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ rvm:
   - 1.9.1
   - 1.9.2
   - ree
-  - rbx
   - jruby


### PR DESCRIPTION
Removing Rubinius from .travis.yml due to hanging rbx process hanging after running rake task. 

Rubinius issue opened: https://github.com/evanphx/rubinius/issues/967.

Sorry for inconvenience. Rubinius guys are looking on the issue itself. Travis-CI people are working on getting isolated environments ready. As soon as one of these is fixed/implemented, issue won't affect rspec-core anymore.

Thanks!
