### PR TITLE
WIP: Fix let definitions eagerly included

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -45,8 +45,12 @@ module RSpec
       #
       # @see #should
       def subject
-        raise NotImplementedError, 'This definition is here for documentation purposes only'
-          ' - it is overriden anyway below when this module gets included.'
+        __memoized.fetch(:subject) do
+          __memoized[:subject] = begin
+            described = described_class || self.class.description
+            Class === described ? described.new : described
+          end
+        end
       end
 
       # When `should` is called with no explicit receiver, the call is
@@ -148,12 +152,6 @@ EOS
 
       def self.included(mod)
         mod.extend(ClassMethods)
-
-        # This logic defines an implicit subject
-        mod.subject do
-          described = described_class || self.class.description
-          Class === described ? described.new : described
-        end
       end
 
       module ClassMethods
@@ -471,7 +469,7 @@ EOS
             }
           end
 
-          example_group.__send__(:include, mod)
+          example_group.before(:all) { example_group.__send__(:include, mod) }
           example_group.const_set(:LetDefinitions, mod)
           mod
         end

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -95,7 +95,9 @@ module RSpec::Core
           subject_value = nil
           group.describe("I'm nested!") do
             example { subject_value = subject }
-          end.run
+          end
+
+          group.run
 
           expect(subject_value).to eq([4, 5, 6])
         end
@@ -106,7 +108,9 @@ module RSpec::Core
             describe("Nesting level 2") do
               example { subject_value = subject }
             end
-          end.run
+          end
+
+          group.run
 
           expect(subject_value).to eq([4, 5, 6])
         end
@@ -116,7 +120,9 @@ module RSpec::Core
           group.describe("Nested") do
             subject { super() + [:override] }
             example { subject_value = subject }
-          end.run
+          end
+
+          group.run
 
           expect(subject_value).to eq([4, 5, 6, :override])
         end


### PR DESCRIPTION
This is an alternate candidate fix for #908.
- I still need to fix `SharedContext`, which I can do later.
- If we like this, I'll probably refactor things so that the `LetDefinitions` module is explicitly included into the example group just before it runs `before(:all)` hooks rather than using `before(:all)` directly.

@alindeman / @JonRowe -- I was having problems with `subject` when playing around with this last night (causing me to abandon the attempt at the time) but after sleeping on it, I found this solution.  Have you tried something like this?

Thinking about the solution of using an obfuscated name...I'm concerned about the fact that it means `super()` would now super to that name rather than the `let` name, which seems like it could break things in ways we haven't yet realized.

Thoughts?  Is this path worth continuing on?
