### PR TITLE
Use detail color instead of failure color for profile output.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,8 @@ Enhancements
 * Block-based DSL methods that run in the context of an example
   (`it`, `before(:each)`, `after(:each)`, `let` and `subject`)
   now yield the example as a block argument (David Chelimsky).
+* Times in profile output are now bold instead of failure_color.
+  (Matthew Boedicker)
 
 ### 2.14.3 / 2013-07-13
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.14.2...v2.14.3)

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -89,7 +89,7 @@ module RSpec
 
           sorted_examples.each do |example|
             output.puts "  #{example.full_description}"
-            output.puts detail_color("    #{failure_color(format_seconds(example.execution_result[:run_time]))} #{failure_color("seconds")} #{format_caller(example.location)}")
+            output.puts "    #{bold(format_seconds(example.execution_result[:run_time]))} #{bold("seconds")} #{format_caller(example.location)}"
           end
         end
 
@@ -117,11 +117,11 @@ module RSpec
 
           output.puts "\nTop #{sorted_groups.size} slowest example groups:"
           sorted_groups.each do |loc, hash| 
-            average = "#{failure_color(format_seconds(hash[:average]))} #{failure_color("seconds")} average"
+            average = "#{bold(format_seconds(hash[:average]))} #{bold("seconds")} average"
             total   = "#{format_seconds(hash[:total_time])} seconds"
             count   = pluralize(hash[:count], "example")
             output.puts "  #{hash[:description]}"
-            output.puts detail_color("    #{average} (#{total} / #{count}) #{loc}")
+            output.puts "    #{average} (#{total} / #{count}) #{loc}"
           end
         end
 


### PR DESCRIPTION
The red makes it look like something failed.

The outer calls to detail_color were not having any effect due to
internal colors.
