### PR TITLE
Revert "Remove color aliases on base text formatter."

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,6 @@
 Breaking Changes for 3.0.0:
 
 * Remove explicit support for 1.8.6 (Jon Rowe)
-* Remove color aliases on BaseTextFormatter. (Sam Phippen)
 * Remove `RSpec::Core::ExampleGroup#example` and
   `RSpec::Core::ExampleGroup#running_example` methods. If you need
   access to the example (e.g. to get its metadata), use a block arg

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -224,6 +224,41 @@ module RSpec
           color(text, RSpec.configuration.default_color)
         end
 
+        def red(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#red", :replacement => "#failure_color")
+          color(text, :red)
+        end
+
+        def green(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#green", :replacement => "#success_color")
+          color(text, :green)
+        end
+
+        def yellow(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#yellow", :replacement => "#pending_color")
+          color(text, :yellow)
+        end
+
+        def blue(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#blue", :replacement => "#fixed_color")
+          color(text, :blue)
+        end
+
+        def magenta(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#magenta")
+          color(text, :magenta)
+        end
+
+        def cyan(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#cyan", :replacement => "#detail_color")
+          color(text, :cyan)
+        end
+
+        def white(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#white", :replacement => "#default_color")
+          color(text, :white)
+        end
+
         def short_padding
           '  '
         end

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -380,4 +380,27 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
        expect(formatter.colorize('abc', :cyan)).to eq "\e[36mabc\e[0m"
     end
   end
+
+  described_class::VT100_COLORS.each do |name, number|
+    next if name == :black
+
+    describe "##{name}" do
+      before do
+        allow(RSpec.configuration).to receive(:color_enabled?) { true }
+        allow(RSpec).to receive(:deprecate)
+      end
+
+      it "prints the text using the color code for #{name}" do
+        expect(formatter.send(name, "text")).to eq("\e[#{number}mtext\e[0m")
+      end
+
+      it "prints a deprecation warning" do
+        expect(RSpec).to receive(:deprecate) {|*args|
+          expect(args.first).to match(/#{name}/)
+        }
+        formatter.send(name, "text")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This reverts commit 54744e4e53653fd4c312882992bc8f664ff8781c.

Conflicts:
    Changelog.md

Closes: #979
