### PR TITLE
Fixed formatting of code examples in documentation.

### DIFF
--- a/lib/rspec/core/subject.rb
+++ b/lib/rspec/core/subject.rb
@@ -81,6 +81,8 @@ module RSpec
         # Creates a nested example group named by the submitted +attribute+,
         # and then generates an example using the submitted block.
         #
+        # @example
+        #
         #   # This ...
         #   describe Array do
         #     its(:size) { should eq(0) }
@@ -99,6 +101,8 @@ module RSpec
         # with dots, the result is as though you concatenated that +String+
         # onto the subject in an expression.
         #
+        # @example
+        #
         #   describe Person do
         #     subject do
         #       Person.new.tap do |person|
@@ -111,6 +115,8 @@ module RSpec
         #
         # When the subject is a +Hash+, you can refer to the Hash keys by
         # specifying a +Symbol+ or +String+ in an array.
+        #
+        # @example
         #
         #   describe "a configuration Hash" do
         #     subject do


### PR DESCRIPTION
Some `@example` tags were missing, I believe.
