### PR TITLE
Switch to be_truthy and be_falsey

### DIFF
--- a/features/configuration/custom_settings.feature
+++ b/features/configuration/custom_settings.feature
@@ -15,17 +15,17 @@ Feature: custom settings
         end
 
         it "acts false by default" do
-          RSpec.configuration.custom_setting.should be_false
+          RSpec.configuration.custom_setting.should be_falsey
         end
 
         it "is exposed as a predicate" do
-          RSpec.configuration.custom_setting?.should be_false
+          RSpec.configuration.custom_setting?.should be_falsey
         end
 
         it "can be overridden" do
           RSpec.configuration.custom_setting = true
-          RSpec.configuration.custom_setting.should be_true
-          RSpec.configuration.custom_setting?.should be_true
+          RSpec.configuration.custom_setting.should be_truthy
+          RSpec.configuration.custom_setting?.should be_truthy
         end
       end
       """
@@ -41,17 +41,17 @@ Feature: custom settings
 
       describe "custom setting" do
         it "is true by default" do
-          RSpec.configuration.custom_setting.should be_true
+          RSpec.configuration.custom_setting.should be_truthy
         end
 
         it "is exposed as a predicate" do
-          RSpec.configuration.custom_setting?.should be_true
+          RSpec.configuration.custom_setting?.should be_truthy
         end
 
         it "can be overridden" do
           RSpec.configuration.custom_setting = false
-          RSpec.configuration.custom_setting.should be_false
-          RSpec.configuration.custom_setting?.should be_false
+          RSpec.configuration.custom_setting.should be_falsey
+          RSpec.configuration.custom_setting?.should be_falsey
         end
       end
       """
@@ -71,11 +71,11 @@ Feature: custom settings
 
       describe "custom setting" do
         it "returns the value set in the last cofigure block to get eval'd" do
-          RSpec.configuration.custom_setting.should be_true
+          RSpec.configuration.custom_setting.should be_truthy
         end
 
         it "is exposed as a predicate" do
-          RSpec.configuration.custom_setting?.should be_true
+          RSpec.configuration.custom_setting?.should be_truthy
         end
       end
       """

--- a/features/configuration/read_options_from_file.feature
+++ b/features/configuration/read_options_from_file.feature
@@ -66,7 +66,7 @@ Feature: read command line configuration options from files
       """ruby
       describe "custom options file" do
         it "causes .rspec to be ignored" do
-          RSpec.configuration.color_enabled.should be_false
+          RSpec.configuration.color_enabled.should be_falsey
         end
       end
       """

--- a/features/example_groups/shared_examples.feature
+++ b/features/example_groups/shared_examples.feature
@@ -53,13 +53,13 @@ Feature: shared examples
         describe "#include?" do
           context "with an an item that is in the collection" do
             it "returns true" do
-              collection.include?(7).should be_true
+              collection.include?(7).should be_truthy
             end
           end
 
           context "with an an item that is not in the collection" do
             it "returns false" do
-              collection.include?(9).should be_false
+              collection.include?(9).should be_falsey
             end
           end
         end

--- a/features/hooks/around_hooks.feature
+++ b/features/hooks/around_hooks.feature
@@ -192,7 +192,7 @@ Feature: around hooks
         end
 
         it "runs the example in the correct context" do
-          included_in_configure_block.should be_true
+          included_in_configure_block.should be_truthy
         end
       end
       """

--- a/spec/rspec/core/backtrace_cleaner_spec.rb
+++ b/spec/rspec/core/backtrace_cleaner_spec.rb
@@ -6,55 +6,55 @@ module RSpec::Core
       it "keeps all lines" do
         lines = ["/tmp/a_file", "some_random_text", "hello\330\271!"]
         cleaner = BacktraceCleaner.new([], [])
-        expect(lines.all? {|line| cleaner.exclude? line}).to be_false
+        expect(lines.all? {|line| cleaner.exclude? line}).to be_falsey
       end
 
       it 'is considered a full backtrace' do
-        expect(BacktraceCleaner.new([], []).full_backtrace?).to be_true
+        expect(BacktraceCleaner.new([], []).full_backtrace?).to be_truthy
       end
     end
 
     context "with an exclusion pattern but no inclusion patterns" do
       it "excludes lines that match the exclusion pattern" do
         cleaner = BacktraceCleaner.new([], [/remove/])
