### PR TITLE
Pull up #summary_line to BaseFormatter

### DIFF
--- a/lib/rspec/core/formatters/base_formatter.rb
+++ b/lib/rspec/core/formatters/base_formatter.rb
@@ -154,6 +154,17 @@ module RSpec
 
         # @api public
         #
+        # Outputs summary with number of examples, failures and pending.
+        #
+        def summary_line(example_count, failure_count, pending_count)
+          summary = pluralize(example_count, "example")
+          summary << ", " << pluralize(failure_count, "failure")
+          summary << ", #{pending_count} pending" if pending_count > 0
+          summary
+        end
+
+        # @api public
+        #
         # Outputs a report of pending examples.  This gets invoked
         # after the summary if option is set to do so.
         #

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -103,17 +103,6 @@ module RSpec
           end
         end
 
-        # @api public
-        #
-        # Outputs summary with number of examples, failures and pending.
-        #
-        def summary_line(example_count, failure_count, pending_count)
-          summary = pluralize(example_count, "example")
-          summary << ", " << pluralize(failure_count, "failure")
-          summary << ", #{pending_count} pending" if pending_count > 0
-          summary
-        end
-
         def dump_pending
           unless pending_examples.empty?
             output.puts

--- a/lib/rspec/core/formatters/json_formatter.rb
+++ b/lib/rspec/core/formatters/json_formatter.rb
@@ -31,13 +31,6 @@ module RSpec
           dump_profile unless mute_profile_output?(failure_count)
         end
 
-        def summary_line(example_count, failure_count, pending_count)
-          summary = pluralize(example_count, "example")
-          summary << ", " << pluralize(failure_count, "failure")
-          summary << ", #{pending_count} pending" if pending_count > 0
-          summary
-        end
-
         def stop
           super
           @output_hash[:examples] = examples.map do |example|


### PR DESCRIPTION
Since this is part of the public API, it could make sense to make this private and expose it only where needed. Thoughts?
