### PR TITLE
Add support for each() on subjects.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ end
 gem "mocha", "~> 0.9.10"
 gem "rr", "~> 1.0.2"
 gem "flexmock", "0.8.8"
+gem "i18n", "0.6.0"
+gem "activesupport", "3.0.9"
 
 ### optional runtime deps
 gem "syntax", "1.0.0"

--- a/features/subject/each_attribute_of_subject.feature
+++ b/features/subject/each_attribute_of_subject.feature
@@ -1,0 +1,31 @@
+Feature: each attribute of subject
+
+  Use the each() method as a short-hand to generate a nested example group with
+  a single example that specifies the expected value of each attribute of the
+  subject.  This can be used with an implicit or explicit subject.
+
+  each() accepts a symbol or a string, and a block representing the example.
+
+      each(:item)     { should be_an(Item)    }
+      each("article") { should be_an(Article) }
+
+  Scenario: specify value of each attribute
+    Given a file named "example_spec.rb" with:
+      """
+      class Movie
+        def ratings
+          [9, 7, 9]
+        end
+      end
+
+      describe Movie do
+        each(:rating) { should be_an(Integer) }
+      end
+      """
+    When I run `rspec example_spec.rb --format documentation`
+    Then the output should contain:
+      """
+      Movie
+        each rating
+          should be a kind of Integer
+      """

--- a/spec/rspec/core/subject_spec.rb
+++ b/spec/rspec/core/subject_spec.rb
@@ -193,7 +193,51 @@ module RSpec::Core
           group.run.should be_true
         end
       end
-
     end
+
+    describe "#each" do
+      context "with an Object having #items returning an Array of Integers" do
+        subject do
+          Class.new do
+            def items
+              [1, 2]
+            end
+          end.new
+        end
+
+        each(:item) { should be_an(Integer) }
+      end
+
+      context "when it doesn't respond to the pluralized version of the attribute" do
+        subject { Object.new }
+
+        context "it raises an error" do
+          each(:item) do
+            expect do
+              should be_an(Integer)
+            end.to raise_error(NoMethodError)
+          end
+        end
+      end
+
+      context "when it doesn't return an object responding to each" do
+        subject do
+          Class.new do
+            def items
+              1
+            end
+          end.new
+        end
+
+        context "it raises an error" do
+          each(:item) do
+            expect do
+              should be_an(Integer)
+            end.to raise_error(NoMethodError)
+          end
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I think the following example will give the idea behind each() on subjects.

```
# This ...
describe Object do
  each(:item) { should be_an(Integer) }
end

# ... generates the same runtime structure as this:
describe Object do
  describe "each item"
    it "should be an Interger" do
      subject.items.each do |item|
        item.should be_an(Integer)
      end
    end
  end
end
```

Includes : documented code, specs and feature.
Tested under MRI1.8.7 and MRI1.9.2
