### PR TITLE
metadata supports arrays for procs

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -169,7 +169,7 @@ module RSpec
 
       # @private
       def filter_applies?(key, value, metadata=self)
-        return metadata.filter_applies_to_any_value?(key, value) if Array === metadata[key]
+        return metadata.filter_applies_to_any_value?(key, value) if Array === metadata[key] && !(Proc === value)
         return metadata.line_number_filter_applies?(value)       if key == :line_numbers
         return metadata.location_filter_applies?(value)          if key == :locations
         return metadata.filters_apply?(key, value)               if Hash === value

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -160,6 +160,14 @@ module RSpec
             metadata_with_array.filter_applies?(:tag, 'fourtune').should be_true
             metadata_with_array.filter_applies?(:tag, 'fortune').should be_false
           end
+
+          it "matches a proc that evaluates to true" do
+            metadata_with_array.filter_applies?(:tag, lambda { |values| values.include? 'three' }).should be_true
+          end
+
+          it "does not match a proc that evaluates to false" do
+            metadata_with_array.filter_applies?(:tag, lambda { |values| values.include? 'nothing' }).should be_false
+          end
         end
       end
 


### PR DESCRIPTION
in my case, and I suppose it's valid for all cases with procs, we want the proc to receive the complete array instead of being called for every single item.

@ineverov added support for arrays in metadata
see: a9dc8a1d36f0ed48a5358dcadf4e340a4f72c9f4

after a refactoring commit, it stopped working for procs
see: 864e192f5ffc65bb6e10b7141f2cc266717fe531 (line 172)
