### PR TITLE
Bypass running specs as if they were pending with Ctrl + T

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -900,6 +900,20 @@ EOM
         order_examples(&block)
       end
 
+      # @private
+      def skip_example_trap
+        if @skip_example_trap.nil?
+          if(Signal.list['INFO'])
+            @skip_example_trap = { :signal => 'INFO', :message => 'Skipped at runtime via Ctrl+T'}
+          elsif(Signal.list['TSTP'])
+            @skip_example_trap = { :signal => 'TSTP', :message => 'Skipped at runtime via Ctrl+Z'}
+          else
+            @skip_example_trap = false
+          end
+        end
+        @skip_example_trap
+      end
+
     private
 
       def get_files_to_run(paths)


### PR DESCRIPTION
This pull request implements a simple feature idea I would love to see in rspec:

Sometimes I have individual specs that hang or take forever. This commit allows users to bypass a long running specs by hitting `Ctrl + t` and sending the `INFO` interrupt signal. Currently I am just marking them as _pending_ but down the road you might consider adding more comprehensive reporting. Let me know what you think.
