### PR TITLE
raise an ArgumentError when the arity of a Proc filter is wrong

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -188,8 +188,9 @@ module RSpec
           metadata[key] =~ value
         when Proc
           case value.arity
-          when 1 then value.call(metadata[key])
+          when 0 then value.call
           when 2 then value.call(metadata[key], metadata)
+          else value.call(metadata[key])
           end
         else
           metadata[key].to_s == value.to_s

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -118,6 +118,10 @@ module RSpec
           end
         end
 
+        it "matches a proc with no arguments that evaluates to true" do
+          example_metadata.filter_applies?(:if, lambda { true }).should be_true
+        end
+
         it "matches a proc that evaluates to true" do
           example_metadata.filter_applies?(:if, lambda { |v| v }).should be_true
         end
@@ -129,6 +133,12 @@ module RSpec
         it "matches a proc with an arity of 2" do
           example_metadata[:foo] = nil
           example_metadata.filter_applies?(:foo, lambda { |v, m| m == example_metadata }).should be_true
+        end
+
+        it "raises an error when the proc has an incorrect arity" do
+          expect {
+            example_metadata.filter_applies?(:if, lambda { |a,b,c| true })
+          }.to raise_error(ArgumentError)
         end
 
         context "with an Array" do


### PR DESCRIPTION
Hello,

Following #556, here is the rebased version on master.

It ensures a Proc with an arity different of 1 and 2 is handled correctly (raise an error, or yield successfully).
It also allows Proc with 0 arguments, which do not use the metadata value (i.e.: depending only on external factors).
