### PR TITLE
Notification to the STDOUT when using an existing DRb server

### DIFF
--- a/lib/rspec/core/drb_command_line.rb
+++ b/lib/rspec/core/drb_command_line.rb
@@ -15,6 +15,8 @@ module RSpec
         rescue SocketError, Errno::EADDRNOTAVAIL
           DRb.start_service("druby://:0")
         end
+
+        out.puts "\nUsing DRb server #{DRb.uri}."
         spec_server = DRbObject.new_with_uri("druby://127.0.0.1:#{drb_port}")
         spec_server.run(@options.drb_argv, err, out)
       end


### PR DESCRIPTION
Hi all!

I recently get the difficulties in testing with spork. Sometimes spork doesn't stop correctly and keep working.
When I fire up tests again, changes are not applied, 'cause rspec is using old codebase, loaded to hanged on spork instance, which in turn using DRb server.

What does this commit add? Just a notification that we are using an existing DRb server.

I used this tweak by myself and found it usefull 'cause sometimes a guard instance is fired up in other terminal tab, but I've forgotten about it or whatever.