-        expect(cleaner.exclude? "remove me").to be_true
+        expect(cleaner.exclude? "remove me").to be_truthy
       end
 
       it "keeps lines that do not match the exclusion pattern" do
         cleaner = BacktraceCleaner.new([], [/remove/])
-        expect(cleaner.exclude? "apple").to be_false
+        expect(cleaner.exclude? "apple").to be_falsey
       end
 
       it 'is considered a partial backtrace' do
-        expect(BacktraceCleaner.new([], [/remove/]).full_backtrace?).to be_false
+        expect(BacktraceCleaner.new([], [/remove/]).full_backtrace?).to be_falsey
       end
     end
 
     context "with an exclusion pattern and an inclusion pattern" do
       it "excludes lines that match the exclusion pattern but not the inclusion pattern" do
         cleaner = BacktraceCleaner.new([/keep/], [/discard/])
-        expect(cleaner.exclude? "discard").to be_true
+        expect(cleaner.exclude? "discard").to be_truthy
       end
 
       it "keeps lines that match the inclusion pattern and the exclusion pattern" do
         cleaner = BacktraceCleaner.new([/hi/], [/.*/])
-        expect(cleaner.exclude? "hi").to be_false
+        expect(cleaner.exclude? "hi").to be_falsey
       end
 
       it "keeps lines that match neither pattern" do
         cleaner = BacktraceCleaner.new([/hi/], [/delete/])
-        expect(cleaner.exclude? "fish").to be_false
+        expect(cleaner.exclude? "fish").to be_falsey
       end
 
       it 'is considered a partial backtrace' do
-        expect(BacktraceCleaner.new([], [/remove/]).full_backtrace?).to be_false
+        expect(BacktraceCleaner.new([], [/remove/]).full_backtrace?).to be_falsey
       end
     end
 
     context "with an exclusion pattern that matches the current working directory" do
       it "defaults to having one inclusion pattern, the current working directory" do
         cleaner = BacktraceCleaner.new(nil, [/.*/])
-        expect(Dir.getwd =~ cleaner.inclusion_patterns.first).to be_true
+        expect(Dir.getwd =~ cleaner.inclusion_patterns.first).to be_truthy
       end
     end
 

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -217,15 +217,15 @@ describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolat
 
   describe "--fail-fast" do
     it "defaults to false" do
-      expect(parse_options[:fail_fast]).to be_false
+      expect(parse_options[:fail_fast]).to be_falsey
     end
 
     it "sets fail_fast on config" do
-      expect(parse_options("--fail-fast")[:fail_fast]).to be_true
+      expect(parse_options("--fail-fast")[:fail_fast]).to be_truthy
     end
 
     it "sets fail_fast on config" do
-      expect(parse_options("--no-fail-fast")[:fail_fast]).to be_false
+      expect(parse_options("--no-fail-fast")[:fail_fast]).to be_falsey
     end
   end
 
@@ -315,10 +315,10 @@ describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolat
       File.open(File.expand_path("~/.rspec"), "w") {|f| f << "--color"}
       with_env_vars 'SPEC_OPTS' => "--example 'foo bar'" do
         options = parse_options("--drb")
-        expect(options[:color]).to be_true
+        expect(options[:color]).to be_truthy
         expect(options[:line_numbers]).to eq(["37"])
         expect(options[:full_description]).to eq([/foo\ bar/])
-        expect(options[:drb]).to be_true
+        expect(options[:drb]).to be_truthy
         expect(options[:formatters]).to eq([['global']])
       end
     end
@@ -364,7 +364,7 @@ describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolat
         File.open("./custom.opts", "w") {|f| f << "--color"}
         options = parse_options("-O", "./custom.opts")
         expect(options[:format]).to be_nil
-        expect(options[:color]).to be_true
+        expect(options[:color]).to be_truthy
       end
 
       it "parses -e 'full spec description'" do

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -94,12 +94,12 @@ module RSpec::Core
 
     describe "#treat_symbols_as_metadata_keys_with_true_values?" do
       it 'defaults to false' do
-        expect(config.treat_symbols_as_metadata_keys_with_true_values?).to be_false
+        expect(config.treat_symbols_as_metadata_keys_with_true_values?).to be_falsey
       end
 
       it 'can be set to true' do
         config.treat_symbols_as_metadata_keys_with_true_values = true
