### PR TITLE
Some tests depend on absence of formatter in ~/.rspec

### DIFF
--- a/features/command_line/format_option.feature
+++ b/features/command_line/format_option.feature
@@ -46,7 +46,7 @@ Feature: --format option
       """
 
   Scenario: progress bar format (default)
-    When I run `rspec example_spec.rb`
+    When I run `rspec --format progress example_spec.rb`
     Then the output should contain ".F*"
 
   Scenario: documentation format

--- a/features/hooks/around_hooks.feature
+++ b/features/hooks/around_hooks.feature
@@ -165,7 +165,7 @@ Feature: around hooks
         end
       end
       """
-    When I run `rspec example_spec.rb`
+    When I run `rspec --format progress example_spec.rb`
     Then the output should contain:
       """
       before all

--- a/features/hooks/before_and_after_hooks.feature
+++ b/features/hooks/before_and_after_hooks.feature
@@ -227,7 +227,7 @@ Feature: before and after hooks
         end
       end
       """
-    When I run `rspec ensure_block_order_spec.rb`
+    When I run `rspec --format progress ensure_block_order_spec.rb`
     Then the output should contain:
       """
       before all
@@ -272,7 +272,7 @@ Feature: before and after hooks
         end
       end
       """
-    When I run `rspec configuration_spec.rb`
+    When I run `rspec --format progress configuration_spec.rb`
     Then the output should contain:
       """
       before suite
@@ -313,7 +313,7 @@ Feature: before and after hooks
 
       end
       """
-    When I run `rspec before_and_after_all_spec.rb`
+    When I run `rspec --format progress before_and_after_all_spec.rb`
     Then the examples should all pass
     And the output should contain:
       """
@@ -323,7 +323,7 @@ Feature: before and after hooks
       outer after all
       """
 
-    When I run `rspec before_and_after_all_spec.rb:14`
+    When I run `rspec --format progress before_and_after_all_spec.rb:14`
     Then the examples should all pass
     And the output should contain:
       """
@@ -333,7 +333,7 @@ Feature: before and after hooks
       outer after all
       """
 
-    When I run `rspec before_and_after_all_spec.rb:6`
+    When I run `rspec --format progress before_and_after_all_spec.rb:6`
     Then the examples should all pass
     And the output should contain:
       """

--- a/features/hooks/filtering.feature
+++ b/features/hooks/filtering.feature
@@ -182,7 +182,7 @@ Feature: filters
         end
       end
       """
-    When I run `rspec filter_after_all_hooks_spec.rb`
+    When I run `rspec --format progress filter_after_all_hooks_spec.rb`
     Then the examples should all pass
     And the output should contain:
       """
@@ -216,7 +216,7 @@ Feature: filters
         it("", :around_each) { puts "example 4" }
       end
       """
-    When I run `rspec less_verbose_metadata_filter.rb`
+    When I run `rspec --format progress less_verbose_metadata_filter.rb`
     Then the examples should all pass
     And the output should contain:
       """


### PR DESCRIPTION
Hello,

A few Cucumber features fail due to expecting the output from the default progress formatter, when the user specified another default (like `--format documentation`) in its ~/.rspec.

A solution is to explicitly give the `-fp` option to those tests, which is what I did here. It does make sense to me since these tests clearly rely on the progress formatter output.

Another is to add `--format progress` to the local `.rspec`:

``` diff
diff --git a/.rspec b/.rspec
index b017218..6d4d003 100644
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --default_path spec
 --order rand
+--format progress
```
