### PR TITLE
Allow `its` keyword to take parameters

### DIFF
--- a/features/subject/attribute_of_subject.feature
+++ b/features/subject/attribute_of_subject.feature
@@ -84,6 +84,21 @@ Feature: attribute of subject
     When I run `rspec example_spec.rb`
     Then the examples should all pass
 
+  Scenario: specify a value for a getter that receives parameters
+    Given a file named "example_spec.rb" with:
+      """
+      describe [1, 2, 3] do
+        its(:join, '-') { should == '1-2-3' }
+      end
+      """
+    When I run `rspec example_spec.rb --format documentation`
+    Then the output should contain:
+      """
+      [1, 2, 3]
+        join ("-")
+          should == "1-2-3"
+      """
+
   Scenario: specify value for key in a hash
     Given a file named "example_spec.rb" with:
       """

--- a/lib/rspec/core/subject.rb
+++ b/lib/rspec/core/subject.rb
@@ -117,8 +117,9 @@ module RSpec
         #     its(:keys) { should include(:max_users) }
         #     its(:count) { should eq(2) }
         #   end
-        def its(attribute, &block)
-          describe(attribute) do
+        def its(attribute, *attributes_args, &block)
+          describe_args = describe_args_for attribute, attributes_args
+          describe(*describe_args) do
             example do
               self.class.class_eval do
                 define_method(:subject) do
@@ -126,7 +127,7 @@ module RSpec
                                   super()[*attribute]
                                 else
                                   attribute.to_s.split('.').inject(super()) do |target, method|
-                                    target.send(method)
+                                    target.send(method, *attributes_args)
                                   end
                                 end
                 end
@@ -167,6 +168,13 @@ module RSpec
         def implicit_subject
           described = describes || description
           Class === described ? proc { described.new } : proc { described }
+        end
+
+        def describe_args_for(attribute, attributes_args)
+          to_return = [attribute]
+          return to_return if attributes_args.empty?
+          attributes_args = attributes_args.map { |arg| arg.inspect }
+          to_return << "(#{attributes_args.join ', '})"
         end
       end
 


### PR DESCRIPTION
In pretty much every project I find myself wanting to describe objects through methods that take parameters like this:

```
class Person
  def initialize(first_name, last_name)
    @first_name, @last_name = first_name, last_name
  end

  def name(format)
    format.gsub('%f', @first_name).gsub('%l', @last_name)
  end
end

describe Person do
  subject { Person.new 'Josh', 'Cheek' }
  its(:name, '%f')    { should == 'Josh' }
  its(:name, '%l')    { should == 'Cheek' }
  its(:name, '%f %l') { should == 'Josh Cheek' }
end
```

This commit adds this feature.
