### PR TITLE
example group: register global hooks before individual config

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -287,8 +287,8 @@ module RSpec
         args << build_metadata_hash_from(args)
         args.unshift(symbol_description) if symbol_description
         @metadata = RSpec::Core::Metadata.new(superclass_metadata).process(*args)
-        world.configure_group(self)
         hooks.register_globals(self, RSpec.configuration.hooks)
+        world.configure_group(self)
       end
 
       # @private

--- a/spec/rspec/core/shared_context_spec.rb
+++ b/spec/rspec/core/shared_context_spec.rb
@@ -40,7 +40,7 @@ describe RSpec::SharedContext do
       c.before(:each) { ordered_hooks << "config" }
     end
 
-    RSpec.world.shared_context "before each stuff", :example => :before_each_hook_order do
+    shared_context("before each stuff", :example => :before_each_hook_order) do
       before(:each) { ordered_hooks << "shared_context"}
     end
 
@@ -51,9 +51,7 @@ describe RSpec::SharedContext do
 
     group.run
 
-    pending "Issue #632" do
-      ordered_hooks.should == ["config", "shared_context", "example_group"]
-    end
+    expect(ordered_hooks).to be == ["config", "shared_context", "example_group"]
   end
 
   it "supports let" do


### PR DESCRIPTION
fixes #632
