### PR TITLE
More removal of string evals

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -58,7 +58,7 @@ module RSpec
         #   @param [Hash] extra_options
         #   @param [Block] implementation
         def self.define_example_method(name, extra_options={})
-          define_method(name) do |*all_args,&block|
+          define_method(name) do |*all_args, &block|
             desc, *args = *all_args
             options = build_metadata_hash_from(args)
             options.update(:pending => RSpec::Core::Pending::NOT_YET_IMPLEMENTED) unless block


### PR DESCRIPTION
Note in this case we will need to wait until we drop 1.8.6 support in RSpec 3 because of the block argument
