### PR TITLE
Fix example of --format with --out

### DIFF
--- a/features/command_line/format_option.feature
+++ b/features/command_line/format_option.feature
@@ -17,7 +17,7 @@ Feature: --format option
   You can also specify an output target (STDOUT by default) by appending a
   filename to the argument:
 
-    $ rspec spec --format documentation:rspec.output.txt
+    $ rspec spec --format documentation --out rspec.txt
 
   `rspec --help` lists available formatters:
 


### PR DESCRIPTION
Seperating format and output file with a colon was never supported and
was probably added by accident. The output filename was also updated to
be consistent with later examples. Fixes #704
