### PR TITLE
set default drb_port in RSpec::Configuration

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -189,6 +189,7 @@ MESSAGE
         @default_path = 'spec'
         @filter_manager = FilterManager.new
         @preferred_options = {}
+        @drb_port = 8989
         @seed = srand % 0xFFFF
       end
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -66,6 +66,17 @@ module RSpec::Core
       end
     end
 
+    describe "#drb_port" do
+      it "defaults to 8989" do
+        config.drb_port.should == 8989
+      end
+
+      it "can be set to any value you like" do
+        config.drb_port = 42
+        config.drb_port.should == 42
+      end
+    end
+
     shared_examples "a configurable framework adapter" do |m|
       it "yields a config object if the framework_module supports it" do
         custom_config = Struct.new(:custom_setting).new


### PR DESCRIPTION
The documentation says this is set to 8989 by default, but it is only
set in RSpec::Core::DRbCommandLine.  This remedies that.

See https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/configuration.rb#L97 for where the default is specified.  Run my spec file to see that it isn't.
