### PR TITLE
Pr/html formatter cleanup

### DIFF
--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -83,23 +83,24 @@ module RSpec
           @printer.move_progress(percent_done)
 
           exception = example.metadata[:execution_result][:exception]
-          extra = extra_failure_content(exception)
-          params = {
-            :pending_fixed => exception.pending_fixed?,
-            :description => example.description,
-            :run_time => example.execution_result[:run_time],
-            :failure_id => @failed_examples.size,
-            :extra_content => (extra == "") ? false : extra
-          }
-
-          if exception
-            params[:exception] = { 
+          exception_details = if exception
+            { 
               :message => exception.message, 
               :backtrace => format_backtrace(exception.backtrace, example).join("\n")
             }
+          else
+            false 
           end
+          extra = extra_failure_content(exception)
 
-          @printer.print_example_failed( params )
+          @printer.print_example_failed( 
+            exception.pending_fixed?,
+            example.description,
+            example.execution_result[:run_time],
+            @failed_examples.size,
+            exception_details,
+            (extra == "") ? false : extra
+          )
           @printer.flush
         end
 
@@ -138,13 +139,13 @@ module RSpec
         end
 
         def dump_summary(duration, example_count, failure_count, pending_count)
-          @printer.print_summary({
-            :was_dry_run => dry_run?,
-            :duration => duration,
-            :example_count => example_count,
-            :failure_count => failure_count,
-            :pending_count => pending_count
-          })
+          @printer.print_summary(
+            dry_run?,
+            duration,
+            example_count,
+            failure_count,
+            pending_count
+          )
           @printer.flush
         end
       end

--- a/lib/rspec/core/formatters/html_printer.rb
+++ b/lib/rspec/core/formatters/html_printer.rb
@@ -28,9 +28,7 @@ class HtmlPrinter
     @output.puts "    <dd class=\"example passed\"><span class=\"passed_spec_name\">#{h(description)}</span><span class='duration'>#{formatted_run_time}s</span></dd>"
   end
 
-  def print_example_failed( params )
-    pending_fixed, description, run_time, failure_id, exception, extra_content = 
-      params.values_at( :pending_fixed, :description, :run_time, :failure_id, :exception, :extra_content )
+  def print_example_failed( pending_fixed, description, run_time, failure_id, exception, extra_content )
     formatted_run_time = sprintf("%.5f", run_time)
 
     @output.puts "    <dd class=\"example #{pending_fixed ? 'pending_fixed' : 'failed'}\">"
@@ -50,9 +48,7 @@ class HtmlPrinter
     @output.puts "    <dd class=\"example not_implemented\"><span class=\"not_implemented_spec_name\">#{h(description)} (PENDING: #{h(pending_message)})</span></dd>"
   end
 
-  def print_summary( params )
-    was_dry_run, duration, example_count, failure_count, pending_count = params.values_at( :was_dry_run, :duration, :example_count, :failure_count, :pending_count)
-
+  def print_summary( was_dry_run, duration, example_count, failure_count, pending_count )
     # TODO - kill dry_run?
     if was_dry_run 
       totals = "This was a dry-run"


### PR DESCRIPTION
I wanted to do some work on extending the HtmlFormatter, but I had a hard time reading through the existing implementation. It felt like the logic was hidden in between all the `@output.puts` calls.

This patch attempts to fix that by extracting an HtmlPrinter which knows what the HTML content should look like but contains pretty much no logic. The HtmlFormatter holds the logic and delegates to the printer for actual HTML generation. Seems like a nice separation of concerns to me.

Assuming this is considered a good direction I'd like to continue with additional cleanup if that's OK.å
