### PR TITLE
the fix of wrong FilterManager#prune testing

### DIFF
--- a/spec/rspec/core/filter_manager_spec.rb
+++ b/spec/rspec/core/filter_manager_spec.rb
@@ -84,24 +84,24 @@ module RSpec::Core
 
     describe "#prune" do
       it "includes objects with tags matching inclusions" do
-        included = RSpec::Core::Metadata.new({:foo => :bar})
-        excluded = RSpec::Core::Metadata.new
+        included = ExampleGroup.describe('g').example('e', {:foo => :bar})
+        excluded = ExampleGroup.describe('g').example('e')
         filter_manager = FilterManager.new
         filter_manager.include :foo => :bar
         filter_manager.prune([included, excluded]).should eq([included])
       end
 
       it "excludes objects with tags matching exclusions" do
-        included = RSpec::Core::Metadata.new
-        excluded = RSpec::Core::Metadata.new({:foo => :bar})
+        included = ExampleGroup.describe('g').example('e')
+        excluded = ExampleGroup.describe('g').example('e', {:foo => :bar})
         filter_manager = FilterManager.new
         filter_manager.exclude :foo => :bar
         filter_manager.prune([included, excluded]).should eq([included])
       end
 
       it "prefers exclusion when matches previously set inclusion" do
-        included = RSpec::Core::Metadata.new
-        excluded = RSpec::Core::Metadata.new({:foo => :bar})
+        included = ExampleGroup.describe('g').example('e')
+        excluded = ExampleGroup.describe('g').example('e', {:foo => :bar})
         filter_manager = FilterManager.new
         filter_manager.include :foo => :bar
         filter_manager.exclude :foo => :bar
@@ -109,8 +109,8 @@ module RSpec::Core
       end
 
       it "prefers inclusion when matches previously set exclusion" do
-        included = RSpec::Core::Metadata.new({:foo => :bar})
-        excluded = RSpec::Core::Metadata.new
+        included = ExampleGroup.describe('g').example('e', {:foo => :bar})
+        excluded = ExampleGroup.describe('g').example('e')
         filter_manager = FilterManager.new
         filter_manager.exclude :foo => :bar
         filter_manager.include :foo => :bar
@@ -118,8 +118,8 @@ module RSpec::Core
       end
 
       it "prefers previously set inclusion when exclusion matches but has lower priority" do
-        included = RSpec::Core::Metadata.new({:foo => :bar})
-        excluded = RSpec::Core::Metadata.new
+        included = ExampleGroup.describe('g').example('e', {:foo => :bar})
+        excluded = ExampleGroup.describe('g').example('e')
         filter_manager = FilterManager.new
         filter_manager.include :foo => :bar
         filter_manager.exclude_with_low_priority :foo => :bar
@@ -127,8 +127,8 @@ module RSpec::Core
       end
 
       it "prefers previously set exclusion when inclusion matches but has lower priority" do
-        included = RSpec::Core::Metadata.new
-        excluded = RSpec::Core::Metadata.new({:foo => :bar})
+        included = ExampleGroup.describe('g').example('e')
+        excluded = ExampleGroup.describe('g').example('e', {:foo => :bar})
         filter_manager = FilterManager.new
         filter_manager.exclude :foo => :bar
         filter_manager.include_with_low_priority :foo => :bar


### PR DESCRIPTION
the #prune method operates with Examples and not with Metadata instances.
