### PR TITLE
Allow RSpec's rake task to live with MiniTest

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -1,4 +1,3 @@
-require 'rspec/core'
 require 'rspec/core/deprecation'
 require 'rake'
 require 'rake/tasklib'


### PR DESCRIPTION
Rails apps can't have both `rspec-rails` and `minitest-rails` loaded at the same time. The Rake task is loading `rspec/core` which loads the DSL which stomps on MiniTest's spec DSL.

This change is related to [rspec-rails #615](https://github.com/rspec/rspec-rails/pull/615). Here is a [gist](https://gist.github.com/cd39c4bbd5f710df696b) that shows these changes working in a test Rails app.
