### PR TITLE
alias_example_to cuke shows how to define `fit` as if it's not part of rspec-core but it is now

### DIFF
--- a/features/configuration/alias_example_to.feature
+++ b/features/configuration/alias_example_to.feature
@@ -6,43 +6,37 @@ Feature: alias_example_to
   If you set the `treat_symbols_as_metadata_keys_with_true_values` config option
   to `true`, you can specify metadata using only symbols.
 
-  Scenario: Use alias_example_to to define focused example
+  Scenario: Use alias_example_to to define pending example
     Given a file named "alias_example_to_spec.rb" with:
       """ruby
       RSpec.configure do |c|
-        c.alias_example_to :fit, :focused => true
-        c.filter_run :focused => true
+        c.alias_example_to :pit, :pending => "Pit alias used"
       end
 
       describe "an example group" do
-        it "does one thing" do
-        end
-
-        fit "does another thing" do
+        pit "does something later on" do
+          fail "not implemented yet"
         end
       end
       """
     When I run `rspec alias_example_to_spec.rb --format doc`
-    Then the output should contain "does another thing"
-    And the output should not contain "does one thing"
+    Then the output should contain "does something later on (PENDING: Pit alias used)"
+    And the output should contain "0 failures"
 
   Scenario: use symbols as metadata
     Given a file named "use_symbols_as_metadata_spec.rb" with:
       """ruby
       RSpec.configure do |c|
         c.treat_symbols_as_metadata_keys_with_true_values = true
-        c.alias_example_to :fit, :focused
-        c.filter_run :focused
+        c.alias_example_to :pit, :pending
       end
 
       describe "an example group" do
-        it "does one thing" do
-        end
-
-        fit "does another thing" do
+        pit "does something later on" do
+          fail "not implemented yet"
         end
       end
       """
     When I run `rspec use_symbols_as_metadata_spec.rb --format doc`
-    Then the output should contain "does another thing"
-    And the output should not contain "does one thing"
+    Then the output should contain "does something later on (PENDING: No reason given)"
+    And the output should contain "0 failures"


### PR DESCRIPTION
The cuke should be updated to show a different example of `alias_example_to`.
