### PR TITLE
Any interest in something like this - display the source location for a duplicate shared example group

### DIFF
--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -31,7 +31,7 @@ module RSpec
       def shared_examples *args, &block
         if key? args.first
           key = args.shift
-          check_if_key_taken key
+          raise_if_key_taken key, block
           RSpec.world.shared_example_groups[key] = block
         end
 
@@ -82,11 +82,22 @@ module RSpec
         raise NameError, "The first argument (#{name}) to share_as must be a legal name for a constant not already in use."
       end
 
-      def check_if_key_taken key
+      def raise_if_key_taken key, new_block
         return unless existing_block = example_block_for(key)
 
-        location = existing_block.source_location.join ":"
-        raise ArgumentError, "Shared example group '#{key}' already exists in #{location}"
+
+        s = <<-WARNING.gsub(/^ */, '')
+             Shared example group '#{key}' defined at:
+             #{formatted_location new_block}
+             already exists in:
+             #{formatted_location existing_block}
+             WARNING
+
+        Kernel.warn s
+      end
+
+      def formatted_location block
+        block.source_location.join ":"
       end
 
       def example_block_for key

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -12,12 +12,19 @@ module RSpec::Core
           Kernel.should respond_to(shared_method_name)
         end
 
-        it "raises an ArgumentError when adding a second shared example group with the same name" do
+        it "displays a warning when adding a second shared example group with the same name" do
           group = ExampleGroup.describe('example group')
           group.send(shared_method_name, 'shared group') {}
-          lambda do
-            group.send(shared_method_name, 'shared group') {}
-          end.should raise_error(ArgumentError, "Shared example group 'shared group' already exists")
+          group.stub(:formatted_location).and_return "path/to/first:1", "path/to/second:2"
+
+          Kernel.should_receive(:warn).with <<-WARNING.gsub(/^ */, '')
+             Shared example group 'shared group' defined at:
+             path/to/first:1
+             already exists in:
+             path/to/second:2
+             WARNING
+
+           group.send(shared_method_name, 'shared group') {}
         end
 
         ["name", :name, ExampleModule, ExampleClass].each do |object|


### PR DESCRIPTION
I couldn't get the specs to run on ruby 1.9 because of the ruby-debug / debugger issue so this is more of a speculative pull request. 

If it looks likely people will find something like this useful I can sort the specs out this weekend.
