### PR TITLE
Make glob order alphabetical, not file-system dependent

### DIFF
--- a/features/example_groups/shared_examples.feature
+++ b/features/example_groups/shared_examples.feature
@@ -6,7 +6,7 @@ Feature: shared examples
   needs to run.
 
   A shared group is included in another group using any of:
-  
+
       include_examples "name"      # include the examples in the current context
       it_behaves_like "name"       # include the examples in a nested context
       it_should_behave_like "name" # include the examples in a nested context
@@ -27,7 +27,7 @@ Feature: shared examples
   2.  Put files containing shared examples in `spec/support/` and require files
       in that directory from `spec/spec_helper.rb`:
 
-          Dir["./spec/support/**/*.rb"].each {|f| require f}
+          Dir["./spec/support/**/*.rb"].sort.each {|f| require f}
 
       This is included in the generated `spec/spec_helper.rb` file in
       `rspec-rails`

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -884,7 +884,7 @@ EOM
 
       def gather_directories(path, patterns)
         patterns.map do |pattern|
-          pattern =~ /^#{path}/ ? Dir[pattern.strip] : Dir["#{path}/{#{pattern.strip}}"]
+          pattern =~ /^#{path}/ ? Dir[pattern.strip].sort : Dir["#{path}/{#{pattern.strip}}"].sort
         end
       end
 

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -144,9 +144,9 @@ module RSpec
 
       def files_to_run
         if ENV['SPEC']
-          FileList[ ENV['SPEC'] ]
+          FileList[ ENV['SPEC'] ].sort
         else
-          FileList[ pattern ].map { |f| f.gsub(/"/, '\"').gsub(/'/, "\\\\'") }
+          FileList[ pattern ].sort.map { |f| f.gsub(/"/, '\"').gsub(/'/, "\\\\'") }
         end
       end
 


### PR DESCRIPTION
Dir[] and FileList[] have undefined order, so sorting them is strictly
better than not. Sorting should not have a performance impact in any
realistic use case: Sorting 100k shuffled elements is
near-instantaneous, and sorting 1M elements takes ~3 seconds, so file
system access time will always dominate.

One particular reason why this is useful is that undefined ordering is a
major source of flickering test suite failures.
