### PR TITLE
Force require (and libs) before spec files loaded. (master)

### DIFF
--- a/features/command_line/pattern_option.feature
+++ b/features/command_line/pattern_option.feature
@@ -29,3 +29,21 @@ Feature: pattern option
       """
     When I run `rspec --pattern "spec/**/*.spec"`
     Then the output should contain "1 example, 0 failures"
+
+  Scenario: override the default pattern in configuration
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+        RSpec.configure do |config|
+          config.pattern << ',**/*.spec'
+        end
+      """
+    And a file named "spec/example.spec" with:
+      """ruby
+      describe "addition" do
+        it "adds things" do
+          (1 + 2).should eq(3)
+        end
+      end
+      """
+    When I run `rspec -rspec_helper`
+    Then the output should contain "1 example, 0 failures"

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -20,10 +20,11 @@ module RSpec
 
       def configure(config)
         config.filter_manager = filter_manager
-        process_options_into config
 
+        config.libs = options[:libs] || []
         config.setup_load_path_and_require(options[:requires] || [])
 
+        process_options_into config
         load_formatters_into config
       end
 
@@ -46,13 +47,13 @@ module RSpec
     private
 
       NON_FORCED_OPTIONS = [
-        :requires, :libs, :profile, :drb, :files_or_directories_to_run,
+        :requires, :profile, :drb, :libs, :files_or_directories_to_run,
         :line_numbers, :full_description, :full_backtrace, :tty
       ].to_set
 
       MERGED_OPTIONS = [:requires, :libs].to_set
 
-      UNPROCESSABLE_OPTIONS = [:formatters, :requires].to_set
+      UNPROCESSABLE_OPTIONS = [:libs, :formatters, :requires].to_set
 
       def force?(key)
         !NON_FORCED_OPTIONS.include?(key)
@@ -68,7 +69,7 @@ module RSpec
       def process_options_into(config)
         opts = options.reject { |k, _| UNPROCESSABLE_OPTIONS.include? k }
 
-        order(opts.keys, :libs, :default_path, :pattern).each do |key|
+        order(opts.keys, :default_path, :pattern).each do |key|
           force?(key) ? config.force(key => opts[key]) : config.send("#{key}=", opts[key])
         end
       end

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -29,6 +29,14 @@ describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolat
       opts.configure(config)
     end
 
+    it "sends loads requires before loading specs" do
+      opts = config_options_object(*%w[-rspec_helper])
+      config = double("config").as_null_object
+      expect(config).to receive(:setup_load_path_and_require).ordered
+      expect(config).to receive(:files_or_directories_to_run=).ordered
+      opts.configure(config)
+    end
+
     it "sets up load path and requires before formatter" do
       opts = config_options_object(*%w[--require a/path -f a/formatter])
       config = double("config").as_null_object


### PR DESCRIPTION
This allows configuration of pattern and other things affecting the spec file loading to work. Fixes #993.
The regression from 2-13 to 2-14 was caused by the interaction of option processing with requires.

Picked across to 3.
