### PR TITLE
support for its("@ivar") { should eq("some value") }

### DIFF
--- a/lib/rspec/core/subject.rb
+++ b/lib/rspec/core/subject.rb
@@ -101,6 +101,19 @@ module RSpec
         #     its("phone_numbers.first") { should eq("555-1212") }
         #   end
         #
+        # Given a +String+ starting with "@", it refers to an instance
+        # variable.
+        #
+        #   describe "@foo" do
+        #     subject do
+        #       Object.new.tap do |o|
+        #         o.instance_variable_set("@foo", "bar")
+        #       end
+        #     end
+        #
+        #     its("@foo") { should eq("bar") }
+        #   end
+        #
         # When the subject is a +Hash+, you can refer to the Hash keys by
         # specifying a +Symbol+ or +String+ in an array.
         #
@@ -124,6 +137,8 @@ module RSpec
                 define_method(:subject) do
                   @_subject ||= if attribute.is_a?(Array)
                                   super()[*attribute]
+                                elsif attribute.to_s.start_with?('@')
+                                  super().instance_variable_get(attribute)
                                 else
                                   attribute.to_s.split('.').inject(super()) do |target, method|
                                     target.send(method)

--- a/spec/rspec/core/subject_spec.rb
+++ b/spec/rspec/core/subject_spec.rb
@@ -194,6 +194,18 @@ module RSpec::Core
         end
       end
 
+      context "accessing instance variable directly" do
+        subject do
+          Class.new do
+            def initialize
+              @foo = "bar"
+            end
+          end.new
+
+        end
+
+        its("@foo") { should eq("bar") }
+      end
     end
   end
 end


### PR DESCRIPTION
This patch enables `its` method to directly access to `subject`'s instance variable.
So this code:

``` ruby
subject { some_object.instance_variable_get('@key') }
it { should eq(value) }
```

becomes like this:

``` ruby
subject { some_object }
its('@key') { should eq(value) }
```

Thoughts?
