### PR TITLE
Warn users about stupid behavior like returning from example.

### DIFF
--- a/lib/rspec/core/command_line.rb
+++ b/lib/rspec/core/command_line.rb
@@ -25,8 +25,33 @@ module RSpec
         @configuration.reporter.report(@world.example_count, @configuration.randomize? ? @configuration.seed : nil) do |reporter|
           begin
             @configuration.run_hook(:before, :suite)
-            @world.example_groups.ordered.map {|g| g.run(reporter)}.all? ? 0 : @configuration.failure_exit_code
+            example_groups_ran = 0
+            example_groups = @world.example_groups.ordered
+            example_groups.map { |g|
+              status = g.run(reporter)
+              example_groups_ran += 1
+              status
+            }.all? ? 0 : @configuration.failure_exit_code
           ensure
+            STDERR.puts %Q{
+ !!!
+ !!! Warning! Not all example groups completed!
+ !!!
+ !!! Only #{example_groups_ran} of #{example_groups.size} example groups managed to complete.
+ !!!
+ !!! This may mean that you have `return` statement somewhere in your examples.
+ !!! Beware that `return` will not return from your example, but instead from
+ !!! your example runner, causing abnormal termination of your spec suite!
+ !!!
+ !!! Do not do this:
+ !!!
+ !!! it "should do something" do
+ !!!   # `return` will cause it to fail!
+ !!!   return unless some_condition
+ !!!   raise "test failed"
+ !!! end
+ !!!
+            } if example_groups_ran != example_groups.size
             @configuration.run_hook(:after, :suite)
           end
         end


### PR DESCRIPTION
Currently if you return from example, RSpec happily carries away not
executing whole bunch of your examples without any warning. This is VERY
dangerous, because it gives false sense that user code is being tested,
while it is really not.

These warnings should at least give user notification that something is
wrong.
