### PR TITLE
RSpec fails when using --pattern when $PWD has a space

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -161,7 +161,7 @@ module RSpec
         if ENV['SPEC']
           FileList[ ENV['SPEC'] ].sort
         else
-          FileList[ pattern ].sort.map { |f| f.gsub(/"/, '\"').gsub(/'/, "\\\\'") }
+          FileList[ pattern ].sort.map { |f| f.shellescape }
         end
       end
 

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -139,14 +139,15 @@ module RSpec::Core
       specify_consistent_ordering_of_files_to_run('a/*.rb', task)
     end
 
-    context "with paths with quotes" do
-      it "escapes the quotes" do
+    context "with paths with quotes or spaces" do
+      it "escapes the quotes and spaces" do
         task.pattern = File.join(Dir.tmpdir, "*spec.rb")
-        ["first_spec.rb", "second_\"spec.rb", "third_\'spec.rb"].each do |file_name|
+        ["first_spec.rb", "second_\"spec.rb", "third_\'spec.rb", "fourth spec.rb"].each do |file_name|
           FileUtils.touch(File.join(Dir.tmpdir, file_name))
         end
         task.__send__(:files_to_run).sort.should eq([
           File.join(Dir.tmpdir, "first_spec.rb"),
+          File.join(Dir.tmpdir, "fourth\\ spec.rb"),
           File.join(Dir.tmpdir, "second_\\\"spec.rb"),
           File.join(Dir.tmpdir, "third_\\\'spec.rb")
         ])


### PR DESCRIPTION
I think .shellescape rather than the pair of gsubs is what we want. Test extended.

Keep up the great work, rspec humans! Do what you do! :-)
