### PR TITLE
Allow classes and modules to be used as shared example group identifiers

### DIFF
--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -3,10 +3,10 @@ module RSpec
     module SharedExampleGroup
 
       def shared_context(*args, &block)
-        if String === args.first || Symbol === args.first
-          name = args.shift
-          ensure_shared_example_group_name_not_taken(name)
-          RSpec.world.shared_example_groups[name] = block
+        if String === args.first || Symbol === args.first || Module === args.first
+          object = args.shift
+          ensure_shared_example_group_name_not_taken(object)
+          RSpec.world.shared_example_groups[object] = block
         end
 
         unless args.empty?


### PR DESCRIPTION
This is code to help with #398. I've opened `share_examples_for` up to allow modules and classes (but not all objects) to be used as identifiers, and added specs for those cases.