-        expect(config.treat_symbols_as_metadata_keys_with_true_values?).to be_true
+        expect(config.treat_symbols_as_metadata_keys_with_true_values?).to be_truthy
       end
     end
 
@@ -127,7 +127,7 @@ module RSpec::Core
           mod_config.custom_setting = true
         end
 
-        expect(custom_config.custom_setting).to be_true
+        expect(custom_config.custom_setting).to be_truthy
       end
 
       it "raises if framework module doesn't support configuration" do
@@ -639,12 +639,12 @@ module RSpec::Core
     describe "#run_all_when_everything_filtered?" do
 
       it "defaults to false" do
-        expect(config.run_all_when_everything_filtered?).to be_false
+        expect(config.run_all_when_everything_filtered?).to be_falsey
       end
 
       it "can be queried with question method" do
         config.run_all_when_everything_filtered = true
-        expect(config.run_all_when_everything_filtered?).to be_true
+        expect(config.run_all_when_everything_filtered?).to be_truthy
       end
     end
 
@@ -661,8 +661,8 @@ module RSpec::Core
               config.tty = true
               config.output_stream.stub :tty? => true
 
-              expect(config.send(color_option)).to be_true
-              expect(config.send(color_option, output)).to be_true
+              expect(config.send(color_option)).to be_truthy
+              expect(config.send(color_option, output)).to be_truthy
             end
           end
 
@@ -674,8 +674,8 @@ module RSpec::Core
               config.tty = true
               config.output_stream.stub :tty? => false
 
-              expect(config.send(color_option)).to be_true
-              expect(config.send(color_option, output)).to be_true
+              expect(config.send(color_option)).to be_truthy
+              expect(config.send(color_option, output)).to be_truthy
             end
           end
 
@@ -687,8 +687,8 @@ module RSpec::Core
               config.tty = false
               config.output_stream.stub :tty? => true
 
-              expect(config.send(color_option)).to be_true
-              expect(config.send(color_option, output)).to be_true
+              expect(config.send(color_option)).to be_truthy
+              expect(config.send(color_option, output)).to be_truthy
             end
           end
 
@@ -700,8 +700,8 @@ module RSpec::Core
               config.tty = false
               config.output_stream.stub :tty? => false
 
-              expect(config.send(color_option)).to be_false
-              expect(config.send(color_option, output)).to be_false
+              expect(config.send(color_option)).to be_falsey
+              expect(config.send(color_option, output)).to be_falsey
             end
           end
 
@@ -724,7 +724,7 @@ module RSpec::Core
                 config.output_stream = StringIO.new
                 config.output_stream.stub :tty? => true
                 config.send "#{color_option}=", true
-                expect(config.send(color_option)).to be_true
+                expect(config.send(color_option)).to be_truthy
               end
 
               it "leaves output stream intact" do
@@ -749,7 +749,7 @@ module RSpec::Core
                 config.stub(:require) { raise LoadError }
                 config.send "#{color_option}=", true
                 config.color_enabled = true
-                expect(config.send(color_option)).to be_false
+                expect(config.send(color_option)).to be_falsey
               end
             end
           end
@@ -761,7 +761,7 @@ module RSpec::Core
         config.output_stream.stub :tty? => true
         config.force :color => true
         config.color = false
-        expect(config.color).to be_true
+        expect(config.color).to be_truthy
       end
     end
 
@@ -919,29 +919,29 @@ module RSpec::Core
 
       describe "the default :if filter" do
         it "does not exclude a spec with  { :if => true } metadata" do
-          expect(config.exclusion_filter[:if].call(true)).to be_false
+          expect(config.exclusion_filter[:if].call(true)).to be_falsey
         end
 
         it "excludes a spec with  { :if => false } metadata" do
-          expect(config.exclusion_filter[:if].call(false)).to be_true
+          expect(config.exclusion_filter[:if].call(false)).to be_truthy
         end
 
         it "excludes a spec with  { :if => nil } metadata" do
-          expect(config.exclusion_filter[:if].call(nil)).to be_true
+          expect(config.exclusion_filter[:if].call(nil)).to be_truthy
         end
       end
 
       describe "the default :unless filter" do
         it "excludes a spec with  { :unless => true } metadata" do
-          expect(config.exclusion_filter[:unless].call(true)).to be_true
+          expect(config.exclusion_filter[:unless].call(true)).to be_truthy
         end
 
         it "does not exclude a spec with { :unless => false } metadata" do
