### PR TITLE
Pluralize 'second' in RSpec::Core::Formatters::Helpers#format_duration

### DIFF
--- a/lib/rspec/core/formatters/helpers.rb
+++ b/lib/rspec/core/formatters/helpers.rb
@@ -11,9 +11,9 @@ module RSpec
             minutes = duration.to_i / 60
             seconds = duration - minutes * 60
 
-            "#{pluralize(minutes, 'minute')} #{format_seconds(seconds)} seconds"
+            "#{pluralize(minutes, 'minute')} #{pluralize(format_seconds(seconds), 'second')}"
           else
-            "#{format_seconds(duration)} seconds"
+            pluralize(format_seconds(duration), 'second')
           end
         end
 
@@ -29,7 +29,7 @@ module RSpec
         end
 
         def pluralize(count, string)
-          "#{count} #{string}#{'s' unless count == 1}"
+          "#{count} #{string}#{'s' unless count.to_f == 1}"
         end
 
       end

--- a/spec/rspec/core/formatters/helpers_spec.rb
+++ b/spec/rspec/core/formatters/helpers_spec.rb
@@ -22,6 +22,18 @@ describe RSpec::Core::Formatters::Helpers do
         helper.format_duration(45.5).should eq("45.5 seconds")
       end
     end
+
+    context '= 61' do
+      it "returns 'x minute x second' formatted string" do
+        helper.format_duration(61).should eq("1 minute 1 second")
+      end
+    end
+
+    context '= 1' do
+      it "returns 'x second' formatted string" do
+        helper.format_duration(1).should eq("1 second")
+      end
+    end
   end
 
   describe "format seconds" do


### PR DESCRIPTION
I also had to add `.to_f` to the pluralize method so it handles strings, I can split that into a separate commit if you like.
