### PR TITLE
Remove a duplicate "private" declaration from rake_task.rb

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -178,8 +178,6 @@ module RSpec
                           end
       end
 
-    private
-
       def runner
         rcov ? rcov_path : rspec_path
       end


### PR DESCRIPTION
The file had two private declarations in, this wasn't necessary. I've
removed the one further down the file.
