### PR TITLE
Shellsplitting input in custom options file.

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -97,7 +97,7 @@ module RSpec
       def args_from_options_file(path)
         return [] unless path && File.exist?(path)
         config_string = options_file_as_erb_string(path)
-        config_string.split(/\n+/).map {|l| l.split}.flatten
+        config_string.split(/\n+/).map {|l| l.shellsplit}.flatten
       end
 
       def options_file_as_erb_string(path)

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -351,6 +351,11 @@ describe RSpec::Core::ConfigurationOptions, :fakefs do
         options[:format].should be_nil
         options[:color].should be_true
       end
+      it "parses -e 'full spec description'" do
+        File.open("./custom.opts", "w") {|f| f << "-e 'The quick brown fox jumps over the lazy dog'"}
+        options = parse_options("-O", "./custom.opts")
+        options[:full_description].should == /The\ quick\ brown\ fox\ jumps\ over\ the\ lazy\ dog/
+      end
     end
   end
 end


### PR DESCRIPTION
If you specify -e "specification" in a custom options file, it doesn't get properly parsed. This fixes the problem.

All credit for the fix goes to https://github.com/rspec/rspec-core/pull/596, I just ported it and added a spec, cc: @antifun.
