### PR TITLE
Don't add `describe` to every object.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ Enhancements
       for background.
     * thanks to Bradley Schaefer for suggesting it and Avdi Grimm for almost
       suggesting it.
+* Limit monkey patching of `describe` onto just the objects
+  that need it rather than every object in the system (Myron Marston).
 
 Bug fixes
 

--- a/lib/rspec/core/dsl.rb
+++ b/lib/rspec/core/dsl.rb
@@ -21,4 +21,9 @@ module RSpec
   end
 end
 
-include RSpec::Core::DSL
+# make describe available on the main object, but not all objects
+extend RSpec::Core::DSL
+
+# make describe available on modules so example groups
+# can be nested within them.
+Module.send(:include, RSpec::Core::DSL)

--- a/spec/rspec/core/dsl_spec.rb
+++ b/spec/rspec/core/dsl_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+main = self
+describe "The describe method" do
+  it 'is available on the main object' do
+    main.should respond_to(:describe)
+  end
+
+  it 'is available on modules (so example groups can be nested inside them)' do
+    Module.new.should respond_to(:describe)
+  end
+
+  it 'is not available on other types of objects' do
+    Object.new.should_not respond_to(:describe)
+  end
+end
+

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -863,6 +863,9 @@ module RSpec::Core
         end
       end
 
+      extend Forwardable
+      def_delegators "RSpec::Core::ExampleGroup", :describe
+
       context "with all examples passing" do
         it "returns true" do
           group = describe("something") do


### PR DESCRIPTION
Instead, make it only available on:
- The main object--so it can be used at the top level.
- Modules--so example groups can be declared nested
  within modules, as is the common practice.

Besides this, the only other place we need describe is from within
example groups (so we can nest them), and this is taken care of by
RSpec::Core::ExampleGroup.describe.

I got the idea for this from a recent change in Sinatra that similarly
limits the DSL to just the main object rather than all objects:

https://github.com/sinatra/sinatra/commit/46bdb7dcf842afdb3bce57a6753eb4d909b1225d

There is some risk to this change, since it is removing `describe` from lots of objects it was available on previously, but users shouldn't be calling #describe on any object willy-nilly, anyway.  The rspec-expectations and rspec-mocks specs pass with this change (as well as the rspec-core specs, of course).

Thoughts?

/cc @dchelimsky @patmaddox @alindeman @justinko @spicycode
