### PR TITLE
Turn off drb with --no-drb

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -99,8 +99,8 @@ module RSpec::Core
           exit
         end
 
-        parser.on('-X', '--drb', 'Run examples via DRb') do |o|
-          options[:drb] = true
+        parser.on('-X', '--[no-]drb', 'Run examples via DRb') do |o|
+          options[:drb] = o
         end
 
         parser.on('--configure COMMAND', 'Generate configuration files') do |cmd|
@@ -132,7 +132,7 @@ module RSpec::Core
         parser.on('--tty', 'Used internally by rspec when sending commands to other processes') do |o|
           options[:tty] = true
         end
-        
+
         parser.on('--default_path PATH', 'Set the default path where RSpec looks for examples.',
                                          'Can be a path to a file or a directory') do |path|
           options[:default_path] = path

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -204,6 +204,14 @@ describe RSpec::Core::ConfigurationOptions do
 
   end
 
+  describe "--no-drb" do
+    it "disables drb" do
+      parse_options("--no-drb").should include(:drb => false)
+      parse_options("--drb", "--no-drb").should include(:drb => false)
+    end
+  end
+
+
   describe "files_or_directories_to_run" do
     it "parses files from '-c file.rb dir/file.rb'" do
       parse_options("-c", "file.rb", "dir/file.rb").should include(:files_or_directories_to_run => ["file.rb", "dir/file.rb"])
@@ -256,7 +264,7 @@ describe RSpec::Core::ConfigurationOptions do
       it "includes --example" do
         config_options_object(*%w[--example foo]).drb_argv.should include("--example", "foo")
       end
-      
+
       it "unescapes characters which were escaped upon storing --example originally" do
         config_options_object("--example", "foo\\ bar").drb_argv.should include("--example", "foo bar")
       end


### PR DESCRIPTION
I have `--drb` in my `.rspec` file, which is nice and easy. But I also have a shell script that runs all tests (cucumber too) and I want to force this script not to use drb, because it can cause some weird issues. So I've added a `--no-drb` option, which should make it overridable from the command line, just like `--[no-]color`.