-          expect(config.exclusion_filter[:unless].call(false)).to be_false
+          expect(config.exclusion_filter[:unless].call(false)).to be_falsey
         end
 
         it "does not exclude a spec with { :unless => nil } metadata" do
-          expect(config.exclusion_filter[:unless].call(nil)).to be_false
+          expect(config.exclusion_filter[:unless].call(nil)).to be_falsey
         end
       end
     end
@@ -1020,7 +1020,7 @@ module RSpec::Core
       it "actually receives the new filter values" do
         config = Configuration.new
         config.backtrace_exclusion_patterns = [/.*/]
-        expect(config.backtrace_cleaner.exclude? "this").to be_true
+        expect(config.backtrace_cleaner.exclude? "this").to be_truthy
       end
     end
 
@@ -1040,33 +1040,33 @@ module RSpec::Core
       it "can be appended to" do
         config = Configuration.new
         config.backtrace_exclusion_patterns << /.*/
-        expect(config.backtrace_cleaner.exclude? "this").to be_true
+        expect(config.backtrace_cleaner.exclude? "this").to be_truthy
       end
     end
 
     describe ".backtrace_cleaner#exclude? defaults" do
       it "returns true for rspec files" do
-        expect(config.backtrace_cleaner.exclude?("lib/rspec/core.rb")).to be_true
+        expect(config.backtrace_cleaner.exclude?("lib/rspec/core.rb")).to be_truthy
       end
 
       it "returns true for spec_helper" do
-        expect(config.backtrace_cleaner.exclude?("spec/spec_helper.rb")).to be_true
+        expect(config.backtrace_cleaner.exclude?("spec/spec_helper.rb")).to be_truthy
       end
 
       it "returns true for java files (for JRuby)" do
-        expect(config.backtrace_cleaner.exclude?("org/jruby/RubyArray.java:2336")).to be_true
+        expect(config.backtrace_cleaner.exclude?("org/jruby/RubyArray.java:2336")).to be_truthy
       end
 
       it "returns true for files within installed gems" do
-        expect(config.backtrace_cleaner.exclude?('ruby-1.8.7-p334/gems/mygem-2.3.0/lib/mygem.rb')).to be_true
+        expect(config.backtrace_cleaner.exclude?('ruby-1.8.7-p334/gems/mygem-2.3.0/lib/mygem.rb')).to be_truthy
       end
 
       it "returns false for files in projects containing 'gems' in the name" do
-        expect(config.backtrace_cleaner.exclude?('code/my-gems-plugin/lib/plugin.rb')).to be_false
+        expect(config.backtrace_cleaner.exclude?('code/my-gems-plugin/lib/plugin.rb')).to be_falsey
       end
 
       it "returns false for something in the current working directory" do
-        expect(config.backtrace_cleaner.exclude?("#{Dir.getwd}/arbitrary")).to be_false
+        expect(config.backtrace_cleaner.exclude?("#{Dir.getwd}/arbitrary")).to be_falsey
       end
     end
 
@@ -1124,7 +1124,7 @@ module RSpec::Core
           end
 
           it "adds a predicate" do
-            expect(config.custom_option?).to be_false
+            expect(config.custom_option?).to be_falsey
           end
 
           it "can be overridden" do
@@ -1143,7 +1143,7 @@ module RSpec::Core
           end
 
           it "returns true for the predicate" do
-            expect(config.custom_option?).to be_true
+            expect(config.custom_option?).to be_truthy
           end
 
           it "can be overridden with a truthy value" do
@@ -1188,7 +1188,7 @@ module RSpec::Core
 
         it "delegates the predicate to the other option" do
           config.custom_option = true
-          expect(config.another_custom_option?).to be_true
+          expect(config.another_custom_option?).to be_truthy
         end
       end
     end
@@ -1335,11 +1335,11 @@ module RSpec::Core
       it "forces 'false' value" do
         config.add_setting :custom_option
         config.custom_option = true
-        expect(config.custom_option?).to be_true
+        expect(config.custom_option?).to be_truthy
         config.force :custom_option => false
-        expect(config.custom_option?).to be_false
+        expect(config.custom_option?).to be_falsey
         config.custom_option = true
-        expect(config.custom_option?).to be_false
+        expect(config.custom_option?).to be_falsey
       end
     end
 
@@ -1355,7 +1355,7 @@ module RSpec::Core
         before { config.order = :random }
 
         it 'returns true' do
