### PR TITLE
Display both minutes and seconds of duration time when specs are finished.

### DIFF
--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -35,7 +35,7 @@ module RSpec
           super(duration, example_count, failure_count, pending_count)
           # Don't print out profiled info if there are failures, it just clutters the output
           dump_profile if profile_examples? && failure_count == 0
-          output.puts "\nFinished in #{format_seconds(duration)} seconds\n"
+          output.puts "\nFinished in #{format_duration(duration)}\n"
           output.puts colorise_summary(summary_line(example_count, failure_count, pending_count))
           dump_commands_to_rerun_failed_examples
         end

--- a/lib/rspec/core/formatters/helpers.rb
+++ b/lib/rspec/core/formatters/helpers.rb
@@ -6,6 +6,17 @@ module RSpec
         SUB_SECOND_PRECISION = 5
         DEFAULT_PRECISION = 2
 
+        def format_duration(duration)
+          if duration > 60
+            minutes = duration.to_i / 60
+            seconds = duration - minutes * 60
+
+            "#{minutes} minute(s) #{format_seconds(seconds)} seconds"
+          else
+            "#{format_seconds(duration)} seconds"
+          end
+        end
+
         def format_seconds(float)
           precision ||= (float < 1) ? SUB_SECOND_PRECISION : DEFAULT_PRECISION
           formatted = sprintf("%.#{precision}f", float)

--- a/spec/rspec/core/formatters/helpers_spec.rb
+++ b/spec/rspec/core/formatters/helpers_spec.rb
@@ -4,6 +4,20 @@ require 'rspec/core/formatters/helpers'
 describe RSpec::Core::Formatters::Helpers do
   let(:helper) { Object.new.extend(RSpec::Core::Formatters::Helpers) }
 
+  describe "format duration" do
+    context '> 60' do
+      it "returns 'x minute(s) xx seconds' formatted string" do
+        helper.format_duration(135.14).should eq("2 minute(s) 15.14 seconds")
+      end
+    end
+
+    context '< 60' do
+      it "returns 'xx seconds' formatted string" do
+        helper.format_duration(45.5).should eq("45.5 seconds")
+      end
+    end
+  end
+
   describe "format seconds" do
     context "sub second times" do
       it "returns 5 digits of precision" do


### PR DESCRIPTION
As far as lots of rails heavy-weight apps (mine too) runs specs much longer than tens seconds (about 23 minutes on my app for instance) because of hardcore DB seeding I think it will be useful to see "xx minutes xx seconds" in output if duration is more than 1 minute.
