### PR TITLE
Allows Rspec to connect to DRb server

### DIFF
--- a/lib/rspec/core/drb_command_line.rb
+++ b/lib/rspec/core/drb_command_line.rb
@@ -11,7 +11,7 @@ module RSpec
 
       def run(err, out)
         begin
-          DRb.start_service("druby://localhost:0")
+          DRb.start_service("druby://127.0.0.1:0")
         rescue SocketError, Errno::EADDRNOTAVAIL
           DRb.start_service("druby://:0")
         end


### PR DESCRIPTION
My coworker and I spent hours finding this fix. Before the fix, we would have Spork running, run Rspec with --drb, and the Rspec would give the "No DRb server running." error. It would then continue to run the specs in both Spork and the local Rspec process.
