### PR TITLE
Pull refactored memoized helpers into 2.14

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,16 @@
+### Dev
+
+Enhancements
+
+* Clean up some internal use of Enumerable methods. (Vipul A M)
+
+Bug fixes
+
+* Refactor memoized helpers (let, subject, named subject) to use an internalised
+  method name to avoid conflict with outside methods. Avoids complex ordering
+  issues with `LetDefinitions` module. See #908 #817 #871 rspec/rspec-rails#738 .
+  (Andy Lindeman, Jon Rowe)
+
 ### 2.14.0.rc1 / 2013-05-27
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.13.1...v2.14.0.rc1)
 

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -190,16 +190,12 @@ EOS
         #     end
         #   end
         def let(name, &block)
-          # We have to pass the block directly to `define_method` to
-          # allow it to use method constructs like `super` and `return`.
-          raise "#let or #subject called without a block" if block.nil?
-          MemoizedHelpers.module_for(self).send(:define_method, name, &block)
-
-          # Apply the memoization. The method has been defined in an ancestor
-          # module so we can use `super` here to get the value.
-          define_method(name) do
-            __memoized.fetch(name) { |k| __memoized[k] = super(&nil) }
-          end
+          MemoizedHelpers.define_memoized_method(
+            self,
+            name,
+            MemoizedHelpers.memoized_method_name_for(name, 'let'),
+            &block
+          )
         end
 
         # Just like `let`, except the block is invoked by an implicit `before`
@@ -291,10 +287,11 @@ EOS
         # @see MemoizedHelpers#should
         def subject(name=nil, &block)
           if name
-            let(name, &block)
+            subject_method_name = MemoizedHelpers.memoized_method_name_for(name, "subject")
+            MemoizedHelpers.define_memoized_method(self, name, subject_method_name, &block)
             alias_method :subject, name
 
-            self::NamedSubjectPreventSuper.send(:define_method, name) do
+            self::NamedSubjectPreventSuper.__send__(:define_method, subject_method_name) do
               raise NotImplementedError, "`super` in named subjects is not supported"
             end
           else
@@ -474,6 +471,26 @@ EOS
           example_group.__send__(:include, mod)
           example_group.const_set(:LetDefinitions, mod)
           mod
+        end
+      end
+
+      # @api private
+      def self.memoized_method_name_for(name, let_or_subject)
+        "__rspec_#{let_or_subject}_definition_#{name}"
+      end
+
+      # @api private
+      def self.define_memoized_method(example_group, name, memoized_method_name, &block)
+        raise "#let or #subject called without a block" if block.nil?
+
+        # We have to pass the block directly to `define_method` to
+        # allow it to use method constructs like `super` and `return`.
+        module_for(example_group).__send__(:define_method, memoized_method_name, &block)
+
+        # Apply the memoization. The method has been defined in an ancestor
+        # module so we can use the decorated name here to get the value.
+        example_group.__send__(:define_method, name) do
+          __memoized.fetch(name) { |k| __memoized[k] = send(memoized_method_name, &nil) }
         end
       end
 

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -616,6 +616,25 @@ module RSpec::Core
         })
       end
     end
+
+    context "when included modules have hooks that define memoized helpers" do
+      it "allows memoized helpers to override methods in previously included modules" do
+        group = ExampleGroup.describe do
+          # this replicates the ordering scenario that breaks in #817
+          include Module.new {
+            def self.included(m); m.let(:unrelated) { :unrelated }; end
+          }
+
+          include Module.new {
+            def hello_message; "Hello from module"; end
+          }
+
+          let(:hello_message) { "Hello from let" }
+        end
+
+        expect(group.new.hello_message).to eq("Hello from let")
+      end
+    end
   end
 
   describe "#let!" do


### PR DESCRIPTION
This pulls the changes from #937 and #938 into 2.14
