### PR TITLE
Do not modify `subject` when defining an `its` example

### DIFF
--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -322,6 +322,20 @@ module RSpec::Core
         end
         its(:false_if_first_time) { should be(false) }
       end
+
+      describe 'accessing `subject` in `before` and `let`' do
+        subject { 'my subject' }
+        before { @subject_in_before = subject }
+        let(:subject_in_let) { subject }
+        let!(:eager_loaded_subject_in_let) { subject }
+
+        # These examples read weird, because we're actually
+        # specifying the behaviour of `its` itself
+        its(nil) { expect(subject).to eq('my subject') }
+        its(nil) { expect(@subject_in_before).to eq('my subject') }
+        its(nil) { expect(subject_in_let).to eq('my subject') }
+        its(nil) { expect(eager_loaded_subject_in_let).to eq('my subject') }
+      end
     end
 
     describe '#subject!' do


### PR DESCRIPTION
See the discussion at #768.

@myronmarston I've added some documentation and renamed the internal subject to `__its_subject` to avoid a potential (however unlikely) name conflict.

I'm also overriding the methods in-line, to keep the usages and definitions of `__its_subject` as close to each other as possible.

Let me know what you think.