-          expect(config.randomize?).to be_true
+          expect(config.randomize?).to be_truthy
         end
       end
 
@@ -1363,7 +1363,7 @@ module RSpec::Core
         before { config.order = nil }
 
         it 'returns false' do
-          expect(config.randomize?).to be_false
+          expect(config.randomize?).to be_falsey
         end
       end
     end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -298,7 +298,7 @@ module RSpec::Core
               end
             end
 
-            expect(group.run).to be_true
+            expect(group.run).to be_truthy
           end
         end
 
@@ -314,7 +314,7 @@ module RSpec::Core
               end
             end
 
-            expect(group.run).to be_true
+            expect(group.run).to be_truthy
           end
         end
       end
@@ -329,7 +329,7 @@ module RSpec::Core
             end
           end
 
-          expect(group.run).to be_true, "expected examples in group to pass"
+          expect(group.run).to be_truthy, "expected examples in group to pass"
         end
       end
 
@@ -402,11 +402,11 @@ module RSpec::Core
         let(:focused_example) { ExampleGroup.describe.send example_alias, "a focused example" }
 
         it 'defines an example that can be filtered with :focused => true' do
-          expect(focused_example.metadata[:focused]).to be_true
+          expect(focused_example.metadata[:focused]).to be_truthy
         end
 
         it 'defines an example that can be filtered with :focus => true' do
-          expect(focused_example.metadata[:focus]).to be_true
+          expect(focused_example.metadata[:focus]).to be_truthy
         end
       end
     end
@@ -431,7 +431,7 @@ module RSpec::Core
         group.example("example") {}
 
         group.run
-        expect(RSpec.wants_to_quit).to be_false
+        expect(RSpec.wants_to_quit).to be_falsey
       end
 
       it "runs the before eachs in order" do
@@ -594,7 +594,7 @@ module RSpec::Core
         group = ExampleGroup.describe
         group.before(:all) { raise "error in before all" }
         example = group.example("equality") { expect(1).to eq(2) }
-        expect(group.run).to be_false
+        expect(group.run).to be_falsey
 
         expect(example.metadata).not_to be_nil
         expect(example.metadata[:execution_result]).not_to be_nil
@@ -766,7 +766,7 @@ module RSpec::Core
           example('ex 2') { expect(1).to eq(1) }
         end
         group.stub(:filtered_examples) { group.examples.extend(Extensions::Ordered::Examples) }
-        expect(group.run(reporter)).to be_true
+        expect(group.run(reporter)).to be_truthy
       end
 
       it "returns false if any of the examples fail" do
@@ -775,7 +775,7 @@ module RSpec::Core
           example('ex 2') { expect(1).to eq(2) }
         end
         group.stub(:filtered_examples) { group.examples.extend(Extensions::Ordered::Examples) }
-        expect(group.run(reporter)).to be_false
+        expect(group.run(reporter)).to be_falsey
       end
 
       it "runs all examples, regardless of any of them failing" do
@@ -787,7 +787,7 @@ module RSpec::Core
         group.filtered_examples.each do |example|
           example.should_receive(:run)
         end
-        expect(group.run(reporter)).to be_false
+        expect(group.run(reporter)).to be_falsey
       end
     end
 
@@ -841,12 +841,12 @@ module RSpec::Core
     describe "ivars are not shared across examples" do
       it "(first example)" do
         @a = 1
-        expect(defined?(@b)).to be_false
+        expect(defined?(@b)).to be_falsey
       end
 
       it "(second example)" do
         @b = 2
-        expect(defined?(@a)).to be_false
+        expect(defined?(@a)).to be_falsey
       end
     end
 
@@ -889,8 +889,8 @@ module RSpec::Core
         it "sets RSpec.wants_to_quit flag if encountering an exception in before(:all)" do
           group.before(:all) { raise "error in before all" }
           group.example("equality") { expect(1).to eq(2) }
-          expect(group.run).to be_false
-          expect(RSpec.wants_to_quit).to be_true
+          expect(group.run).to be_falsey
+          expect(RSpec.wants_to_quit).to be_truthy
         end
       end
 
@@ -936,7 +936,7 @@ module RSpec::Core
             end
           end
 
-          expect(group.run(reporter)).to be_true
+          expect(group.run(reporter)).to be_truthy
         end
       end
 
