### PR TITLE
Extract backtrace filtering methods into helper module.

### DIFF
--- a/lib/rspec/core/formatters/base_formatter.rb
+++ b/lib/rspec/core/formatters/base_formatter.rb
@@ -115,29 +115,10 @@ module RSpec
           restore_sync_output
         end
 
-        def format_backtrace(backtrace, example)
-          return "" unless backtrace
-          return backtrace if example.metadata[:full_backtrace] == true
-
-          if at_exit_index = backtrace.index(RSpec::Core::Runner::AT_EXIT_HOOK_BACKTRACE_LINE)
-            backtrace = backtrace[0, at_exit_index]
-          end
-
-          cleansed = backtrace.map { |line| backtrace_line(line) }.compact
-          cleansed.empty? ? backtrace : cleansed
-        end
-
       protected
 
         def configuration
           RSpec.configuration
-        end
-
-        def backtrace_line(line)
-          return nil if configuration.cleaned_from_backtrace?(line)
-          RSpec::Core::Metadata::relative_path(line)
-        rescue SecurityError
-          nil
         end
 
         def read_failed_line(exception, example)

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -156,7 +156,7 @@ module RSpec
         end
 
         def dump_backtrace(example)
-          format_backtrace(example.execution_result[:exception].backtrace, example).each do |backtrace_info|
+          format_backtrace(example.execution_result[:exception].backtrace, example.metadata).each do |backtrace_info|
             output.puts cyan("#{long_padding}# #{backtrace_info}")
           end
         end

--- a/lib/rspec/core/formatters/helpers.rb
+++ b/lib/rspec/core/formatters/helpers.rb
@@ -1,8 +1,34 @@
 module RSpec
   module Core
-    module Formatters
+    module BacktraceFormatter
+      extend self
 
+      def format_backtrace(backtrace, options = {})
+        return "" unless backtrace
+        return backtrace if options[:full_backtrace] == true
+
+        if at_exit_index = backtrace.index(RSpec::Core::Runner::AT_EXIT_HOOK_BACKTRACE_LINE)
+          backtrace = backtrace[0, at_exit_index]
+        end
+
+        cleansed = backtrace.map { |line| backtrace_line(line) }.compact
+        cleansed.empty? ? backtrace : cleansed
+      end
+
+    protected
+
+      def backtrace_line(line)
+        return nil if RSpec.configuration.cleaned_from_backtrace?(line)
+        RSpec::Core::Metadata::relative_path(line)
+      rescue SecurityError
+        nil
+      end
+    end
+
+    module Formatters
       module Helpers
+        include BacktraceFormatter
+
         SUB_SECOND_PRECISION = 5
         DEFAULT_PRECISION = 2
 
@@ -31,7 +57,6 @@ module RSpec
         def pluralize(count, string)
           "#{count} #{string}#{'s' unless count.to_f == 1}"
         end
-
       end
 
     end

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -86,7 +86,7 @@ module RSpec
           exception_details = if exception
             { 
               :message => exception.message, 
-              :backtrace => format_backtrace(exception.backtrace, example).join("\n")
+              :backtrace => format_backtrace(exception.backtrace, example.metadata).join("\n")
             }
           else
             false 

--- a/spec/rspec/core/formatters/base_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_formatter_spec.rb
@@ -91,7 +91,7 @@ describe RSpec::Core::Formatters::BaseFormatter do
     end
 
     it "removes lines from rspec and lines that come before the invocation of the at_exit autorun hook" do
-      formatter.format_backtrace(backtrace, stub.as_null_object).should eq(["./my_spec.rb:5"])
+      formatter.format_backtrace(backtrace).should eq(["./my_spec.rb:5"])
     end
   end
 


### PR DESCRIPTION
This will be used by rspec/rspec-expectations#59.
