### PR TITLE
Fix travis image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 RSpec Core provides the structure for writing executable examples of how your
 code should behave.
 
-[![build status](https://travis-ci.org/rspec/rspec-core.png)](http://travis-ci.org/rspec/rspec-core)
+[![build status](https://secure.travis-ci.org/rspec/rspec-core.png)](http://travis-ci.org/rspec/rspec-core)
 
 ## Documentation
 


### PR DESCRIPTION
The Travis build status image wasn't rendered in the README due to an incorrect https url (see the part on SSL on http://about.travis-ci.org/docs/user/status-images/ )
