### PR TITLE
Prevent deprecation warnings in newer rake versions

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -6,6 +6,7 @@ require 'rake/tasklib'
 module RSpec
   module Core
     class RakeTask < ::Rake::TaskLib
+      include ::Rake::DSL
 
       # Name of task.
       #


### PR DESCRIPTION
Include ::Rake::DSL to avoid deprecation warnings in newer versions of rake.