@@ -953,7 +953,7 @@ module RSpec::Core
             end
           end
 
-          expect(group.run(reporter)).to be_false
+          expect(group.run(reporter)).to be_falsey
         end
       end
 
@@ -970,7 +970,7 @@ module RSpec::Core
             end
           end
 
-          expect(group.run(reporter)).to be_false
+          expect(group.run(reporter)).to be_falsey
         end
       end
     end
@@ -1042,7 +1042,7 @@ module RSpec::Core
               def foo; "bar"; end
             end
           end
-          expect(group.run).to be_true
+          expect(group.run).to be_truthy
         end
       end
     end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -203,7 +203,7 @@ describe RSpec::Core::Example, :parent_metadata => 'sample' do
         example('example') { expect(1).to eq(1) }
       end
       group.run
-      expect(after_run).to be_true, "expected after(:each) to be run"
+      expect(after_run).to be_truthy, "expected after(:each) to be run"
     end
 
     it "runs after(:each) when the example fails" do
@@ -213,7 +213,7 @@ describe RSpec::Core::Example, :parent_metadata => 'sample' do
         example('example') { expect(1).to eq(2) }
       end
       group.run
-      expect(after_run).to be_true, "expected after(:each) to be run"
+      expect(after_run).to be_truthy, "expected after(:each) to be run"
     end
 
     it "runs after(:each) when the example raises an Exception" do
@@ -223,7 +223,7 @@ describe RSpec::Core::Example, :parent_metadata => 'sample' do
         example('example') { raise "this error" }
       end
       group.run
-      expect(after_run).to be_true, "expected after(:each) to be run"
+      expect(after_run).to be_truthy, "expected after(:each) to be run"
     end
 
     context "with an after(:each) that raises" do
@@ -235,7 +235,7 @@ describe RSpec::Core::Example, :parent_metadata => 'sample' do
           example('example') { expect(1).to eq(1) }
         end
         group.run
-        expect(after_run).to be_true, "expected after(:each) to be run"
+        expect(after_run).to be_truthy, "expected after(:each) to be run"
       end
 
       it "stores the exception" do
@@ -284,7 +284,7 @@ describe RSpec::Core::Example, :parent_metadata => 'sample' do
           expect(@before_all).to eq(:before_all)
           expect(@before_each).to eq(:before_each)
         end
-        expect(group.run(double.as_null_object)).to be_true
+        expect(group.run(double.as_null_object)).to be_truthy
         group.new do |example|
           %w[@before_all @before_each @after_each @after_all].each do |ivar|
             expect(example.instance_variable_get(ivar)).to be_nil
@@ -298,7 +298,7 @@ describe RSpec::Core::Example, :parent_metadata => 'sample' do
           example("first") { expect(@before_all).not_to be_nil }
           example("second") { expect(@before_all).not_to be_nil }
         end
-        expect(group.run).to be_true
+        expect(group.run).to be_truthy
       end
     end
 

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -82,7 +82,7 @@ module RSpec::Core
               subject
               subject
             end
-            expect(group.run).to be_true, "expected subject block to be evaluated only once"
+            expect(group.run).to be_truthy, "expected subject block to be evaluated only once"
           end
         end
       end
@@ -343,7 +343,7 @@ module RSpec::Core
           it { should_not be_not_ok }
         end
 
-        expect(group.run).to be_true
+        expect(group.run).to be_truthy
       end
     end
 
@@ -443,7 +443,7 @@ module RSpec::Core
             end
           end
 
-          expect(group.run).to be_true
+          expect(group.run).to be_truthy
         end
       end
 

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -69,27 +69,27 @@ module RSpec
           it "matches the group when the line_number is the example group line number" do
             # this call doesn't really make sense since filter_applies? is only called
             # for example metadata not group metadata
-            expect(group_metadata.filter_applies?(condition_key, group_condition)).to be_true
+            expect(group_metadata.filter_applies?(condition_key, group_condition)).to be_truthy
           end
 
           it "matches the example when the line_number is the grandparent example group line number" do
-            expect(example_metadata.filter_applies?(condition_key, parent_group_condition)).to be_true
+            expect(example_metadata.filter_applies?(condition_key, parent_group_condition)).to be_truthy
           end
 
           it "matches the example when the line_number is the parent example group line number" do
