### PR TITLE
Fixing nilclass error when clearing shared example groups

### DIFF
--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -91,7 +91,7 @@ module RSpec
         end
 
         def clear
-          @shared_example_groups.clear
+          shared_example_groups.clear
         end
 
       private


### PR DESCRIPTION
Problem occurred for me on startup when running guard-jruby-rspec on windows.
