### PR TITLE
Add setters for RSpec.world and RSpec.configuration

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -61,6 +61,12 @@ module RSpec
   end
 
   # @private
+  # Used internally to set the global object
+  def self.world=(new_world)
+    @world = new_world
+  end
+
+  # @private
   # Used internally to ensure examples get reloaded between multiple runs in
   # the same process.
   def self.reset
@@ -92,6 +98,12 @@ Called from #{caller(0)[1]}
 WARNING
     end
     @configuration ||= RSpec::Core::Configuration.new
+  end
+
+  # @private
+  # Used internally to set the global object
+  def self.configuration=(new_configuration)
+    @configuration = new_configuration
   end
 
   # Yields the global configuration to a block.

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -7,6 +7,16 @@ describe RSpec do
     end
   end
 
+  describe "::configuration=" do
+    it "sets the configuration object" do
+      configuration = RSpec::Core::Configuration.new
+
+      RSpec.configuration = configuration
+
+      expect(RSpec.configuration).to equal(configuration)
+    end
+  end
+
   describe "::configure" do
     it "yields the current configuration" do
       RSpec.configure do |config|
@@ -18,6 +28,16 @@ describe RSpec do
   describe "::world" do
     it "returns the same object every time" do
       expect(RSpec.world).to equal(RSpec.world)
+    end
+  end
+
+  describe "::world=" do
+    it "sets the world object" do
+      world = RSpec::Core::World.new
+
+      RSpec.world = world
+
+      expect(RSpec.world).to equal(world)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,8 +41,8 @@ Spork.prefork do
       @orig_world  = RSpec.world
       new_config = RSpec::Core::Configuration.new
       new_world  = RSpec::Core::World.new(new_config)
-      RSpec.instance_variable_set(:@configuration, new_config)
-      RSpec.instance_variable_set(:@world, new_world)
+      RSpec.configuration = new_config
+      RSpec.world = new_world
       object = Object.new
       object.extend(RSpec::Core::SharedExampleGroup)
 
@@ -63,8 +63,8 @@ Spork.prefork do
         remove_method :orig_run
       end
 
-      RSpec.instance_variable_set(:@configuration, @orig_config)
-      RSpec.instance_variable_set(:@world, @orig_world)
+      RSpec.configuration = @orig_config
+      RSpec.world = @orig_world
     end
   end
 


### PR DESCRIPTION
It would be great to be able to set the global world and configuration objects using setters instead of `RSpec.instance_variable_set(:@configuration, new_config)`.
