### PR TITLE
#let fails in an ugly way when accidentally called without a block

### DIFF
--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -486,6 +486,10 @@ module RSpec::Core
       expect(@nil_value_count).to eq(1)
     end
 
+    it 'raises a useful error when called without a block' do
+      ExampleGroup.describe { let(:list) }
+    end
+
     let(:a_value) { "a string" }
 
     context 'when overriding let in a nested context' do


### PR DESCRIPTION
here's the error rspec raises when this happens:

``` shell
ArgumentError:
  tried to create Proc object without a block
# ./spec/rspec/core/memoized_helpers_spec.rb:490:in `block (3 levels) in <module:Core>'
# ./spec/rspec/core/memoized_helpers_spec.rb:490:in `block (2 levels) in <module:Core>'
```

took me a minute to figure out what went wrong. especially because:
1. it works on my mac but [fails on travis](https://travis-ci.org/savonrb/savon/jobs/5264663). same versions and everything.
2. i was actually [calling `#subject` without a block](https://github.com/savonrb/savon/blob/2ecb6fddb3cf27a778613b6b7483751011600314/spec/savon/model_spec.rb#L52) which delegates to `#let`.
3. i had to tell rake (which runs the specs on travis) to output complete stacktraces to even find that line.

so i'm not really sure how to proceed and would like to hear your thoughts.

i would suggest to add a guard clause and at least change the error message to tell the user what went wrong. not sure if you would change the error type though. and maybe the error could even point to the line of code which calls `#let`, but i don't know if there's a cheap and reliable way to do this through the caller.
