### PR TITLE
Adding a new feature called "stress-test"

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -149,6 +149,9 @@ MESSAGE
       # don't accidentally leave the seed encoded.
       define_reader :seed
 
+      # Time limit for stress testing, if any (default: nil).
+      add_setting :stress_test
+
       # When a block passed to pending fails (as expected), display the failure
       # without reporting it as a failure (default: false).
       add_setting :show_failures_in_pending_blocks
@@ -927,7 +930,7 @@ EOM
       end
 
       def randomize?
-        order.to_s.match(/rand/)
+        order.to_s.match(/rand/) || stress_test
       end
 
       # @private

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -75,6 +75,10 @@ module RSpec::Core
           options[:order] = "rand:#{seed}"
         end
 
+        parser.on('--stress-test LIMIT', Float, 'Repeatedly run randomly selected examples for LIMIT seconds.') do |o|
+          options[:stress_test] = o.to_f
+        end
+
         parser.on('-d', '--debugger', 'Enable debugging.') do |o|
           options[:debug] = true
         end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -52,6 +52,12 @@ module RSpec
         end
       end
 
+      def all_examples
+        example_groups.collect {|g| g.descendants}.flatten.inject([]) do |array, g|
+          array += g.filtered_examples
+        end
+      end
+
       def preceding_declaration_line(filter_line)
         declaration_line_numbers.sort.inject(nil) do |highest_prior_declaration_line, line|
           line <= filter_line ? line : highest_prior_declaration_line

--- a/spec/command_line/order_spec.rb
+++ b/spec/command_line/order_spec.rb
@@ -177,6 +177,25 @@ describe 'command line', :ui do
     end
   end
 
+  describe '--stress-test' do
+    it 'repeatedly runs randomly selected examples until time limit' do
+      run_command 'tmp/aruba/spec/order_spec.rb --stress-test 0.1 --seed 123 -f doc'
+
+      # there should be some repetition
+      groups = top_level_groups {|g| g}.flatten
+      expect(groups.size).to be > 100
+      # group1 should be chosen about 30 times more than group2
+      ratio = groups.count('group 1') / groups.count('group 2')
+      expect(ratio).to be >= 30 / 2
+      expect(ratio).to be <= 30 * 2
+
+      # examples1 should be chosen about the same as examples11
+      ratio = examples('group 1') {|e| e}.flatten.size / examples('group 1-1') {|e| e}.flatten.size
+      expect(ratio).to be >= 1 / 2
+      expect(ratio).to be <= 1 * 2
+    end
+  end
+
   def examples(group)
     yield split_in_half(stdout.string.scan(/^\s+#{group} example.*$/))
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,8 +48,8 @@ Spork.prefork do
 
       (class << RSpec::Core::ExampleGroup; self; end).class_eval do
         alias_method :orig_run, :run
-        def run(reporter=nil)
-          orig_run(reporter || NullObject.new)
+        def run(reporter=nil, chain_to_execute=nil)
+          orig_run(reporter || NullObject.new, chain_to_execute || NullObject.new)
         end
       end
 


### PR DESCRIPTION
This feature is very simple, for a given set of examples, we run the tests in random order for given amount of time.

This is not to be used a performance testing against say a website or a service, but to stress the individual set of tests to uncover any flakey behavior. If a set of tests runs non-stop for 10 mins without a single test flaking out, we can consider a test to be stable.

Thanks!
