### PR TITLE
Stack requests and libs params form different sources

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -66,7 +66,9 @@ module RSpec
       end
 
       def parse_options
-        @options ||= [file_options, command_line_options, env_options].inject {|merged, o| merged.merge o}
+        @options ||= [file_options, command_line_options, env_options].inject do |merged, o|
+          merged.merge(o) {|key, oldval, newval| [:requires, :libs].include?(key) ? oldval + newval : newval}
+        end
       end
 
     private

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -48,6 +48,20 @@ describe RSpec::Core::ConfigurationOptions do
       opts.configure(config)
       config.exclusion_filter.should have_key(:slow)
     end
+
+    it "merges the reqire and lib options form different sources" do
+      orig_env = ENV["SPEC_OPTS"]
+      begin
+        ENV["SPEC_OPTS"] = "-r b/file -I b/lib"
+        opts = config_options_object(*%w[-r a/file -I a/lib])
+        config = double("config").as_null_object
+        config.should_receive(:libs=).with(["a/lib", "b/lib"])
+        config.should_receive(:requires=).with(["a/file", "b/file"])
+        opts.configure(config)
+      ensure
+        ENV["SPEC_OPTS"] = orig_env
+      end
+    end
   end
 
   describe "-c, --color, and --colour" do


### PR DESCRIPTION
Libs and requires are taken only form one source according to the precedence: file, command line, env
For instance ci_reporter uses env to load itself, and this prevents any of both command line and file requires/libs to be taken into account.

I do not know about most common RSpec configurations though. It might have happen that it can broke some code that relays on overriding load sources. Need to check for common sense :octocat:
