### PR TITLE
unnecessary to_s

### DIFF
--- a/lib/rspec/core/drb_options.rb
+++ b/lib/rspec/core/drb_options.rb
@@ -55,8 +55,8 @@ module RSpec::Core
     def add_filter(argv, name, hash)
       hash.each_pair do |k, v|
         next if [:if,:unless].include?(k)
-        tag = name == :inclusion ? k.to_s : "~#{k.to_s}"
-        tag << ":#{v.to_s}" if v.is_a?(String)
+        tag = name == :inclusion ? k.to_s : "~#{k}"
+        tag << ":#{v}" if v.is_a?(String)
         argv << "--tag" << tag
       end unless hash.empty?
     end


### PR DESCRIPTION
(tested with 1.8.7 & 1.9.2)
