### PR TITLE
two additional tests for FilterManager

### DIFF
--- a/spec/rspec/core/filter_manager_spec.rb
+++ b/spec/rspec/core/filter_manager_spec.rb
@@ -26,6 +26,16 @@ module RSpec::Core
         filter_manager.send name, :low_priority, :foo => 2
         filter_manager.send(type).should eq(:foo => 1)
       end
+
+      it "replaces previous #{type} if priority is :replace" do
+        filter_manager = FilterManager.new
+        filter_manager.exclusions.clear # defaults
+        filter_manager.send name, :foo => 1
+        filter_manager.send name, :baz => 2
+        filter_manager.send name, :bar => 3
+        filter_manager.send name, :replace, :very => "high_priority"
+        filter_manager.send(type).should eq(:very => "high_priority")
+      end
     end
 
     describe "#prune" do


### PR DESCRIPTION
If rename :replace into :some_other in the FilterManager#update, and then run tests,
only couple of them would fail and they all are indirect.

configuration.rb inclusion_filter= and exclusion_filter= also needs tests.
I'll write them later, when I'll be digging through the configuration.rb.
