### PR TITLE
Update lib/rspec/core/example_group.rb

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -234,6 +234,10 @@ module RSpec
       class << self
         alias_method :context, :describe
       end
+      
+      class << self
+        alias_method :action, :describe
+      end
 
       # @private
       def self.subclass(parent, args, &example_group_block)


### PR DESCRIPTION
"action" alias for describe:

The purpose of this is to declare a description of some kind of action which is performed repeatedly on many sub-items with out "abusing" context and without needing to alias it_behaves_like and calling that repeatedly.

One situation where this would be useful would be an auditing database trigger that inserts a record into an auditing table for each column of the record that the trigger was fired on.

Currently it would be done something like this:

``` rspec
describe "My Trigger" do
    context "When an update is done on a record" do
        it_performs "an audit", "COLUMN_ONE"
        it_performs "an audit", "COLUMN_TWO"
        it_performs "an audit", "COLUMN_THREE"
    end
end
```

Which outputs along the lines of:

```
My Trigger
    When an update is done on a record
        performs an audit
            On COLUMN_ONE
        performs an audit
            On COLUMN_TWO
        performs an audit
            On COLUMN_THREE
```

What the action alias would do is allow you to declare that a required action should take place, but to not repeat this for every item the action should happen for. Which would allow for the following:

``` rspec
describe "My Trigger" do
    context "When an update is done on a record" do
        action "performs an audit" do
            include_examples "test the audit results", "COLUMN_ONE"
            include_examples "test the audit results", "COLUMN_TWO"
            include_examples "test the audit results", "COLUMN_THREE"
        end
    end
end
```

Which would output along the lines of:

```
My Trigger
    When an update is done on a record
        performs an audit
            On COLUMN_ONE
            On COLUMN_TWO
            On COLUMN_THREE
```

While there my be other benefits to this, the main purpose behind this idea is to enhance readability.
