### PR TITLE
Allow implicit subject to be used with block taking matchers (e.g. change)

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -65,7 +65,7 @@ module RSpec
       #
       # @see #subject
       def should(matcher=nil, message=nil)
-        RSpec::Expectations::PositiveExpectationHandler.handle_matcher(subject, matcher, message)
+        RSpec::Expectations::PositiveExpectationHandler.handle_matcher(__subject_for(matcher), matcher, message)
       end
 
       # Just like `should`, `should_not` delegates to the subject (implicit or
@@ -79,10 +79,19 @@ module RSpec
       #
       # @see #subject
       def should_not(matcher=nil, message=nil)
-        RSpec::Expectations::NegativeExpectationHandler.handle_matcher(subject, matcher, message)
+        RSpec::Expectations::NegativeExpectationHandler.handle_matcher(__subject_for(matcher), matcher, message)
       end
 
       private
+
+      # @private
+      def __subject_for(matcher)
+        if matcher.respond_to?(:expects_implementation?) && matcher.expects_implementation?
+          method(:subject)
+        else
+          subject
+        end
+      end
 
       # @private
       def __memoized

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -53,6 +53,19 @@ module RSpec::Core
         expect(outer_subject_value).to eq([:parent_group])
         expect(inner_subject_value).to eq([:parent_group, :child_group])
       end
+
+      describe "when used with an matcher expecting an implementation" do
+        let(:thing) { Struct.new(:value).new(1) }
+
+        before do
+          allow_any_instance_of(RSpec::Matchers::BuiltIn::Change).to receive(:expects_implementation?).and_return(true)
+        end
+
+        subject { thing.value += 1 }
+
+        it { should change { thing.value }.by(1) }
+        it { should_not change(thing,:value).to(3) }
+      end
     end
 
     describe "explicit subject" do


### PR DESCRIPTION
This is a WIP implementation allowing the use of matchers which expect to take a block/lambda to compare multiple 
values and assert on the change in them (e.g. the Change matcher) with the one-line implicit subject syntax. (Inspired by conversation with @jamesotron and hack night coding with @puyo).

WDYT superfriends? /cc @myronmarston @samphippen
