### PR TITLE
Abort instead of raise on Rake task failure

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -146,7 +146,7 @@ module RSpec
         rescue
           puts failure_message if failure_message
         end
-        raise("#{command} failed") if fail_on_error unless success
+        abort("#{command} failed") if fail_on_error unless success
       end
 
     private


### PR DESCRIPTION
Use abort instead of raise, stops the rake task but doesnt print the rake stack trace.
