### PR TITLE
its-block should only work for public methods

### DIFF
--- a/lib/rspec/core/subject.rb
+++ b/lib/rspec/core/subject.rb
@@ -126,7 +126,7 @@ module RSpec
                                   super()[*attribute]
                                 else
                                   attribute.to_s.split('.').inject(super()) do |target, method|
-                                    target.send(method)
+                                    target.respond_to?(:public_send) ? target.public_send(method) : target.send(method)
                                   end
                                 end
                 end

--- a/spec/rspec/core/subject_spec.rb
+++ b/spec/rspec/core/subject_spec.rb
@@ -122,6 +122,23 @@ module RSpec::Core
         its(:nil_value) { should be_nil }
       end
 
+      context "with a private method name", :ruby => 1.9 do
+        subject do
+          Class.new do
+            private
+            def implementation_detail
+              "hidden"
+            end
+          end.new
+        end
+
+        its(:implementation_detail) do
+          lambda {
+            subject
+          }.should raise_error(NoMethodError, /private method `implementation_detail' called for/)
+        end
+      end
+
       context "with nested attributes" do
         subject do
           Class.new do


### PR DESCRIPTION
Only works in 1.9, using `#public_method`.  Still allows private methods in 1.8.
