### PR TITLE
Document the order in which configuration options are loaded

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -2,7 +2,10 @@ require 'fileutils'
 
 module RSpec
   module Core
-    # Stores runtime configuration information.
+    # Stores runtime configuration information. Configuration options are loaded
+    # from the following files: .rspec-local, .rspec and ~/.rspec. They are
+    # loaded from those files in presedence (highest to lowest) order.
+    #
     #
     # @example Standard settings
     #     RSpec.configure do |c|


### PR DESCRIPTION
Configuration options are loaded from files, this docstring clarifies
which order they are loaded in and where they are loaded from (hopefully!)

related #738
