### PR TITLE
change `uniq` to `uniq!` as the intended operation.

### DIFF
--- a/lib/autotest/rspec2.rb
+++ b/lib/autotest/rspec2.rb
@@ -20,7 +20,7 @@ class Autotest::Rspec2 < Autotest
     self.completed_re = /\n(?:\e\[\d*m)?\d* examples?/m
   end
 
-  # Adds conventional spec-to-file mappings to Autotest configuation.
+  # Adds conventional spec-to-file mappings to Autotest configuration.
   def setup_rspec_project_mappings
     add_mapping(%r%^spec/.*_spec\.rb$%) { |filename, _|
       filename

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -14,7 +14,7 @@ module RSpec
           hash[group] = begin
             examples = group.examples.dup
             examples = filter_manager.prune(examples)
-            examples.uniq
+            examples.uniq!
             examples.extend(Extensions::Ordered::Examples)
           end
         }


### PR DESCRIPTION
Change `uniq` to `uniq!` as the intended operation.

Fix a typo
