### PR TITLE
Comment out and document the generated config

### DIFF
--- a/lib/rspec/core/project_initializer.rb
+++ b/lib/rspec/core/project_initializer.rb
@@ -31,9 +31,9 @@ CONTENT
 
       def create_spec_helper_file
         if File.exist?('spec/spec_helper.rb')
-          report_exists("spec/spec_helper.rb")
+          report_exists('spec/spec_helper.rb')
         else
-          report_creating("spec/spec_helper.rb")
+          report_creating('spec/spec_helper.rb')
           FileUtils.mkdir_p('spec')
           File.open('spec/spec_helper.rb','w') do |f|
             f.write <<-CONTENT
@@ -44,14 +44,21 @@ CONTENT
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.run_all_when_everything_filtered = true
-  config.filter_run :focus
+  # Limit the spec run to only specs with the focus metadata. If no specs have
+  # the filtering metadata and `run_all_when_everything_filtered = true` then
+  # all specs will run.
+  #config.filter_run :focus
+
+  # Run all specs when none match the provided filter. This works well in
+  # conjunction with `config.filter_run :focus`, as it will run the entire
+  # suite when no specs have `:filter` metadata.
+  #config.run_all_when_everything_filtered = true
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = 'random'
+  #config.order = 'random'
 end
 CONTENT
           end


### PR DESCRIPTION
All of the settings within the config file are slated to become the
default for 3.0. In the meantime comment them out of the generated
configuration and provide explanitory comments, hopefully to reduce any
confusion for people who are starting new projects.

As discussed in rspec/rspec-core/pull/796
