### PR TITLE
2.14.0 DeprecationFormatter errors when using ruby-debug

### DIFF
--- a/lib/rspec/core/formatters/deprecation_formatter.rb
+++ b/lib/rspec/core/formatters/deprecation_formatter.rb
@@ -8,6 +8,10 @@ module RSpec
           @count = 0
         end
 
+        def start(example_count=nil)
+          #no-op to fix #966
+        end
+
         def deprecation(data)
           @count += 1
           if data[:message]

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -4,6 +4,13 @@ require 'tempfile'
 
 module RSpec::Core::Formatters
   describe DeprecationFormatter do
+    describe '#start' do
+      it 'prevents Kernel#start from being called on jruby' do
+        formatter = DeprecationFormatter.new StringIO.new, StringIO.new
+        expect(formatter.start).to eq nil
+      end
+    end
+
     describe "#deprecation" do
       let(:deprecation_stream) { StringIO.new }
       let(:summary_stream)     { StringIO.new }


### PR DESCRIPTION
It looks like new DeprecationFormatter doesn't implement start method, so the call is routed to the Kernel method, that is injected by ruby-debug and has a different signature.

``` Ruby
module Kernel
  def start(options={}, &block)
  ......
  end
end


class BaseFormatter
   def start(example_count)
   ....
   end
end
```

Error Message:

```
TypeError: can't convert Fixnum into Hash
     merge at org/jruby/RubyHash.java:1756
     start at /Users/aportnov/.rvm/gems/jruby-1.7.4@hockey-core/gems/ruby-debug-base-0.10.4-java/lib/ruby-debug-base.rb:205
  __send__ at org/jruby/RubyBasicObject.java:1709
      send at org/jruby/RubyKernel.java:2213
    notify at /Users/aportnov/.rvm/gems/jruby-1.7.4@hockey-core/gems/rspec-core-2.14.0/lib/rspec/core/reporter.rb:127
      each at org/jruby/RubyArray.java:1617
    notify at /Users/aportnov/.rvm/gems/jruby-1.7.4@hockey-core/gems/rspec-core-2.14.0/lib/rspec/core/reporter.rb:126
     start at /Users/aportnov/.rvm/gems/jruby-1.7.4@hockey-core/gems/rspec-core-2.14.0/lib/rspec/core/reporter.rb:66
    report at /Users/aportnov/.rvm/gems/jruby-1.7.4@hockey-core/gems/rspec-core-2.14.0/lib/rspec/core/reporter.rb:56
       run at /Users/aportnov/.rvm/gems/jruby-1.7.4@hockey-core/gems/rspec-core-2.14.0/lib/rspec/core/command_line.rb:25
       run at /Users/aportnov/.rvm/gems/jruby-1.7.4@hockey-core/gems/rspec-core-2.14.0/lib/rspec/core/runner.rb:80
   autorun at /Users/aportnov/.rvm/gems/jruby-1.7.4@hockey-core/gems/rspec-core-2.14.0/lib/rspec/core/runner.rb:17
```
