### PR TITLE
Allow let to memoize similar methods in a single block by passing multiple arguments

### DIFF
--- a/lib/rspec/core/let.rb
+++ b/lib/rspec/core/let.rb
@@ -19,9 +19,11 @@ module RSpec
         #       thing.should be_something
         #     end
         #   end
-        def let(name, &block)
-          define_method(name) do
-            __memoized.fetch(name) {|k| __memoized[k] = instance_eval(&block) }
+        def let(*names, &block)
+          names.each do |name|
+            define_method(name) do
+              __memoized.fetch(name) {|k| __memoized[k] = instance_eval(&block) }
+            end
           end
         end
 
@@ -79,9 +81,11 @@ module RSpec
         #       end
         #     end
         #   end
-        def let!(name, &block)
-          let(name, &block)
-          before { __send__(name) }
+        def let!(*names, &block)
+          names.each do |name|
+            let(name, &block)
+            before { __send__(name) }
+          end
         end
       end
 

--- a/spec/rspec/core/let_spec.rb
+++ b/spec/rspec/core/let_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "#let" do
-  let(:counter) do
+  let(:counter, :another_counter) do
     Class.new do
       def initialize
         @count = 0
@@ -33,10 +33,14 @@ describe "#let" do
 
     @nil_value_count.should eq(1)
   end
+
+  it "caches multiple arguments separately" do
+    counter.should_not eq(another_counter)
+  end
 end
 
 describe "#let!" do
-  let!(:creator) do
+  let!(:creator, :another_creator) do
     Class.new do
       @count = 0
       def self.count
@@ -52,4 +56,9 @@ describe "#let!" do
   it "does not interfere between tests" do
     creator.count.should eq(1)
   end
+
+  it "caches multiple arguments separately" do
+    creator.should_not eq(another_creator)
+  end
+
 end


### PR DESCRIPTION
For some specs I want to instantiate similar but distinct objects.
But instead of doing:

``` ruby
let(:thing) do
   thing = Thing.new
   thing.do_something
   thing
end

let(:another_thing) do
   thing = Thing.new
   thing.do_something
   thing
end
```

I'd like to be able to do:

``` ruby
let(:thing, :another_thing) do
   thing = Thing.new
   thing.do_something
   thing
end
```
