### PR TITLE
Scenario documenting multiple exclude

### DIFF
--- a/features/command_line/tag.feature
+++ b/features/command_line/tag.feature
@@ -1,16 +1,16 @@
 Feature: --tag option
 
   Use the --tag (or -t) option to filter the examples by tags.
-  
+
   The tag can be a simple name or a name:value pair. In the first case,
   examples with :name => true will be filtered. In the second case, examples
   with :name => value will be filtered, where value is always a string.  In
   both cases, name is converted to a symbol.
-  
+
   Tags can also be used to exclude examples by adding a ~ before the tag.  For
   example ~tag will exclude all examples marked with :tag => true and
   ~tag:value will exclude all examples marked with :tag => value.
-  
+
   To be compatible with the Cucumber syntax, tags can optionally start with
   an @ symbol, which will be ignored.
 
@@ -49,7 +49,7 @@ Feature: --tag option
       """
     And the output should contain "2 examples"
     And the examples should all pass
-  
+
   Scenario: filter examples with a name:value tag and @
     When I run `rspec . --tag @type:special`
     Then the output should contain:
@@ -57,7 +57,7 @@ Feature: --tag option
       include {:type=>"special"}
       """
     And the examples should all pass
-  
+
   Scenario: exclude examples with a simple tag
     When I run `rspec . --tag ~skip`
     Then the output should contain "exclude {:skip=>true}"
@@ -67,7 +67,7 @@ Feature: --tag option
     When I run `rspec . --tag ~@skip`
     Then the output should contain "exclude {:skip=>true}"
     Then the examples should all pass
-    
+
   Scenario: exclude examples with a name:value tag
     When I run `rspec . --tag ~speed:slow`
     Then the output should contain:
@@ -75,7 +75,7 @@ Feature: --tag option
       exclude {:speed=>"slow"}
       """
     Then the examples should all pass
-  
+
   Scenario: exclude examples with a name:value tag and @
     When I run `rspec . --tag ~@speed:slow`
     Then the output should contain:
@@ -89,3 +89,10 @@ Feature: --tag option
     Then the output should contain "include {:focus=>true}"
     And the output should contain "exclude {:skip=>true}"
     And the examples should all pass
+
+  Scenario: exclude examples with multiple tags
+    When I run `rspec . --tag ~skip --tag ~speed:slow`
+    Then the output should contain one of the following:
+      | exclude {:skip=>true, :speed=>"slow"} |
+      | exclude {:speed=>"slow", :skip=>true} |
+    Then the examples should all pass

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -12,6 +12,14 @@ Then /^the output should not contain any of these:$/ do |table|
   end
 end
 
+Then /^the output should contain one of the following:$/ do |table|
+  matching_output = table.raw.flatten.select do |string|
+    all_output =~ regexp(string)
+  end
+
+  matching_output.should have(1).item
+end
+
 Then /^the example(?:s)? should(?: all)? pass$/ do
   step %q{the output should contain "0 failures"}
   step %q{the output should not contain "0 examples"}


### PR DESCRIPTION
This adds a scenario that explicitly shows how excluding examples with multiple tags should behave. For example using `-t ~skip -t ~speed:slow`.

I was unsure of how this would behave and there didn't appear to be anything that covered it on Relish.
