### PR TITLE
Encourage custom formatters to use a proper namespace.

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -763,6 +763,8 @@ MESSAGE
           formatter_ref
         elsif string_const?(formatter_ref)
           begin
+            RSpec::Core::Formatters::const_get(formatter_ref)
+          rescue NameError
             eval(formatter_ref)
           rescue NameError
             require path_for(formatter_ref)


### PR DESCRIPTION
The code could use more work, such as corresponding require code, but this addition marks the main idea of it.
