### PR TITLE
Using let variable in before(:all) hook, example store let variable in each scope and it break rspec test.

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -307,7 +307,7 @@ module RSpec
 
       # @private
       def self.assign_before_all_ivars(ivars, example_group_instance)
-        ivars.each { |ivar, val| example_group_instance.instance_variable_set(ivar, val) }
+        ivars.each { |ivar, val| example_group_instance.instance_variable_set(ivar, val) unless ivar == :@__memoized }
       end
 
       # @private


### PR DESCRIPTION
I think this is a bug. and should not store let variable.

this is demo spec.
https://gist.github.com/natsumesou/5300504
