### PR TITLE
Fix Cucumber deprecation warnings

### DIFF
--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -11,8 +11,8 @@ Then /^the output should not contain any of these:$/ do |table|
 end
 
 Then /^the example(?:s)? should(?: all)? pass$/ do
-  Then %q{the output should contain "0 failures"}
-  Then %q{the exit status should be 0}
+  step %q{the output should contain "0 failures"}
+  step %q{the exit status should be 0}
 end
 
 Then /^the file "([^"]*)" should contain:$/ do |file, partial_content|


### PR DESCRIPTION
This removes the following warning:

```
WARNING: Using 'Given/When/Then' in step definitions
is deprecated, use 'step' to call other steps instead
```
