### PR TITLE
Add some humanistic logic to test time precision.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ Enhancements
   `--default-path` to the load path (which defaults to `spec`). This
   better supports folks who choose to put their specs in a different
   directory (John Feminella).
+* Add some logic to test time duration precision. Make it a
+  function of time, dropping precision as the time increases. (Aaron Kromer)
 
 Bug fixes
 

--- a/lib/rspec/core/formatters/helpers.rb
+++ b/lib/rspec/core/formatters/helpers.rb
@@ -43,20 +43,27 @@ module RSpec
         #    format_duration(1) #=>  "1 minute 1 second"
         #    format_duration(135.14) #=> "2 minutes 15.14 seconds"
         def format_duration(duration)
+          precision = case
+                      when duration < 1;    SUB_SECOND_PRECISION
+                      when duration < 120;  DEFAULT_PRECISION
+                      when duration < 300;  1
+                      else                  0
+                      end
+
           if duration > 60
             minutes = duration.to_i / 60
             seconds = duration - minutes * 60
 
-            "#{pluralize(minutes, 'minute')} #{pluralize(format_seconds(seconds), 'second')}"
+            "#{pluralize(minutes, 'minute')} #{pluralize(format_seconds(seconds, precision), 'second')}"
           else
-            pluralize(format_seconds(duration), 'second')
+            pluralize(format_seconds(duration, precision), 'second')
           end
         end
 
         # @api private
         #
         # Formats seconds to have 5 digits of precision with trailing zeros removed if the number
-        # if less than 1 or with 2 digits of precision if the number is greater than zero.
+        # is less than 1 or with 2 digits of precision if the number is greater than zero.
         #
         # @param [Float] float
         # @return [String] formatted float
@@ -69,7 +76,7 @@ module RSpec
         # The precision used is set in {Helpers::SUB_SECOND_PRECISION} and {Helpers::DEFAULT_PRECISION}.
         #
         # @see #strip_trailing_zeroes
-        def format_seconds(float)
+        def format_seconds(float, precision = nil)
           precision ||= (float < 1) ? SUB_SECOND_PRECISION : DEFAULT_PRECISION
           formatted = sprintf("%.#{precision}f", float)
           strip_trailing_zeroes(formatted)

--- a/spec/rspec/core/formatters/helpers_spec.rb
+++ b/spec/rspec/core/formatters/helpers_spec.rb
@@ -5,21 +5,33 @@ describe RSpec::Core::Formatters::Helpers do
   let(:helper) { Object.new.extend(RSpec::Core::Formatters::Helpers) }
 
   describe "format duration" do
+    context '< 1' do
+      it "returns '0.xxxxx seconds' formatted string" do
+        expect(helper.format_duration(0.123456)).to eq("0.12346 seconds")
+      end
+    end
+
+    context '> 1 and < 60' do
+      it "returns 'xx.xx seconds' formatted string" do
+        expect(helper.format_duration(45.51)).to eq("45.51 seconds")
+      end
+    end
+
     context '> 60 and < 120' do
-      it "returns 'x minute xx seconds' formatted string" do
+      it "returns 'x minute xx.xx seconds' formatted string" do
         expect(helper.format_duration(70.14)).to eq("1 minute 10.14 seconds")
       end
     end
 
-    context '> 120' do
-      it "returns 'x minutes xx seconds' formatted string" do
-        expect(helper.format_duration(135.14)).to eq("2 minutes 15.14 seconds")
+    context '> 120 and < 300' do
+      it "returns 'x minutes xx.x seconds' formatted string" do
+        expect(helper.format_duration(135.14)).to eq("2 minutes 15.1 seconds")
       end
     end
 
-    context '< 60' do
-      it "returns 'xx seconds' formatted string" do
-        expect(helper.format_duration(45.5)).to eq("45.5 seconds")
+    context '> 300' do
+      it "returns 'x minutes xx seconds' formatted string" do
+        expect(helper.format_duration(335.14)).to eq("5 minutes 35 seconds")
       end
     end
 
@@ -37,6 +49,10 @@ describe RSpec::Core::Formatters::Helpers do
   end
 
   describe "format seconds" do
+    it "uses passed in precision if specified unless result is 0" do
+      expect(helper.format_seconds(0.01234, 2)).to eq("0.01")
+    end
+
     context "sub second times" do
       it "returns 5 digits of precision" do
         expect(helper.format_seconds(0.000006)).to eq("0.00001")


### PR DESCRIPTION
Precision should really be a function of the number of tests and time. A
small number of tests with a long time, does not warrant a high
precision. However, if you had 8,000 tests (think JPL code) you would
care about a higher precision, even if your test suite ran for 4
minutes.

Since the code that does the formatting does not know about the number
of tests, the following is a rough middle ground, which is completely
arbitrary based on how I felt and not on any real science.
- <   1 seconds: Give me all the precisions
- < 120 seconds: Hundredths of a second are good
- < 300 seconds: Tenths of a second, because I just can't give em up
- > 300 seconds: Seconds, because you can't wait this long anyways

[Close #807]
