### PR TITLE
Add a "use_rspec_syntax" configuration option.

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -970,6 +970,16 @@ module RSpec
         $VERBOSE
       end
 
+      def use_rspec_syntax(syntax)
+        mock_with(:rspec) do |configuration|
+          configuration.syntax = syntax
+        end
+
+        expect_with(:rspec) do |configuration|
+          configuration.syntax = syntax
+        end
+      end
+
     private
 
       def get_files_to_run(paths)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -28,6 +28,47 @@ module RSpec::Core
       end
     end
 
+    describe "#use_rspec_syntaxes" do
+      include_context "with isolated syntax"
+
+      shared_examples_for "setting the syntaxes on -mocks and -expectations" do
+
+        it "sets the syntax on -expectations" do
+          RSpec.configuration.use_rspec_syntax(syntax)
+          expect(RSpec::Matchers.configuration.syntax).to eq(Array(syntax))
+        end
+
+        it "sets the syntax on -mocks" do
+          RSpec.configuration.use_rspec_syntax(syntax)
+          expect(RSpec::Mocks.configuration.syntax).to eq(Array(syntax))
+        end
+      end
+
+      context "setting the syntax to :expect" do
+        let(:syntax) { :expect }
+        it_behaves_like "setting the syntaxes on -mocks and -expectations"
+      end
+
+      context "setting the syntax to :should, [:expect]" do
+        let(:syntax) { [:should, :expect] }
+        it_behaves_like "setting the syntaxes on -mocks and -expectations"
+      end
+
+      context "setting the syntax to :should" do
+        let(:syntax) { :should }
+
+        it "sets the syntax on -expectations" do
+          RSpec.configuration.use_rspec_syntax(syntax)
+          RSpec::Matchers.configuration.syntax.should eq(Array(syntax))
+        end
+
+        it "sets the syntax on -mocks" do
+          RSpec.configuration.use_rspec_syntax(syntax)
+          RSpec::Mocks.configuration.syntax.should eq(Array(syntax))
+        end
+      end
+    end
+
     describe "#setup_load_path_and_require" do
       include_context "isolate load path mutation"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -140,3 +140,18 @@ end
 
 Spork.each_run do
 end
+
+shared_context "with isolated syntax" do
+  orig_matchers_syntax = nil
+  orig_mocks_syntax = nil
+
+  before(:each) do
+    orig_matchers_syntax = RSpec::Matchers.configuration.syntax
+    orig_mocks_syntax = RSpec::Mocks.configuration.syntax
+  end
+
+  after(:each) do
+    RSpec::Matchers.configuration.syntax = orig_matchers_syntax
+    RSpec::Mocks.configuration.syntax = orig_mocks_syntax
+  end
+end


### PR DESCRIPTION
Allows users to do

`configuration.use_rspec_syntax(:expect)`

instead of:

```
  config.mock_with :rspec do |configuration|
    configuration.syntax = :expect
  end

  config.expect_with :rspec do |configuration|
    configuration.syntax = :expect
  end
```

I briefly told @alindeman about this when we were pairing and he said he thought it was a good idea :)
