### PR TITLE
Fix top_level_description does not return always the same description

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -454,7 +454,7 @@ An error occurred in an after(:all) hook.
 
       # @private
       def self.top_level_description
-        parent_groups.last.description
+        parent_groups.last.description.dup
       end
 
       # @private

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -863,6 +863,19 @@ module RSpec::Core
 
         expect(group.top_level_description).to eq("top")
       end
+
+      it "returns always the same description" do
+        group = nil
+        ExampleGroup.describe("top") do
+          context "middle" do
+            group = describe "bottom" do
+            end
+            group.top_level_description.sub!('op', '')
+          end
+        end
+
+        expect(group.top_level_description).to eq("top")
+      end
     end
 
     describe "#run" do


### PR DESCRIPTION
If the top_level_description is modified in one spec affects the next specs.

For example, I you are doing view specs for different formats, and the format is described in the top_level_description, the format will be removed in the following code:

`actionpack-3.1.11/lib/action_view/renderer/abstract_renderer.rb`

```
    # Checks if the given path contains a format and if so, change
    # the lookup context to take this new format into account.
    def wrap_formats(value)
      return yield unless value.is_a?(String)

      if value.sub!(formats_regexp, "")
        update_details(:formats => [$1.to_sym]){ yield }
      else
        yield
      end
    end
```

Example: The first time a a view spec the top_level_description `/api/users.csv` the second time the view is rendered the top_level_description is `/api/users`
