### PR TITLE
Fix rcov integration on windows (or platoform where PATH_SEPARATOR != : more generally)

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -161,7 +161,7 @@ module RSpec
                             cmd_parts << "bundle exec" if gemfile? unless skip_bundler
                             cmd_parts << runner
                             if rcov
-                              cmd_parts << ["-Ispec#{File::PATH_SEPARATOR}lib", rcov_opts]
+                              cmd_parts << ["-Ispec:lib", rcov_opts]
                             else
                               cmd_parts << rspec_opts
                             end


### PR DESCRIPTION
Fixes incorrect behavior on windows platform where PATH_SEPARATOR
is set to ';' which tricks rcov to add "spec;lib" to path instead
of adding ["spec", "lib"].
