### PR TITLE
Prevent an inner group method def from overriding an outer group subject

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,12 @@ Enhancements
 * Add some logic to test time duration precision. Make it a
   function of time, dropping precision as the time increases. (Aaron Kromer)
 
+Bug fixes
+
+* Fix named subjects so that if an inner group defines a method that
+  overrides the named method, `subject` still retains the originally
+  declared value (Myron Marston).
+
 ### 2.13.1 / 2013-03-12
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.13.0...v2.13.1)
 

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -276,7 +276,7 @@ EOS
         def subject(name=nil, &block)
           if name
             let(name, &block)
-            subject { __send__ name }
+            alias_method :subject, name
 
             self::NamedSubjectPreventSuper.define_method(name) do
               raise NotImplementedError, "`super` in named subjects is not supported"

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -254,6 +254,21 @@ module RSpec::Core
           expect(subject_value).to eq(:inner)
         end
 
+        it 'is not overriden when an inner group defines a new method with the same name' do
+          subject_value = nil
+
+          ExampleGroup.describe do
+            subject(:named) { :outer_subject }
+
+            describe "inner" do
+              let(:named) { :inner_named }
+              example { subject_value = self.subject }
+            end
+          end.run
+
+          expect(subject_value).to be(:outer_subject)
+        end
+
         context 'when `super` is used' do
           def should_raise_not_supported_error(&block)
             ex = nil


### PR DESCRIPTION
This is something I recently realized was unspecified by our specs.  I think the behavior we had it before is actually confusing and should be considered a bug, so I changed it...but there's always the chance that there are spec suites out in the wild that rely on the old behavior -- so I'd like another pair of eyes (/cc @alindeman and @dchelimsky...) on this before I merge.
