### PR TITLE
Fix a few potential warnings

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -191,10 +191,13 @@ EOS
         def let(name, &block)
           # We have to pass the block directly to `define_method` to
           # allow it to use method constructs like `super` and `return`.
-          MemoizedHelpers.module_for(self).define_method(name, &block)
+          mod = MemoizedHelpers.module_for self
+          mod.undef_method name if mod.method_defined? name
+          mod.define_method name, &block
 
           # Apply the memoization. The method has been defined in an ancestor
           # module so we can use `super` here to get the value.
+          undef_method name if method_defined? name
           define_method(name) do
             __memoized.fetch(name) { |k| __memoized[k] = super(&nil) }
           end
@@ -472,6 +475,7 @@ EOS
             # Expose `define_method` as a public method, so we can
             # easily use it below.
             public_class_method :define_method
+            public_class_method :undef_method
           end
 
           example_group.__send__(:include, mod)


### PR DESCRIPTION
If a let is already defined, redefining it causes a warning. Because of this, patterns like creating a helper method that creates default lets will cause warnings if one of those lets is overridden:

```
warning: method redefined; discarding old letname
warning: previous definition of letname was here
```

Maybe this isn't the best practice, though, and these warnings should stay.
