### PR TITLE
`rspec --drb` (without other args) runs specs in default_path

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -504,7 +504,7 @@ EOM
       # @private
       def files_or_directories_to_run=(*files)
         files = files.flatten
-        files << default_path if command == 'rspec' && default_path && files.empty?
+        files << default_path if (command == 'rspec' || Runner.running_in_drb?) && default_path && files.empty?
         self.files_to_run = get_files_to_run(files)
       end
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -332,6 +332,13 @@ module RSpec::Core
           config.files_to_run.should_not be_empty
         end
 
+        it "loads files in the default path when run with DRB (e.g., spork)" do
+          config.stub(:command) { 'spork' }
+          RSpec::Core::Runner.stub(:running_in_drb?) { true }
+          config.files_or_directories_to_run = []
+          config.files_to_run.should_not be_empty
+        end
+
         it "does not load files in the default path when run by ruby" do
           config.stub(:command) { 'ruby' }
           config.files_or_directories_to_run = []


### PR DESCRIPTION
- Fixes #631
