### PR TITLE
Define `fit` for example groups as a shortcut to define examples with `focus` => true based off 2-14

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,19 @@
 ### Dev
 
 Bug fixes
+=======
+Breaking Changes for 3.0.0:
+
+* Remove explicit support for 1.8.6 (Jon Rowe)
+
+Enhancements
+
+* Clean up some internal use of Enumerable methods. (Vipul A M)
+* Replace unmaintained syntax gem with coderay gem. (Xavier Shay)
+* Apply focus to examples defined with `fit` (equivalent of
+  `it "description", focus: true`) (Michael de Silva)
+
+Bug fix
 
 * Ensure methods defined by `let` take precedence over others
   when there is a name collision (e.g. from an included module).

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -85,6 +85,9 @@ module RSpec
         define_example_method :focus,   :focused => true, :focus => true
         # Shortcut to define an example with `:focus` => true
         define_example_method :focused, :focused => true, :focus => true
+        # Shortcut to define an example with `:focus` => true
+        # @see example
+        define_example_method :fit,     :focused => true, :focus => true
 
         # Shortcut to define an example with :pending => true
         define_example_method :pending,  :pending => true

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -397,7 +397,7 @@ module RSpec::Core
       end
     end
 
-    [:focus, :focused].each do |example_alias|
+    [:focus, :focused, :fit].each do |example_alias|
       describe "##{example_alias}" do
         let(:focused_example) { ExampleGroup.describe.send example_alias, "a focused example" }
 


### PR DESCRIPTION
This is #955 based off 2-14
