### PR TITLE
Do not modify example ancestry when dumping errors

### DIFF
--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -186,7 +186,7 @@ module RSpec
         end
 
         def group_and_ancestors(example)
-          example.example_group.ancestors.push(example.example_group)
+          example.example_group.ancestors + [example.example_group]
         end
       end
     end

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -57,6 +57,12 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
         group.example("example name") { raise exception_without_message }
         expect { run_all_and_dump_failures }.not_to raise_error(NoMethodError)
       end
+
+      it "preserves ancestry" do
+        example = group.example("example name") { raise "something" }
+        run_all_and_dump_failures
+        example.example_group.ancestors.size.should == 1
+      end
     end
 
     context "with an exception class other than RSpec" do


### PR DESCRIPTION
This causes bugs (Notably that after blocks / transaction rollback is not executed properly)
when errors are dumped while examples are still running
as is done by [rspec-instafail](https://github.com/grosser/rspec-instafail) and therefore fuubar formatter.
