### PR TITLE
allow activate defined `let` by `let!` without block

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -212,7 +212,9 @@ EOS
         #     end
         #   end
         def let!(name, &block)
-          let(name, &block)
+          # if let with same name exist and you just want to active it
+          # you only specify `let!(:name)` without block
+          let(name, &block) unless !block_given? && instance_methods.include?(name)
           before { __send__(name) }
         end
 

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -563,6 +563,7 @@ module RSpec::Core
   describe "#let!" do
     subject { [1,2,3] }
     let!(:popped) { subject.pop }
+    let(:lazy_poped) { subject.pop }
 
     it "evaluates the value non-lazily" do
       expect(subject).to eq([1,2])
@@ -570,6 +571,13 @@ module RSpec::Core
 
     it "returns memoized value from first invocation" do
       expect(popped).to eq(3)
+    end
+
+    context "activate defined let" do
+      let!(:lazy_poped)
+
+      specify { expect(subject).to eq([1]) }
+      specify { expect(lazy_poped).to eq(2) }
     end
   end
 


### PR DESCRIPTION
In last few months I have a lot specs of next structure:

``` ruby
describe 'Some specs' do
  let(:car) { create :car }

  it "spec which doesn't need `car`" do

  end

  it "spec which need `car` not instantly" do
    # some code
    car.turn_left
    # some code
  end

  context 'context which needs preloaded car' do
    let!(:car) { create :car }

  end

  context 'another context which needs preloaded car' do
    let!(:car) { create :car }

  end
end
```

Above example shows us the duplication. Another solution for this problem might be next

``` ruby
describe 'Some specs' do
  let(:car) { create :car }

  it "spec which doesn't need `car`" do

  end

  it "spec which need `car` not instantly" do
    # some code
    car.turn_left
    # some code
  end

  context 'context which needs preloaded car' do
    before { car }

  end

  context 'another context which needs preloaded car' do
    before { car }

  end
end
```

But using before make specs little bit unreadable.

My solution is using `let!` without block

``` ruby
describe 'Some specs' do
  let(:car) { create :car }

  it "spec which doesn't need `car`" do

  end

  it "spec which need `car` not instantly" do
    # some code
    car.turn_left
    # some code
  end

  context 'context which needs preloaded car' do
    let!(:car)

  end

  context 'another context which needs preloaded car' do
    let!(:car)

  end
end
```

It activates defined `let` with lefting specs clean.
