### PR TITLE
Also run excluded examples when turning run_all_when_everything_filtered on.

### DIFF
--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -78,9 +78,10 @@ module RSpec
         end
 
         if @configuration.run_all_when_everything_filtered? && example_count.zero?
-          reporter.message("#{everything_filtered_message}; ignoring #{inclusion_filter.description}")
+          reporter.message("#{everything_filtered_message}; Running all.")
           filtered_examples.clear
           inclusion_filter.clear
+          exclusion_filter.clear
         end
 
         if example_count.zero?
@@ -90,7 +91,7 @@ module RSpec
           elsif exclusion_filter.empty_without_conditional_filters?
             message = everything_filtered_message
             if @configuration.run_all_when_everything_filtered?
-              message << "; ignoring #{inclusion_filter.description}"
+              message << "; Running all."
             end
             reporter.message(message)
           elsif inclusion_filter.empty?

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -139,6 +139,28 @@ module RSpec::Core
           end
         end
       end
+      
+      context "with an exclustion filter and run_all_when_everything_filtered" do
+        let(:group) do
+          group = RSpec::Core::ExampleGroup.describe("group", :foo => 'bar') do
+            example("example") {}
+          end
+          group.stub!(:world){world}
+          group
+        end
+
+        before do
+          world.register(group)
+          configuration.filter_run_excluding :foo => 'bar'
+          configuration.run_all_when_everything_filtered = true
+        end
+        
+        it "announces" do
+          world.announce_filters
+          world.example_count.should eq(1)
+        end
+      end
+      
     end
   end
 end


### PR DESCRIPTION
I'm not sure if this was an intentional omission, but when an exclusion filter removes exampels from a run, the `run_all_when_everything_filtered` option does not bring them back, even if, for example, you have an entire file marked as `:slow => true` and try to run _just that file_.

**The changes I made in this request are not yet ready to be merged!**

I'm not quite sure what's going on in the second half of the `World#announce_filters` method and also my change breaks a few examples from the example_group_spec.

I'd like to get some feedback on this and maybe get an explanation for the current behavior or some help in developing the solution into something that works and doesn't break other stuff.
