### PR TITLE
Remove unnecessary assignment from RSpec::Core::Let.get_constant_or_yield

### DIFF
--- a/lib/rspec/core/let.rb
+++ b/lib/rspec/core/let.rb
@@ -49,7 +49,7 @@ module RSpec
         # uses a `let` should get its own `LetDefinitions` module.
         def self.get_constant_or_yield(example_group, name)
           if example_group.const_defined?(name, (check_ancestors = false))
-            example_group.const_get(name, (check_ancestors = false))
+            example_group.const_get(name, check_ancestors)
           else
             yield
           end


### PR DESCRIPTION
See https://github.com/rspec/rspec-core/commit/c5172be7378fcadf2b468c6d0ed367bb7471985c#commitcomment-2368939
