### PR TITLE
Add nailgun to cucumber.

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,9 +6,15 @@ Before do
   @aruba_timeout_seconds = timeouts.fetch(RUBY_PLATFORM) { 10 }
 end
 
-Aruba.configure do |config|
-  config.before_cmd do |cmd|
-    set_env('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
+if RUBY_PLATFORM == "java"
+  pid = Process.spawn("jruby --ng-server &")
+  Aruba.configure do |config|
+    config.before_cmd do |cmd|
+      set_env('JRUBY_OPTS', "--ng -X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
+    end
   end
-end if RUBY_PLATFORM == 'java'
 
+  at_exit do
+    Process.spawn("kill #{pid}")
+  end
+end


### PR DESCRIPTION
This adds nailgun usage to cucumber. There's a couple of janky things with this implementation, but it is faster (13 minutes versus 26 on my laptop).

Some annoyances:
- Nailgun seems to fiddle exit codes
- Running the nailgun server from jruby starts the server, then the jruby process exits, meaning the pid you get back isn't the one you need to kill.

I'm not sure the speed is worth the pain of working with nailgun. Thoughts?

Edit: this code is super prototypical and demonstrates the speedup, but is not yet anywhere near ready for merging.
