### PR TITLE
Defines shellescape method

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -157,11 +157,21 @@ module RSpec
 
     private
 
+      if RUBY_VERSION == '1.8.6'
+        def shellescape(string)
+          string.gsub(/"/, '\"').gsub(/'/, "\\\\'")
+        end
+      else
+        def shellescape(string)
+          string.shellescape
+        end
+      end
+
       def files_to_run
         if ENV['SPEC']
           FileList[ ENV['SPEC'] ].sort
         else
-          FileList[ pattern ].sort.map { |f| f.shellescape }
+          FileList[ pattern ].sort.map { |f| shellescape(f) }
         end
       end
 


### PR DESCRIPTION
Method allows newer versions of Ruby to use string.shellescape while not breaking in 1.8.6.

Attempting to solve the issue introduced in this comment:
https://github.com/rspec/rspec-core/pull/721#issuecomment-10054185
