### PR TITLE
Rspec-core cukes currently don't use executables/rspec

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,5 +2,5 @@ require 'aruba/cucumber'
 
 Before do
   @aruba_timeout_seconds = 5
-  ENV['PATH'] = ([File.expand_path('executables')] + @__aruba_original_paths).join(File::PATH_SEPARATOR)
+  ENV['PATH'] = "#{File.expand_path(File.dirname(__FILE__) + '/../../executables')}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
 end


### PR DESCRIPTION
Fix PATH so Aruba runs executables/rspec and not current/environment/rspec-core-gem/rspec
