### PR TITLE
Fix Metadata#fetch to support computed values.

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -41,7 +41,18 @@ module RSpec
         # ExampleMetadataHash and GroupMetadataHash, which get mixed in to
         # Metadata for ExampleGroups and Examples (respectively).
         def [](key)
-          return super if has_key?(key)
+          store_computed(key) unless has_key?(key)
+          super
+        end
+
+        def fetch(key, *args)
+          store_computed(key) unless has_key?(key)
+          super
+        end
+
+        private
+
+        def store_computed(key)
           case key
           when :location
             store(:location, location)
@@ -49,7 +60,6 @@ module RSpec
             file_path, line_number = file_and_line_number
             store(:file_path, file_path)
             store(:line_number, line_number)
-            super
           when :execution_result
             store(:execution_result, {})
           when :describes, :described_class
@@ -61,12 +71,8 @@ module RSpec
             store(:full_description, full_description)
           when :description
             store(:description, build_description_from(*self[:description_args]))
-          else
-            super
           end
         end
-
-        private
 
         def location
           "#{self[:file_path]}:#{self[:line_number]}"

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -186,26 +186,32 @@ module RSpec
         let(:line_number)        { __LINE__ - 1 }
 
         it "stores the description" do
+          mfe.fetch(:description).should eq("example description")
           mfe[:description].should eq("example description")
         end
 
         it "stores the full_description (group description + example description)" do
+          mfe.fetch(:full_description).should eq("group description example description")
           mfe[:full_description].should eq("group description example description")
         end
 
         it "creates an empty execution result" do
+          mfe.fetch(:execution_result).should eq({})
           mfe[:execution_result].should eq({})
         end
 
         it "extracts file path from caller" do
+          mfe.fetch(:file_path).should eq(relative_path(__FILE__))
           mfe[:file_path].should eq(relative_path(__FILE__))
         end
 
         it "extracts line number from caller" do
+          mfe.fetch(:line_number).should eq(line_number)
           mfe[:line_number].should eq(line_number)
         end
 
         it "extracts location from caller" do
+          mfe.fetch(:location).should eq("#{relative_path(__FILE__)}:#{line_number}")
           mfe[:location].should eq("#{relative_path(__FILE__)}:#{line_number}")
         end
 
@@ -215,6 +221,7 @@ module RSpec
         end
 
         it "merges arbitrary options" do
+          mfe.fetch(:arbitrary).should eq(:options)
           mfe[:arbitrary].should eq(:options)
         end
 


### PR DESCRIPTION
If example.metadata.fetch(:description) was called before example.metadata[:description], fetch would raise a KeyError.

My use case is a DSL built on top of RSpec. I want to be able to inject the example's metadata into a collaborator which treats the metadata like a normal hash. In order to fail fast, the collaborator calls `fetch` on the injected hash, which fails when the fetched key is, e.g., :description.

Let me know if you would like this tested/implemented differently.
