### PR TITLE
Use inject instead of reduce.

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -52,7 +52,7 @@ module RSpec
         end
 
         def build_description_from(*parts)
-          parts.map {|p| p.to_s}.reduce do |desc, p|
+          parts.map {|p| p.to_s}.inject do |desc, p|
             p =~ /^(#|::|\.)/ ? "#{desc}#{p}" : "#{desc} #{p}"
           end || ""
         end


### PR DESCRIPTION
Reduce is an alias for inject introduced in 1.8.7 -- using inject instead (while less readable) preserves 1.8.6 compatibility. 

Now, I'm not sure how many people are _actually_ using 1.8.6 and rspec 2 -- we do in CI, but only as a regression test for Jasmine. ;) 
