### PR TITLE
shellescape matching for Rubies other than 1.8.6

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -158,7 +158,7 @@ module RSpec
 
     private
 
-      if RUBY_VERSION == '1.8.6'
+      if RUBY_VERSION =~ /^1\.8\.\d/
         def shellescape(string)
           string.gsub(/"/, '\"').gsub(/'/, "\\\\'")
         end


### PR DESCRIPTION
https://github.com/rspec/rspec-core/pull/728 breaks on Rubies other then 1.8.6 (i.e. 1.8.7) - changed the monkey patch for shellescape to catch other 1.8 versions
