### PR TITLE
Preserve the original state of ARGV by duplicating the array. Closes #787

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -8,13 +8,13 @@ module RSpec
       attr_reader :options
 
       def initialize(args)
-        @args = args
-        if args.include?("--default_path")
-          args[args.index("--default_path")] = "--default-path"
+        @args = args.dup
+        if @args.include?("--default_path")
+          @args[@args.index("--default_path")] = "--default-path"
         end
 
-        if args.include?("--line_number")
-          args[args.index("--line_number")] = "--line-number"
+        if @args.include?("--line_number")
+          @args[@args.index("--line_number")] = "--line-number"
         end
       end
 

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -13,6 +13,13 @@ describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolat
     end
   end
 
+  it "duplicates the arguments array" do
+    args = ['-e', 'some spec']
+    coo = RSpec::Core::ConfigurationOptions.new(args)
+    coo.parse_options
+    expect(args).to eq(['-e', 'some spec'])
+  end
+
   describe "#configure" do
     it "sends libs before requires" do
       opts = config_options_object(*%w[--require a/path -I a/lib])


### PR DESCRIPTION
See https://github.com/rspec/rspec-core/issues/787
