### PR TITLE
Register formatters for the events they listen to

### DIFF
--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -15,15 +15,22 @@ module RSpec::Core
       end
     end
 
+    context "given a formatter not implementing an event listener method" do
+      let(:formatter) { double('formatter') }
+      let(:reporter)  { Reporter.new(formatter) }
+
+      it "does not send unhandled events to the formatter" do
+        reporter.message(nil)
+      end
+    end
+
     context "given one formatter" do
+      let(:formatter) { double('formatter') }
+
       it "passes messages to that formatter" do
-        formatter = double("formatter")
-        example = double("example")
+        formatter.should_receive(:example_started).with(example)
+
         reporter = Reporter.new(formatter)
-
-        formatter.should_receive(:example_started).
-          with(example)
-
         reporter.example_started(example)
       end
 
@@ -56,30 +63,24 @@ module RSpec::Core
     end
 
     context "given an example group with no examples" do
+      let(:formatter) { double("formatter").as_null_object }
+
       it "does not pass example_group_started or example_group_finished to formatter" do
-        formatter = double("formatter").as_null_object
         formatter.should_not_receive(:example_group_started)
         formatter.should_not_receive(:example_group_finished)
 
-        group = ExampleGroup.describe("root")
-
-        group.run(Reporter.new(formatter))
+        ExampleGroup.describe("root").run(Reporter.new(formatter))
       end
     end
 
     context "given multiple formatters" do
       it "passes messages to all formatters" do
         formatters = [double("formatter"), double("formatter")]
-        example = double("example")
-        reporter = Reporter.new(*formatters)
-
         formatters.each do |formatter|
-          formatter.
-            should_receive(:example_started).
-            with(example)
+          formatter.should_receive(:example_started).with(example)
         end
 
-        reporter.example_started(example)
+        Reporter.new(*formatters).example_started(example)
       end
     end
 


### PR DESCRIPTION
I just saw #884 after I had done this - almost exactly the same thing. One comment I would have on #884 is that `Notifications` is a constant, so should be upcase, and I think it's slightly more consistent to call them `EVENTS`.

@jonrowe - if you want to fix up your PR and close this one, that's cool. Or if you want to take this one, either way. Sorry for the duplication.

I still think any new listener methods should be implemented and documented on `BaseFormatter` for now, but a new formatter won't have to inherit from that class to prevent breaking after this change... I want to catch you on IRC to chat about this sometime.
