### PR TITLE
Ensure let methods return a cached nil value instead of repeatedly evaling block

### DIFF
--- a/lib/rspec/core/let.rb
+++ b/lib/rspec/core/let.rb
@@ -21,7 +21,7 @@ module RSpec
         #  end
         def let(name, &block)
           define_method(name) do
-            __memoized[name] ||= instance_eval(&block)
+            __memoized.fetch(name) {|k| __memoized[k] = instance_eval(&block) }
           end
         end
 

--- a/spec/rspec/core/let_spec.rb
+++ b/spec/rspec/core/let_spec.rb
@@ -12,6 +12,11 @@ describe "#let" do
     end.new
   end
 
+  let(:nil_value) do
+    @called += 1
+    nil
+  end
+
   it "generates an instance method" do
     counter.count.should == 1
   end
@@ -19,6 +24,14 @@ describe "#let" do
   it "caches the value" do
     counter.count.should == 1
     counter.count.should == 2
+  end
+
+  it "caches a nil value" do
+    @called = 0
+    nil_value
+    nil_value
+
+    @called.should == 1
   end
 end
 


### PR DESCRIPTION
If a let method block evaluates to nil, the block will be evaluated on every call to the let method.
