### PR TITLE
Autotest fails if RSpec executable path contains spaces

### DIFF
--- a/lib/autotest/rspec2.rb
+++ b/lib/autotest/rspec2.rb
@@ -47,7 +47,7 @@ class Autotest::Rspec2 < Autotest
   # Overrides Autotest's implementation to generate the rspec command to run
   def make_test_cmd(files_to_test)
     files_to_test.empty? ? '' :
-      "#{prefix}#{ruby}#{suffix} -S #{RSPEC_EXECUTABLE} --tty #{normalize(files_to_test).keys.flatten.map { |f| "'#{f}'"}.join(' ')}"
+      "#{prefix}#{ruby}#{suffix} -S '#{RSPEC_EXECUTABLE}' --tty #{normalize(files_to_test).keys.flatten.map { |f| "'#{f}'"}.join(' ')}"
   end
 
   # Generates a map of filenames to Arrays for Autotest

--- a/spec/autotest/rspec_spec.rb
+++ b/spec/autotest/rspec_spec.rb
@@ -30,7 +30,7 @@ describe Autotest::Rspec2 do
 
     it "makes the appropriate test command" do
       actual_command = rspec_autotest.make_test_cmd(@files_to_test)
-      expected_command = /#{ruby_cmd}.*#{spec_cmd} (.*)/
+      expected_command = /#{ruby_cmd}.*'#{spec_cmd}' (.*)/
 
       actual_command.should match(expected_command)
 


### PR DESCRIPTION
#132 fixed this for the spec file paths, e.g. in the case where the project directory name contains spaces, but if RSpec itself is installed beneath the project directory (e.g. with `bundle install --path vendor/bundle`) then the same problem exists for the path of the `rspec` executable.

I don't want to think about what happens if the project directory name contains apostrophes.
