### PR TITLE
fix bug in memorize of subject in its method

### DIFF
--- a/lib/rspec/core/subject.rb
+++ b/lib/rspec/core/subject.rb
@@ -120,13 +120,16 @@ module RSpec
             example do
               self.class.class_eval do
                 define_method(:subject) do
-                  @_subject ||= if attribute.is_a?(Array)
+                  unless instance_variable_defined?(:@_subject)
+                    @_subject = if attribute.is_a?(Array)
                                   super()[*attribute]
                                 else
                                   attribute.to_s.split('.').inject(super()) do |target, method|
                                     target.send(method)
                                   end
                                 end
+                  end
+                  @_subject
                 end
               end
               instance_eval(&block)

--- a/spec/rspec/core/subject_spec.rb
+++ b/spec/rspec/core/subject_spec.rb
@@ -196,6 +196,24 @@ module RSpec::Core
         end
       end
 
+      context "memorize subject" do
+        subject do
+          Class.new do
+            def initialize
+              @counter = 0
+            end
+            def false_if_first_time
+              if @counter == 0
+                @counter += 1
+                false
+              else
+                true
+              end
+            end
+          end.new
+        end
+        its(:false_if_first_time) { should be_false }
+      end
     end
   end
 end


### PR DESCRIPTION
i found a bug in its method.

 define_method(:subject) do
   @_subject ||= some_method 
 end

can't memory if some_method return false or nil.
so fix to use instance_variable_defined? instead of ||=

its simple code for testing it
https://gist.github.com/2050346
