### PR TITLE
Restore simpler deprecation formatter fix

### DIFF
--- a/lib/rspec/core/formatters/deprecation_formatter.rb
+++ b/lib/rspec/core/formatters/deprecation_formatter.rb
@@ -8,6 +8,10 @@ module RSpec
           @count = 0
         end
 
+        def start(example_count=nil)
+          #no-op to fix #966
+        end
+
         def deprecation(data)
           @count += 1
           if data[:message]

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -21,7 +21,7 @@ module RSpec::Core
     # events to all registered listeners
     def register_listener(listener, *notifications)
       notifications.each do |notification|
-        @listeners[notification.to_sym] << listener if understands(listener, notification)
+        @listeners[notification.to_sym] << listener if listener.respond_to?(notification)
       end
       true
     end
@@ -127,19 +127,6 @@ module RSpec::Core
         formatter.send(event, *args, &block)
       end
     end
-
-    private
-      if Method.method_defined?(:owner) # 1.8.6 lacks Method#owner
-        def understands(listener, notification)
-          listener.respond_to?(notification) && listener.method(notification).owner != ::Kernel
-        end
-      else
-        def understands(listener, notification)
-          # Hack for 1.8.6
-          # {}.method(:=~).to_s # => "#<Method: Hash(Kernel)#=~>"
-          listener.respond_to?(notification) && !listener.method(notification).to_s.include('(Kernel)')
-        end
-      end
 
   end
 end

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -4,12 +4,29 @@ require 'tempfile'
 
 module RSpec::Core::Formatters
   describe DeprecationFormatter do
+    let(:deprecation_stream) { StringIO.new }
+    let(:summary_stream)     { StringIO.new }
+    let(:formatter) { DeprecationFormatter.new deprecation_stream, summary_stream }
+
+    def with_start_defined_on_kernel
+      return yield if ::Kernel.method_defined?(:start)
+
+      begin
+        ::Kernel.module_eval { def start(*); raise "boom"; end }
+        yield
+      ensure
+        ::Kernel.module_eval { undef start }
+      end
+    end
+
+    it 'does not blow up when `Kernel` defines `start`' do
+      with_start_defined_on_kernel do
+        reporter = ::RSpec::Core::Reporter.new(formatter)
+        reporter.start(3)
+      end
+    end
 
     describe "#deprecation" do
-      let(:deprecation_stream) { StringIO.new }
-      let(:summary_stream)     { StringIO.new }
-      let(:formatter) { DeprecationFormatter.new deprecation_stream, summary_stream }
-
       it "includes the method" do
         formatter.deprecation(:deprecated => "i_am_deprecated")
         deprecation_stream.rewind

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -120,28 +120,6 @@ module RSpec::Core
       end
     end
 
-    describe 'when message implemented on kernel' do
-      def with_message_defined_on_kernel
-        return yield if ::Kernel.method_defined?(:start)
-
-        begin
-          ::Kernel.module_eval { def start(*); raise "boom"; end }
-          yield
-        ensure
-          ::Kernel.module_eval { undef start }
-        end
-      end
-
-      let(:formatter) { double("formatter") }
-
-      it 'does not blow up when `Kernel` defines message instead of a formatter' do
-        with_message_defined_on_kernel do
-          reporter = ::RSpec::Core::Reporter.new(formatter)
-          reporter.start(3)
-        end
-      end
-    end
-
     describe "timing" do
       it "uses RSpec::Core::Time as to not be affected by changes to time in examples" do
         formatter = double(:formatter)


### PR DESCRIPTION
Given the implications of #968 this restores the simpler fix from #966 and #967 which whilst not perfect, should have virtually 0 side effects. The aim being to refactor the formatter/reporter relationship for RSpec 3 anyway.
