### PR TITLE
Update the cucumber feature on configuration files to have docs about .rspec-local

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,8 @@ Enhancements
   (Gabor Garami).
 * Give a better error message when let and subject are called without a block.
   (Sam Phippen).
+* List the precedence of `.rspec-local` in the configuration documentation
+  (Sam Phippen)
 
 Bug fixes
 

--- a/features/configuration/read_options_from_file.feature
+++ b/features/configuration/read_options_from_file.feature
@@ -3,11 +3,14 @@ Feature: read command line configuration options from files
   RSpec reads command line configuration options from files in two different
   locations:
 
-    Local:  "./.rspec" (i.e. in the project's root directory)
-    Global: "~/.rspec" (i.e. in the user's home directory)
+    Local: `./.rspec-local` (i.e. in the project's root directory, can be gitignored)
+    Project:  `./.rspec` (i.e. in the project's root directory, usually checked into the project)
+    Global: `~/.rspec` (i.e. in the user's home directory)
 
-  Options declared in the local file override those in the global file, while
-  those declared in RSpec.configure will override any ".rspec" file.
+  Configuration options are loaded from `~/.rspec`, `.rspec`,
+  `.rspec-local`, command line switches, and the `SPEC_OPTS` environment
+  variable (listed in lowest to highest precedence; for example, an option
+  in `~/.rspec` can be overridden by an option in `.rspec-local`).
 
   Scenario: color set in .rspec
     Given a file named ".rspec" with:


### PR DESCRIPTION
This is so we can get some docs on relish for `.rpsec-local`.

Also this closes #738.
