### PR TITLE
at_exit: don't mask nonzero exit status due to $!

### DIFF
--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -7,7 +7,7 @@ module RSpec
       # Register an at_exit hook that runs the suite.
       def self.autorun
         return if autorun_disabled? || installed_at_exit? || running_in_drb?
-        at_exit { exit run(ARGV, $stderr, $stdout).to_i }
+        at_exit { exit run(ARGV, $stderr, $stdout).to_i unless $! }
         @installed_at_exit = true
       end
       AT_EXIT_HOOK_BACKTRACE_LINE = "#{__FILE__}:#{__LINE__ - 2}:in `autorun'"


### PR DESCRIPTION
This change ensures that RSpec's at_exit handler doesn't mask (override)
any nonzero exit status, which can happen when Ruby is on it's way out
due to an uncaught exception ($!) such as a SyntaxError.

Please see this bug report for more information:

https://github.com/sunaku/tork/issues/31#issuecomment-3801441
