### PR TITLE
Deprecate autotest support in 2.99

### DIFF
--- a/lib/autotest/rspec2.rb
+++ b/lib/autotest/rspec2.rb
@@ -73,5 +73,5 @@ rescue LoadError
       File.exist?('./Gemfile')
     end
   end
-  Autotest.add_hook(:ran_command) { warn "\n\e[31mUsing the inbuilt rspec-core autotest support is deprecated and will be removed in RSpec 3. Please switch to rspec-autotest\e[0m" }
+  Autotest.add_hook(:ran_command) { warn "\n\e[31mUsing the built in rspec-core autotest support is deprecated and will be removed in RSpec 3. Please switch to the rspec-autotest gem\e[0m" }
 end


### PR DESCRIPTION
This will print a `Kernel.warn` line after each run of an rspec suite if someone isn't using `rspec-autotest`

I choose to deprecate this with a naked warn because otherwise I'd have to load parts of `rspec-core` into the autotest runner, which seemed unnecessary compared to a simple warning...
