### PR TITLE
Add "calling_it" method to the ExampleGroup DSL

### DIFF
--- a/features/subject/as_proc.feature
+++ b/features/subject/as_proc.feature
@@ -1,0 +1,28 @@
+Feature: treat subject as a proc
+
+  Use `calling_it` to treat subject as a proc; replaces
+  cases where `expect` would be used in "classic" syntax.
+
+  Scenario: explicit subject
+    Given a file named "calling_it_spec.rb" with:
+      """
+      $counter = 0
+      describe 'calling_it' do
+        subject { $counter += 1 }
+        calling_it { should change { $counter }.by(1) }
+      end
+      """
+    When I run `rspec calling_it_spec.rb`
+    Then the examples should all pass
+
+  Scenario: explicit subject with failure
+    Given a file named "calling_it_spec_with_failure.rb" with:
+      """
+      $counter = 0
+      describe 'calling_it' do
+        subject { $counter += 1 }
+        calling_it { should change { $counter }.by(2) }
+      end
+      """
+    When I run `rspec calling_it_spec_with_failure.rb`
+    Then the output should contain "1 example, 1 failure"

--- a/lib/rspec/core/subject.rb
+++ b/lib/rspec/core/subject.rb
@@ -136,6 +136,37 @@ module RSpec
           end
         end
 
+        # Treats the subject as a proc, to allow expressing expectations
+        # on consequences of calling the subject, not only its properties.
+        #
+        # The following examples are equivalent:
+        #
+        # describe BankTransfer, "::perform" do
+        #   let(:bank_account) { BankAccount.new(100) }
+        #   subject { BankTransfer.perform(bank_account, 30) }
+        #
+        #   it "should change bank account deposit" do
+        #     expect { subject }.to change { bank_account.deposit }.by(30)
+        #     # or: proc { subject }.should change { bank_account.deposit }.by(30)
+        #   end
+        # end
+        #
+        # describe BankTransfer, "::perform" do
+        #   let(:bank_account) { BankAccount.new(100) }
+        #   subject { BankTransfer.perform(bank_account, 30) }
+        #   calling_it { should change { bank_account.deposit }.by(30) }
+        # end
+        def calling_it(&block)
+          example do
+            self.class.class_eval do
+              define_method(:subject) do
+                @_subject ||= self.class.subject
+              end
+            end
+            instance_eval(&block)
+          end
+        end
+
         # Defines an explicit subject for an example group which can then be the
         # implicit receiver (through delegation) of calls to +should+.
         #


### PR DESCRIPTION
Treats the subject as a proc, to allow expressing expectations
on consequences of calling the subject, not only its properties.

The following examples are equivalent:

``` ruby
describe BankTransfer, "::perform" do
  let(:bank_account) { BankAccount.new(100) }
  subject { BankTransfer.perform(bank_account, 30) }

  it "should change bank account deposit" do
    expect { subject }.to change { bank_account.deposit }.by(30)
    # or: proc { subject }.should change { bank_account.deposit }.by(30)
  end
end

describe BankTransfer, "::perform" do
  let(:bank_account) { BankAccount.new(100) }
  subject { BankTransfer.perform(bank_account, 30) }
  calling_it { should change { bank_account.deposit }.by(30) }
end
```

I'm not 100% happy with the name, but maybe the community would have better suggestions?

Also, I'd gladly add more documentation if the idea gets accepted (just need some hints where exactly to add it).
