### PR TITLE
support for more than one tag simultaneously

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -80,7 +80,7 @@ module RSpec::Core
         parser.on('-O', '--options PATH', 'Specify the path to an options file') do |path|
           options[:custom_options_file] = path
         end
-        
+
         parser.on('--order TYPE', 'Run examples by the specified order type',
                   '  [rand] randomized',
                   '  [random] alias for rand',
@@ -131,23 +131,26 @@ module RSpec::Core
           options[:failure_exit_code] = o.to_i
         end
 
-        parser.on('-t', '--tag TAG[:VALUE]', 'Run examples with the specified tag',
+        parser.on('-t', '--tag TAG[:VALUES]', Array,
+                'Run examples with the specified tags (separated by commas)',
                 'To exclude examples, add ~ before the tag (e.g. ~slow)',
-                '(TAG is always converted to a symbol)') do |tag|
-          filter_type = tag =~ /^~/ ? :exclusion_filter : :inclusion_filter
+                '(TAG is always converted to a symbol)') do |tags|
+          tags.each do |tag|
+            filter_type = tag =~ /^~/ ? :exclusion_filter : :inclusion_filter
 
-          name,value = tag.gsub(/^(~@|~|@)/, '').split(':')
-          name = name.to_sym
+            name,value = tag.gsub(/^(~@|~|@)/, '').split(':')
+            name = name.to_sym
 
-          options[filter_type] ||= {}
-          options[filter_type][name] = case value
-                                       when /^(true|false|nil)$/
-                                         eval(value)
-                                       when nil
-                                         true
-                                       else
-                                         value
-                                       end
+            options[filter_type] ||= {}
+            options[filter_type][name] = case value
+                                         when /^(true|false|nil)$/
+                                           eval(value)
+                                         when nil
+                                           true
+                                         else
+                                           value
+                                         end
+          end
         end
 
         parser.on('--tty', 'Used internally by rspec when sending commands to other processes') do |o|

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -271,7 +271,6 @@ describe RSpec::Core::ConfigurationOptions do
     end
   end
 
-
   describe "files_or_directories_to_run" do
     it "parses files from '-c file.rb dir/file.rb'" do
       parse_options("-c", "file.rb", "dir/file.rb").should include(:files_or_directories_to_run => ["file.rb", "dir/file.rb"])


### PR DESCRIPTION
I did some specs for it, but this part of code changed just now in rspec-core.

Guys, I'd be glad to know your opinion on it, also any improvements I need to do in order to enable this feature in rspec.

We have a heavy integration specs project that motivated me to do this change. Some contexts are slow and we don't want to run them all the time. Other just fail, and since they fail because of an external dependency, they're not pending in our side. We'd like to use multiple tags to exclude the right ones, and enable the use of wip, for instance.  