-            expect(example_metadata.filter_applies?(condition_key, group_condition)).to be_true
+            expect(example_metadata.filter_applies?(condition_key, group_condition)).to be_truthy
           end
 
           it "matches the example when the line_number is the example line number" do
-            expect(example_metadata.filter_applies?(condition_key, example_condition)).to be_true
+            expect(example_metadata.filter_applies?(condition_key, example_condition)).to be_truthy
           end
 
           it "matches when the line number is between this example and the next" do
-            expect(example_metadata.filter_applies?(condition_key, between_examples_condition)).to be_true
+            expect(example_metadata.filter_applies?(condition_key, between_examples_condition)).to be_truthy
           end
 
           it "does not match when the line number matches the next example" do
-            expect(example_metadata.filter_applies?(condition_key, next_example_condition)).to be_false
+            expect(example_metadata.filter_applies?(condition_key, next_example_condition)).to be_falsey
           end
         end
 
@@ -136,25 +136,25 @@ module RSpec
           it_has_behavior "matching by line number"
 
           it "ignores location filters for other files" do
-            expect(example_metadata.filter_applies?(:locations, {"/path/to/other_spec.rb" => [3,5,7]})).to be_true
+            expect(example_metadata.filter_applies?(:locations, {"/path/to/other_spec.rb" => [3,5,7]})).to be_truthy
           end
         end
 
         it "matches a proc with no arguments that evaluates to true" do
-          expect(example_metadata.filter_applies?(:if, lambda { true })).to be_true
+          expect(example_metadata.filter_applies?(:if, lambda { true })).to be_truthy
         end
 
         it "matches a proc that evaluates to true" do
-          expect(example_metadata.filter_applies?(:if, lambda { |v| v })).to be_true
+          expect(example_metadata.filter_applies?(:if, lambda { |v| v })).to be_truthy
         end
 
         it "does not match a proc that evaluates to false" do
-          expect(example_metadata.filter_applies?(:if, lambda { |v| !v })).to be_false
+          expect(example_metadata.filter_applies?(:if, lambda { |v| !v })).to be_falsey
         end
 
         it "matches a proc with an arity of 2" do
           example_metadata[:foo] = nil
-          expect(example_metadata.filter_applies?(:foo, lambda { |v, m| m == example_metadata })).to be_true
+          expect(example_metadata.filter_applies?(:foo, lambda { |v, m| m == example_metadata })).to be_truthy
         end
 
         it "raises an error when the proc has an incorrect arity" do
@@ -169,35 +169,35 @@ module RSpec
           }
 
           it "matches a symbol" do
-            expect(metadata_with_array.filter_applies?(:tag, 'one')).to be_true
-            expect(metadata_with_array.filter_applies?(:tag, :one)).to be_true
-            expect(metadata_with_array.filter_applies?(:tag, 'two')).to be_false
+            expect(metadata_with_array.filter_applies?(:tag, 'one')).to be_truthy
+            expect(metadata_with_array.filter_applies?(:tag, :one)).to be_truthy
+            expect(metadata_with_array.filter_applies?(:tag, 'two')).to be_falsey
           end
 
           it "matches a string" do
-            expect(metadata_with_array.filter_applies?(:tag, 'three')).to be_true
-            expect(metadata_with_array.filter_applies?(:tag, :three)).to be_true
-            expect(metadata_with_array.filter_applies?(:tag, 'tree')).to be_false
+            expect(metadata_with_array.filter_applies?(:tag, 'three')).to be_truthy
+            expect(metadata_with_array.filter_applies?(:tag, :three)).to be_truthy
+            expect(metadata_with_array.filter_applies?(:tag, 'tree')).to be_falsey
           end
 
           it "matches an integer" do
-            expect(metadata_with_array.filter_applies?(:tag, '2')).to be_true
-            expect(metadata_with_array.filter_applies?(:tag, 2)).to be_true
-            expect(metadata_with_array.filter_applies?(:tag, 3)).to be_false
+            expect(metadata_with_array.filter_applies?(:tag, '2')).to be_truthy
+            expect(metadata_with_array.filter_applies?(:tag, 2)).to be_truthy
+            expect(metadata_with_array.filter_applies?(:tag, 3)).to be_falsey
           end
 
           it "matches a regexp" do
