### PR TITLE
avoid creating unused Array instance

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -781,7 +781,7 @@ EOM
 
       # @private
       def load_spec_files
-        files_to_run.uniq.map {|f| load File.expand_path(f) }
+        files_to_run.uniq.each {|f| load File.expand_path(f) }
         raise_if_rspec_1_is_loaded
       end
 


### PR DESCRIPTION
The return value of `map` here is apparently unused.
