### PR TITLE
Instead of using rand in --order random please use Kernel.rand

### DIFF
--- a/lib/rspec/core/extensions/ordered.rb
+++ b/lib/rspec/core/extensions/ordered.rb
@@ -6,8 +6,8 @@ module RSpec
       module Ordered
         def ordered
           if RSpec.configuration.randomize?
-            srand RSpec.configuration.seed
-            sort_by { rand size }
+            Kernel.srand RSpec.configuration.seed
+            sort_by { Kernel.rand size }
           else
             self
           end


### PR DESCRIPTION
Hi There,

I found an interesting little bug due to someone monkey patching Array#rand.

When running rspec --order random it would throw an error

Exception encountered: #<ArgumentError: wrong number of arguments (1 for 0)>
backtrace:
/Users/matthewkirk/.rvm/gems/ruby-1.9.2-p290@svsecure/gems/faker-0.3.1/lib/extensions/array.rb:2:in `rand'

I know it's Faker who is monkey patching Array but it seems like an easy enough fix to just call Kernel.rand and Kernel.srand instead of relying on whatever is included at that particular point.

Thanks!
