### PR TITLE
Allow example groups to have user specified ordering

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -936,7 +936,7 @@ EOM
       # @private
       RANDOM_ORDERING = lambda do |list|
         Kernel.srand RSpec.configuration.seed
-        orders = list.map {|x| x.order.nil? ? Kernel.rand(list.size) : x.order}
+        orders = list.map {|x| !(x.respond_to?(:order)) || x.order.nil? || x.order == :random ? Kernel.rand(list.size) : 1}
         zipped = list.zip(orders)
 
         ordering = zipped.sort_by { |x| x[1] }.map { |x| x.first }

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -83,7 +83,7 @@ module RSpec
         @metadata  = @example_group_class.metadata.for_example(description, metadata)
         @example_group_instance = @exception = nil
         @pending_declared_in_example = false
-        @order = metadata[:order]
+        @order = example_group_class.order
       end
 
       # @deprecated access options via metadata instead

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -242,7 +242,11 @@ module RSpec
       # @private
       def self.subclass(parent, args, &example_group_block)
         subclass = Class.new(parent)
-        subclass.define_singleton_method(:order) { args.last[:order] }
+        if args.last[:order]
+          subclass.define_singleton_method(:order) { args.last[:order] }
+        elsif parent && parent.order
+          subclass.define_singleton_method(:order) { parent.order }
+        end
         subclass.set_it_up(*args)
         subclass.module_eval(&example_group_block) if example_group_block
         subclass


### PR DESCRIPTION
This is an attempt to fix #636.

This is super prototypical, but it seems to work. Basically on both example groups and examples users can pass in a `:order` option which is used when we shuffle the examples. Basically everything else gets a random number in the range (0...examples.length), but if these orders are specified consistently then those examples will always be ordered relative to each other because the list is sorted.

Take a gander, let me know what you think.
