### PR TITLE
quote make_test_command

### DIFF
--- a/lib/autotest/rspec2.rb
+++ b/lib/autotest/rspec2.rb
@@ -47,7 +47,7 @@ class Autotest::Rspec2 < Autotest
   # Overrides Autotest's implementation to generate the rspec command to run
   def make_test_cmd(files_to_test)
     files_to_test.empty? ? '' :
-      "#{prefix}#{ruby}#{suffix} -S '#{RSPEC_EXECUTABLE}' --tty #{normalize(files_to_test).keys.flatten.map { |f| "'#{f}'"}.join(' ')}"
+      %Q(#{prefix}"#{ruby}"#{suffix} -S '#{RSPEC_EXECUTABLE}' --tty #{normalize(files_to_test).keys.flatten.map { |f| "'#{f}'"}.join(' ')})
   end
 
   # Generates a map of filenames to Arrays for Autotest


### PR DESCRIPTION
I have a ruby installed in a directory with spaces.  This patch quotes the ruby command in make_test_command so that it works properly
