### PR TITLE
Fixing grammatical typo in command-line description. 

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -85,7 +85,7 @@ module RSpec::Core
           options[:profile_examples] = o
         end
 
-        parser.on('-P', '--pattern PATTERN', 'Load files those matching this pattern. Default is "spec/**/*_spec.rb"') do |o|
+        parser.on('-P', '--pattern PATTERN', 'Load files matching this pattern. Default is "spec/**/*_spec.rb"') do |o|
           options[:pattern] = o
         end
 


### PR DESCRIPTION
'load files those matching' -> 'load files matching'
