### PR TITLE
Use localhost otherwise it will not work if localhost resolves to ::1 (IPv6)

### DIFF
--- a/lib/rspec/core/drb_command_line.rb
+++ b/lib/rspec/core/drb_command_line.rb
@@ -18,7 +18,7 @@ module RSpec
         rescue SocketError, Errno::EADDRNOTAVAIL
           DRb.start_service("druby://:0")
         end
-        spec_server = DRbObject.new_with_uri("druby://127.0.0.1:#{drb_port}")
+        spec_server = DRbObject.new_with_uri("druby://localhost:#{drb_port}")
         spec_server.run(@options.drb_argv, err, out)
       end
     end


### PR DESCRIPTION
On my mac the `localhost` resolves to `::1` which leads to problem in communication problem if one side tries to connect to `lacalhost` and the other side to `::1`. The best solution is if all parties use localhost for there communication.
