### PR TITLE
Remove unneeded require of `rspec/core/project_initializer`.

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -28,7 +28,6 @@ require_rspec['core/formatters']
 
 require_rspec['core/world']
 require_rspec['core/configuration']
-require_rspec['core/project_initializer']
 require_rspec['core/option_parser']
 require_rspec['core/configuration_options']
 require_rspec['core/command_line']

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -96,6 +96,7 @@ module RSpec::Core
         end
 
         parser.on('--init', 'Initialize your project with RSpec.') do |cmd|
+          require 'rspec/core/project_initializer'
           ProjectInitializer.new(cmd).run
           exit
         end

--- a/spec/rspec/core/project_initializer_spec.rb
+++ b/spec/rspec/core/project_initializer_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'rspec/core/project_initializer'
 
 module RSpec::Core
   describe ProjectInitializer, :isolated_directory => true do


### PR DESCRIPTION
Each require takes time and it is a waste to require a file like this
that is so rarely used up front. Things that are rarely used should
be required at the point they are used rather than upfront.

@alindeman / @JonRowe / @soulcutter / @samphippen -- I'd like us to be more intentional about when we require files.  Requires add to the rspec boot time.  We should see where else we are requiring files unnecessarily.  It might also be worth looking into moving the contents of some smaller files into another one to cut down on the number of requires, given that known perf problems with `require` on 1.9. We shouldn't go too crazy and sacrifice maintainability, but I am curious to see how much it would help boot time to combine stuff into one file, just so we know how much of an affect it has.
