### PR TITLE
better message when the command line arguments are incorrect

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -21,9 +21,7 @@ module RSpec::Core
       begin
         parser(options).parse!(args)
       rescue OptionParser::InvalidOption => e
-        puts e.message
-        puts "please use --help for documentation on the options available"
-        exit(false) #exit with error
+        abort(e.message + "\n" + "please use --help for documentation on the options available")
       end
       options
     end

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -15,6 +15,12 @@ module RSpec::Core
       parser.parse!([])
     end
 
+    it "proposes you to use --help and returns an error on incorrect argument" do
+      parser = Parser.new
+      parser.should_receive(:abort).with(/use --help/)
+      parser.parse!(%w[--my_very_wrong_argument_ein])
+    end
+
     describe "--formatter" do
       it "is deprecated" do
         RSpec.should_receive(:deprecate)


### PR DESCRIPTION
Currently we let the exception from OptionParser to propagate, is difficult to read and ugly.
