### PR TITLE
prettify `shellwords` usage

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -123,7 +123,7 @@ module RSpec
       def args_from_options_file(path)
         return [] unless path && File.exist?(path)
         config_string = options_file_as_erb_string(path)
-        config_string.split(/\n+/).map {|l| Shellwords.shellwords(l) }.flatten
+        config_string.split(/\n+/).map(&:shellsplit).flatten
       end
 
       def options_file_as_erb_string(path)

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -155,7 +155,7 @@ module RSpec
         if ENV['SPEC']
           FileList[ ENV['SPEC'] ].sort
         else
-          FileList[ pattern ].sort.map &:shellescape
+          FileList[ pattern ].sort.map(&:shellescape)
         end
       end
 


### PR DESCRIPTION
Since `shellwords` extends `String` with `shellescape` and `shellsplit` (corresponding to `Shellwords::shellwords`), we may omit blocks to `map` that just invoke those methods.

The `&:inst_meth` works on 1.8 too.
