### PR TITLE
Demonstrates problem where a module can affect how `LetDefinition`s are put in the ancestor chain

### DIFF
--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -616,6 +616,24 @@ module RSpec::Core
         })
       end
     end
+
+    context "when included modules have hooks that define memoized helpers" do
+      it "allows memoized helpers to override methods in previously included modules" do
+        group = ExampleGroup.describe do
+          include Module.new {
+            def self.included(m); m.let(:unrelated) { :unrelated }; end
+          }
+
+          include Module.new {
+            def hello_message; "Hello from module"; end
+          }
+
+          let(:hello_message) { "Hello from let" }
+        end
+
+        expect(group.new.hello_message).to eq("Hello from let")
+      end
+    end
   end
 
   describe "#let!" do


### PR DESCRIPTION
:warning: For now this pull request has a failing test for demonstration.
- This was originally filed as rspec/rspec-rails#738, but we can
  demonstrate it without rails or activesupport
