### PR TITLE
Add example parameter to extra_failure_content

### DIFF
--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -91,7 +91,7 @@ module RSpec
           else
             false
           end
-          extra = extra_failure_content(exception)
+          extra = extra_failure_content(exception, example)
 
           @printer.print_example_failed(
             exception.pending_fixed?,
@@ -116,7 +116,7 @@ module RSpec
         # Override this method if you wish to output extra HTML for a failed spec. For example, you
         # could output links to images or other files produced during the specs.
         #
-        def extra_failure_content(exception)
+        def extra_failure_content(exception, example)
           require 'rspec/core/formatters/snippet_extractor'
           backtrace = exception.backtrace.map {|line| backtrace_line(line)}
           backtrace.compact!

--- a/lib/rspec/core/formatters/text_mate_formatter.rb
+++ b/lib/rspec/core/formatters/text_mate_formatter.rb
@@ -21,7 +21,7 @@ module RSpec
           end
         end
 
-        def extra_failure_content(exception)
+        def extra_failure_content(exception, example)
           require 'rspec/core/formatters/snippet_extractor'
           backtrace = exception.backtrace.map {|line| backtrace_line(line, :skip_textmate_conversion)}
           backtrace.compact!


### PR DESCRIPTION
Some custom formatters may want to add data based on the example metadata, but there isn't a good way to grab that from just the failure AFAIK.

If there is a better way to do this, please let me know. This was the simplest change I could think of.

Thanks,
George
