### PR TITLE
Safely clear shared example groups

### DIFF
--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -91,7 +91,7 @@ module RSpec
         end
 
         def clear
-          @shared_example_groups.clear
+          shared_example_groups.clear
         end
 
       private


### PR DESCRIPTION
This micro fix avoids a possible nil error if `@shared_example_groups` has not been initialized yet.
