### PR TITLE
Add support for passing parameters and a block through include_examples

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -98,6 +98,11 @@ module RSpec
       #
       # @see SharedExampleGroup
       def self.include_context(name, *args)
+        if block_given?
+          block_not_supported("context")
+          return
+        end
+
         find_and_execute_shared_block("context", name, *args)
       end
 
@@ -105,7 +110,16 @@ module RSpec
       #
       # @see SharedExampleGroup
       def self.include_examples(name, *args)
+        if block_given?
+          block_not_supported("examples")
+          return
+        end
+
         find_and_execute_shared_block("examples", name, *args)
+      end
+
+      def self.block_not_supported(label)
+        warn("Customization blocks not supported for include_#{label}.  Use it_behaves_like instead.")
       end
 
       def self.find_and_execute_shared_block(label, name, *args, &customization_block)

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -938,6 +938,18 @@ module RSpec::Core
           passed_params.should eq({ :param1 => :value1, :param2 => :value2 })
         end
       end
+
+      context "given a block" do
+        it "warns the user that blocks are not supported" do
+          group = ExampleGroup.describe do
+            self.should_receive(:warn).with(/blocks not supported for include_context/)
+            include_context "named this with block" do
+              true
+            end
+          end
+          group.run
+        end
+      end
     end
 
     describe "#include_examples" do
@@ -997,6 +1009,18 @@ module RSpec::Core
           group = ExampleGroup.describe('fake group')
           group.include_examples("named this with params", :a)
           eval_count.should eq(1)
+        end
+      end
+
+      context "given a block" do
+        it "warns the user that blocks are not supported" do
+          group = ExampleGroup.describe do
+            self.should_receive(:warn).with(/blocks not supported for include_examples/)
+            include_examples "named this with block" do
+              true
+            end
+          end
+          group.run
         end
       end
     end


### PR DESCRIPTION
The `it_should_behave_like` and `it_behaves_like` methods of pulling in shared examples both allow you to pass parameters and a customization block.  In my case I preferred the `include_examples` method instead of those alternatives but it did not support passing parameters or a block.  This change adds that support along with tests for it.
