### PR TITLE
Autoload RSpec::Mocks and RSpec::Expectations (299)

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -149,20 +149,26 @@ WARNING
 
   end
 
+  MODULES_TO_AUTOLOAD = {
+    :Matchers     => "rspec/expectations",
+    :Expectations => "rspec/expectations",
+    :Mocks        => "rspec/mocks"
+  }
+
   def self.const_missing(name)
-    case name
-      when :Matchers
-        # Load rspec-expectations when RSpec::Matchers is referenced. This allows
-        # people to define custom matchers (using `RSpec::Matchers.define`) before
-        # rspec-core has loaded rspec-expectations (since it delays the loading of
-        # it to allow users to configure a different assertion/expectation
-        # framework). `autoload` can't be used since it works with ruby's built-in
-        # require (e.g. for files that are available relative to a load path dir),
-        # but not with rubygems' extended require.
-        require 'rspec/expectations'
-        ::RSpec::Matchers
-      else super
-    end
+    # Load rspec-expectations when RSpec::Matchers is referenced. This allows
+    # people to define custom matchers (using `RSpec::Matchers.define`) before
+    # rspec-core has loaded rspec-expectations (since it delays the loading of
+    # it to allow users to configure a different assertion/expectation
+    # framework). `autoload` can't be used since it works with ruby's built-in
+    # require (e.g. for files that are available relative to a load path dir),
+    # but not with rubygems' extended require.
+    #
+    # As of rspec 2.14.1, we no longer require `rspec/mocks` and
+    # `rspec/expectations` when `rspec` is required, so we want
+    # to make them available as an autoload. For more info, see:
+    require MODULES_TO_AUTOLOAD.fetch(name) { return super }
+    ::RSpec.const_get(name)
   end
 end
 

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -58,4 +58,22 @@ describe RSpec do
       expect(RSpec::Core.path_to_executable).to eq File.expand_path('../../../exe/rspec',__FILE__)
     end
   end
+
+  # This is hard to test :(. Best way I could come up with was starting
+  # fresh ruby process w/o this stuff already loaded.
+  it "loads mocks and expectations when the constants are referenced" do
+    code = "$LOAD_PATH.replace(#{$LOAD_PATH.inspect}); " +
+           'require "rspec"; ' +
+           "puts RSpec::Mocks.name; " +
+           "puts RSpec::Expectations.name"
+
+    result = `ruby -e '#{code}'`.chomp
+    expect(result.split("\n")).to eq(%w[ RSpec::Mocks RSpec::Expectations ])
+  end
+
+  it 'correctly raises an error when an invalid const is referenced' do
+    expect {
+      RSpec::NotAConst
+    }.to raise_error(NameError, /uninitialized constant RSpec::NotAConst/)
+  end
 end


### PR DESCRIPTION
> We already autoload RSpec::Matchers to support folks using
> `RSpec::Matchers.define` before the normal time that rspec-core
> loads rspec-expectation (e.g. right before eval'ing the first
> example group block). This extends it to RSpec::Mocks and
> RSpec::Expectations for parity and to improve things for folks
> who we accidentally broke via this rspec gem change:
> 
> https://github.com/rspec/rspec/commit/f10bedd498dff2961d4be9cce793fa152c4a0bbe
> 
> That was put in place to address rspec/rspec-mocks#359, which has more info.

Based off master
