### PR TITLE
Create the fakefs home directory path so writes to ~/.rspec succeed

### DIFF
--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -303,6 +303,10 @@ describe RSpec::Core::ConfigurationOptions do
   end
 
   describe "sources: ~/.rspec, ./.rspec, custom, CLI, and SPEC_OPTS" do
+    before(:each) do
+      FileUtils.mkpath(File.expand_path("~"))
+    end
+
     it "merges global, local, SPEC_OPTS, and CLI" do
       File.open("./.rspec", "w") {|f| f << "--line 37"}
       File.open("~/.rspec", "w") {|f| f << "--color"}


### PR DESCRIPTION
Fix 4 spec failures in the configuration_options_spec tests by creating the home directory path in the fakefs file system prior to each test being run.  Without this I am getting ENOENT errors because the home directory does not exist so the write to the file in that directory fails.
