### PR TITLE
add better error message when shared context is missing

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -90,7 +90,12 @@ module RSpec
       alias_it_should_behave_like_to :it_behaves_like, "behaves like"
 
       def self.include_context(name)
-        module_eval(&world.shared_example_groups[name])
+        group = world.shared_example_groups[name]
+        if group
+          module_eval(&group)
+        else
+          raise ArgumentError, "shared context \"#{name}\" not found"
+        end          
       end
 
       class << self

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -888,6 +888,19 @@ module RSpec::Core
         end
         group.run.should be_true
       end
+
+      it "should raise proper error message when shared context is not found" do
+        expect do
+          group = ExampleGroup.describe do
+            include_context "not exist"
+            
+            it "accesses foo" do
+              foo.should eq('foo')
+            end
+          end
+        end.to raise_error(ArgumentError,'shared context "not exist" not found')
+      end
+
     end
 
     describe "#include_examples" do


### PR DESCRIPTION
Now, when we try to include not exist shared context we got misleading error: ArgumentError Exception: block not supplied, my commit provides more friendly message.
