### PR TITLE
Add colour option for -p's slow test output

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -157,6 +157,10 @@ MESSAGE
       #     end
       add_setting :treat_symbols_as_metadata_keys_with_true_values
 
+      # When profiling your specs, this option allows you to set the color
+      # of the slow spec times.
+      add_setting :slow_color
+
       # @private
       add_setting :tty
       # @private
@@ -184,6 +188,7 @@ MESSAGE
         @files_to_run = []
         @formatters = []
         @color = false
+        @slow_color = 'cyan'
         @pattern = '**/*_spec.rb'
         @failure_exit_code = 1
         @backtrace_clean_patterns = DEFAULT_BACKTRACE_PATTERNS.dup

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -58,7 +58,7 @@ module RSpec
           output.puts "\nTop #{sorted_examples.size} slowest examples:\n"
           sorted_examples.each do |example|
             output.puts "  #{example.full_description}"
-            output.puts cyan("    #{red(format_seconds(example.execution_result[:run_time]))} #{red("seconds")} #{format_caller(example.location)}")
+            output.puts "    #{time_colorer(format_seconds example.execution_result[:run_time])} #{time_colorer("seconds")} #{format_caller(example.location)}"
           end
         end
 
@@ -140,6 +140,10 @@ module RSpec
 
         def long_padding
           '     '
+        end
+
+        def time_colorer(time_string)
+          send configuration.slow_color, time_string
         end
 
       private

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -120,6 +120,14 @@ module RSpec::Core
           options[:profile_examples] = o
         end
 
+        valid_colors = %w[cyan yellow red green white blue magenta]
+        parser.on('-s', '--slow-color', '--slow-colour COLOR',
+                  "when using -p, allows overriding colour used to display the slowest times",
+                  "valid options: #{valid_colors.join ', '}",
+                  /^#{valid_colors.join '|'}$/) do |color|
+          options[:slow_color] = color
+        end
+
         parser.separator <<-FILTERING
 
   **** Filtering and tags ****
@@ -135,6 +143,7 @@ FILTERING
         parser.on('-P', '--pattern PATTERN', 'Load files matching pattern (default: "spec/**/*_spec.rb")') do |o|
           options[:pattern] = o
         end
+
 
         parser.on('-e', '--example STRING', "Run examples whose full nested names include STRING") do |o|
           options[:full_description] = Regexp.compile(Regexp.escape(o))

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -120,6 +120,14 @@ describe RSpec::Core::ConfigurationOptions do
     end
   end
 
+  describe "-s, --slow-color, and --slow-colour" do
+    it "sets :slow_color" do
+      parse_options('-s', 'cyan').should include(:slow_color => 'cyan')
+      parse_options('--slow-color', 'red').should include(:slow_color => 'red')
+      parse_options('--slow-colour', 'yellow').should include(:slow_color => 'yellow')
+    end
+  end
+
   describe "-I" do
     example "adds to :libs" do
       parse_options('-I', 'a_dir').should include(:libs => ['a_dir'])

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -554,6 +554,12 @@ module RSpec::Core
       end
     end
 
+    describe '#slow_color=' do
+      it 'defaults to cyan' do
+        config.slow_color.should eq('cyan')
+      end
+    end
+
     describe '#formatter=' do
       it "delegates to add_formatter (better API for user-facing configuration)" do
         config.should_receive(:add_formatter).with('these','options')

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -340,5 +340,30 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
 
       output.string.should =~ /#{filename}\:#{__LINE__ - 21}/
     end
+
+    context 'with --slow-color' do
+      let :output_stream do
+        output_stream = StringIO.new
+        output_stream.stub(:tty?).and_return(true)
+        output_stream
+      end
+
+      def output_for(color)
+        RSpec.configure do |config|
+          config.output_stream = output_stream
+          config.color_enabled = true
+          config.slow_color = color
+        end
+
+        formatter.dump_profile
+        output.string
+      end
+
+      it 'colors the slow times according to configuration.slow_color' do
+        output_for("red").should include("\e[31m")
+        output_for("blue").should include("\e[34m")
+        output_for("cyan").should include("\e[36m")
+      end
+    end
   end
 end

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -140,6 +140,21 @@ module RSpec::Core
       end
     end
 
+    %w[-s --slow-color --slow-colour].each do |option|
+      describe option do
+        it 'raises an error when given an invalid value' do
+          expect { Parser.parse! [option, 'fuchsia'] }.to raise_error
+        end
+
+        %w[red green yellow blue magenta cyan white].each do |color|
+          specify "#{color} is a valid option" do
+            options = Parser.parse!([option, color])
+            options[:slow_color].should eq(color)
+          end
+        end
+      end
+    end
+
     describe "--order" do
       it "is nil by default" do
         Parser.parse!([])[:order].should be_nil


### PR DESCRIPTION
Worked on with @cdemyanovich during waza at @8thlight

When running RSpec with the --profile option, slow tests are displayed in red. This causes me to think my tests fail!

This patch introduces the `--slow-color` (akas: `--slow-colour`, `-s`) option to allow the color to be changed. It defaults to cyan.

![example](https://s3.amazonaws.com/josh.cheek/images/scratch/rspec-slow-color.png)
