### PR TITLE
Enable the spec task to traverse symlinked directories

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -122,7 +122,7 @@ module RSpec
 
         @rcov_path  ||= 'rcov'
         @rspec_path ||= 'rspec'
-        @pattern    ||= './spec/**/*_spec.rb'
+        @pattern    ||= './spec/**/*/**/*_spec.rb'
 
         desc("Run RSpec code examples") unless ::Rake.application.last_comment
 


### PR DESCRIPTION
I encountered a problem when I split a project into a master git repo and a submodule, moving the model directory and associated model specs into the submodule. The models and model specs were symlinked into the appropriate places in the rails project. "rake" and "rake spec" would no longer find the model specs, though it would find specs that were not symlinked. 

The spec rake task passes a pattern to rake, and rake uses Dir[pattern] to glob those files. Apparently Dir globbing with a "**" does not follow symlinks, at least not in the form of the original pattern. 

The commit in this pull request includes a spec that checks that files are found in a directory structure that includes a sym link. This failed with the original pattern and passes with the modified pattern.

This resolves the issue I reported here:

https://github.com/rspec/rspec-rails/issues/442

-Kelly