-            expect(metadata_with_array.filter_applies?(:tag, 'four')).to be_true
-            expect(metadata_with_array.filter_applies?(:tag, 'fourtune')).to be_true
-            expect(metadata_with_array.filter_applies?(:tag, 'fortune')).to be_false
+            expect(metadata_with_array.filter_applies?(:tag, 'four')).to be_truthy
+            expect(metadata_with_array.filter_applies?(:tag, 'fourtune')).to be_truthy
+            expect(metadata_with_array.filter_applies?(:tag, 'fortune')).to be_falsey
           end
 
           it "matches a proc that evaluates to true" do
-            expect(metadata_with_array.filter_applies?(:tag, lambda { |values| values.include? 'three' })).to be_true
+            expect(metadata_with_array.filter_applies?(:tag, lambda { |values| values.include? 'three' })).to be_truthy
           end
 
           it "does not match a proc that evaluates to false" do
-            expect(metadata_with_array.filter_applies?(:tag, lambda { |values| values.include? 'nothing' })).to be_false
+            expect(metadata_with_array.filter_applies?(:tag, lambda { |values| values.include? 'nothing' })).to be_falsey
           end
         end
       end

--- a/spec/rspec/core/project_initializer_spec.rb
+++ b/spec/rspec/core/project_initializer_spec.rb
@@ -83,13 +83,13 @@ module RSpec::Core
           it "removes it if confirmed" do
             command_line_config.stub(:gets => 'yes')
             command_line_config.run
-            expect(File.exist?('autotest/discover.rb')).to be_false
+            expect(File.exist?('autotest/discover.rb')).to be_falsey
           end
 
           it "leaves it if not confirmed" do
             command_line_config.stub(:gets => 'no')
             command_line_config.run
-            expect(File.exist?('autotest/discover.rb')).to be_true
+            expect(File.exist?('autotest/discover.rb')).to be_truthy
           end
         end
 
@@ -107,13 +107,13 @@ module RSpec::Core
           it "removes it if confirmed" do
             command_line_config.stub(:gets => 'yes')
             command_line_config.run
-            expect(File.exist?('lib/tasks/rspec.rake')).to be_false
+            expect(File.exist?('lib/tasks/rspec.rake')).to be_falsey
           end
 
           it "leaves it if not confirmed" do
             command_line_config.stub(:gets => 'no')
             command_line_config.run
-            expect(File.exist?('lib/tasks/rspec.rake')).to be_true
+            expect(File.exist?('lib/tasks/rspec.rake')).to be_truthy
           end
         end
       end

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -29,7 +29,7 @@ module RSpec::Core
         end
 
         task.should_receive(:run_task) { true }
-        expect(Rake.application.invoke_task("rake_task_args[first_spec.rb]")).to be_true
+        expect(Rake.application.invoke_task("rake_task_args[first_spec.rb]")).to be_truthy
       end
     end
 
@@ -88,7 +88,7 @@ module RSpec::Core
       # since the config block is deferred til task invocation, must fake
       # calling the task so the expected pattern is picked up
       task.should_receive(:run_task) { true }
-      expect(Rake.application.invoke_task(task.name)).to be_true
+      expect(Rake.application.invoke_task(task.name)).to be_truthy
 
       specify_consistent_ordering_of_files_to_run('a/*.rb', task)
     end

--- a/spec/rspec/core/shared_context_spec.rb
+++ b/spec/rspec/core/shared_context_spec.rb
@@ -28,10 +28,10 @@ describe RSpec::SharedContext do
 
     group.run
 
-    expect(before_all_hook).to be_true
-    expect(before_each_hook).to be_true
-    expect(after_each_hook).to be_true
-    expect(after_all_hook).to be_true
+    expect(before_all_hook).to be_truthy
+    expect(before_each_hook).to be_truthy
+    expect(after_each_hook).to be_truthy
+    expect(after_all_hook).to be_truthy
   end
 
   it "runs the before each hooks in configuration before those of the shared context" do

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -65,8 +65,8 @@ describe RSpec do
 
   describe "::Core.path_to_executable" do
     it 'returns the absolute location of the exe/rspec file' do
-      expect(File.exist? RSpec::Core.path_to_executable).to be_true
-      expect(File.executable? RSpec::Core.path_to_executable).to be_true
+      expect(File.exist? RSpec::Core.path_to_executable).to be_truthy
+      expect(File.executable? RSpec::Core.path_to_executable).to be_truthy
     end
   end
 


### PR DESCRIPTION
Since we're changing to `be_truthy` and `be_falsey`, we must update our own usage of these matchers.
