### PR TITLE
Require backward compatibility in rake task

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -1,3 +1,4 @@
+require 'rspec/core/backward_compatibility'
 require 'rspec/core/deprecation'
 require 'rake'
 require 'rake/tasklib'


### PR DESCRIPTION
When upgrading from an old version, `Rspec` may not be available where
`backward_compatibility` is not required. Fixes rspec/rspec-rails#638
