### PR TITLE
Ensure MemoizedHelpers#its respects object visibility.

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -433,7 +433,11 @@ EOS
               let(:__its_subject) do
                 attribute_chain = attribute.to_s.split('.')
                 attribute_chain.inject(subject) do |inner_subject, attr|
-                  inner_subject.send(attr)
+                  if _visible?(inner_subject, attr)
+                    inner_subject.send(attr)
+                  else
+                    raise NoMethodError, "This method is not available."
+                  end
                 end
               end
             end
@@ -450,6 +454,12 @@ EOS
           end
         end
       end
+
+      def _visible?(klass, name)
+        klass.public_methods.include?(name.to_sym)
+      end
+      private :_visible?
+
 
       # @api private
       #

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -340,6 +340,48 @@ module RSpec::Core
         its(:call_count) { should eq(1) }
       end
 
+      context "its raises error when instance method under test is private" do
+        subject do
+          Class.new do
+            def name
+              private_name
+            end
+
+            private
+
+            def private_name
+              "foo"
+            end
+          end.new
+        end
+
+        its(:private_name) do
+          expect do
+            should eq("foo")
+          end.to raise_error(NoMethodError)
+        end
+      end
+
+      context "its raises error when class method under test is private" do
+        subject do
+          class TestPublicAvailability
+            class << self
+              private
+              def private_name
+                "foo"
+              end
+            end
+            self
+          end
+        end
+
+        its(:private_name) do
+          expect do
+            should eq("foo")
+          end.to raise_error(NoMethodError)
+        end
+      end
+
       context "with nil value" do
         subject do
           Class.new do


### PR DESCRIPTION
@syntaxritual, @nurugger07, @rjackson, and I stumbled across and interesting problem with regards to MemoizedHelpers#its.  

Before this patch If you call a private_method on an implicit subject with #its like:

``` ruby
subject do
  Class.new do
    private 
    def private_name
      "foo"
     end
  end
end

its(:private_name) { should eq("foo") }
```

Rspec will not through a NoMethodError as one would expect.  This patch attempts to address this in a way that is backward compatible (no public_send).  

To accomplish this we added a `_visibility?` method that checks for the availability of the method before calling send.  If the method is not visible it throws a NoMethodError.

Cheers,
Jon
