### PR TITLE
Break up RakeTask#spec_command method.

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -164,18 +164,20 @@ module RSpec
       end
 
       def spec_command
-        @spec_command ||= begin
-                            cmd_parts = []
-                            cmd_parts << RUBY
-                            cmd_parts << ruby_opts
-                            cmd_parts << "-w" if @warning
-                            cmd_parts << "-S" << runner
-                            cmd_parts << "-Ispec:lib" << rcov_opts if rcov
-                            cmd_parts << files_to_run
-                            cmd_parts << "--" if rcov && rspec_opts
-                            cmd_parts << rspec_opts
-                            cmd_parts.flatten.reject(&blank).join(" ")
-                          end
+        @spec_command ||= default_spec_command
+      end
+
+      def default_spec_command
+        cmd_parts = []
+        cmd_parts << RUBY
+        cmd_parts << ruby_opts
+        cmd_parts << "-w" if @warning
+        cmd_parts << "-S" << runner
+        cmd_parts << "-Ispec:lib" << rcov_opts if rcov
+        cmd_parts << files_to_run
+        cmd_parts << "--" if rcov && rspec_opts
+        cmd_parts << rspec_opts
+        cmd_parts.flatten.reject(&blank).join(" ")
       end
 
     private


### PR DESCRIPTION
There was a big inline block in the middle of this method, I think
it's cleaner to do this by creating the default_spec_command method and
then invoking that, rather than just taking the result of the block.
I've also noticed that there are 2 `private` declarations in this file,
I think the bottom one can be removed.
