### PR TITLE
Expose exe file location on 2-99

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -141,6 +141,12 @@ WARNING
         define_method(:now,&::Time.method(:now))
       end
     end
+
+    # @private path to executable file
+    def self.path_to_executable
+      File.expand_path('../../../exe/rspec', __FILE__)
+    end
+
   end
 
   def self.const_missing(name)

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -52,4 +52,10 @@ describe RSpec do
       expect(RSpec.world).not_to equal(world_before_reset)
     end
   end
+
+  describe "::Core.path_to_executable" do
+    it 'returns the absolute location of the exe/rspec file' do
+      expect(RSpec::Core.path_to_executable).to eq File.expand_path('../../../exe/rspec',__FILE__)
+    end
+  end
 end


### PR DESCRIPTION
For tools that run rspec (like `rspec-autotest`) it'd be helpful to have the `exe/rspec` location exposed.
