### PR TITLE
Candidate fix for #800

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -117,7 +117,7 @@ module RSpec
         def let(name, &block)
           # We have to pass the block directly to `define_method` to
           # allow it to use method constructs like `super` and `return`.
-          ::RSpec::Core::MemoizedHelpers.module_for(self).define_method(name, &block)
+          MemoizedHelpers.module_for(self).define_method(name, &block)
 
           # Apply the memoization. The method has been defined in an ancestor
           # module so we can use `super` here to get the value.
@@ -215,14 +215,12 @@ module RSpec
         # @see MemoizedHelpers#should
         def subject(name=nil, &block)
           if name
-            # Ensure `super()` within a named subject acts correctly...
-            mod = ::RSpec::Core::MemoizedHelpers.module_for(self, :NamedSubjectSuper)
-            mod.define_method(name) do
-              self.class.superclass.instance_method(:subject).bind(self).call
-            end
-
             let(name, &block)
             subject { __send__ name }
+
+            self::NamedSubjectPreventSuper.define_method(name) do
+              raise NotImplementedError, "`super` in named subjects is not supported"
+            end
           else
             let(:subject, &block)
           end
@@ -389,13 +387,21 @@ module RSpec
       # The memoization is provided by a method definition on the
       # example group that supers to the LetDefinitions definition
       # in order to get the value to memoize.
-      def self.module_for(example_group, const_name = :LetDefinitions)
-        get_constant_or_yield(example_group, const_name) do
-          # Expose `define_method` as a public method, so we can
-          # easily use it below.
-          mod = Module.new { public_class_method :define_method }
+      def self.module_for(example_group)
+        get_constant_or_yield(example_group, :LetDefinitions) do
+          mod = Module.new do
+            include Module.new {
+              public_class_method :define_method
+              example_group.const_set(:NamedSubjectPreventSuper, self)
+            }
+
+            # Expose `define_method` as a public method, so we can
+            # easily use it below.
+            public_class_method :define_method
+          end
+
           example_group.__send__(:include, mod)
-          example_group.const_set(const_name, mod)
+          example_group.const_set(:LetDefinitions, mod)
           mod
         end
       end


### PR DESCRIPTION
Fix inner/outer subject confusion when using a named subject.

This fixes #800 while preserving the behavior we settled on in #757.  However, the complexity of supporting `super` in a named subject (look at that crazy metaprogramming I had to do!) makes me think that we should disable `super` in named subjects altogether instead.  @alindeman and I [discussed this previously](https://github.com/rspec/rspec-core/pull/757#issuecomment-11770186) and decided that `super` in a named subject should super to the outer subject, not an outer `let` declaration; however, to prevent the bug reported in #800, we have to make the `let` declaration primary with the subject simply an alias to the `let`...which causes `super` to call the parent `let` method, not the parent subject.

So...I'm thinking of changing this so that it raises a `super() can't be used in a named subject` error instead.  Really, I don't think there's a good use case for supporting it.  It is a bit of a breaking change (since 2.13.0 is out with `super` calling the parent subject), and we need to get a patch release out to fix #800, so that's a bit of a problem, but I'm not sure what to do about it.
