### PR TITLE
Delegate #configuration through to rspec-mocks.

### DIFF
--- a/lib/rspec/core/mocking/with_rspec.rb
+++ b/lib/rspec/core/mocking/with_rspec.rb
@@ -3,9 +3,13 @@ require 'rspec/mocks'
 module RSpec
   module Core
     module MockFrameworkAdapter
-      
+
       def self.framework_name; :rspec end
-      
+
+      def self.configuration
+        RSpec::Mocks.configuration
+      end
+
       def setup_mocks_for_rspec
         RSpec::Mocks::setup(self)
       end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -94,6 +94,16 @@ module RSpec::Core
         end
       end
 
+      it "allows rspec-mocks to be configured with a provided block" do
+        mod = Module.new
+
+        RSpec::Mocks.configuration.should_receive(:add_stub_and_should_receive_to).with(mod)
+
+        config.mock_with :rspec do |c|
+          c.add_stub_and_should_receive_to mod
+        end
+      end
+
       context "with a module" do
         it "sets the mock_framework_adapter to that module" do
           mod = Module.new


### PR DESCRIPTION
This allows our block config API to be used.

This depends on rspec/rspec-mocks#188 and should be merged after that.
