### PR TITLE
Use flat_map {..} instead of map {..}.flatten

### DIFF
--- a/benchmarks/map_then_flatten_vs_flat_map_benchmarks.rb
+++ b/benchmarks/map_then_flatten_vs_flat_map_benchmarks.rb
@@ -1,0 +1,94 @@
+require 'benchmark'
+
+$n = 10000
+size = 100
+
+puts "size: #{size}"
+puts
+
+def report
+  reals = []
+  Benchmark.benchmark do |bm|
+    3.times do
+      reals << bm.report { $n.times { yield } }.real
+    end
+  end
+
+  reals.reduce(&:+) / reals.count
+end
+
+avgs = []
+
+puts "map then flatten"
+avgs << report {
+  (1..size).
+    map {|n| [n]}.
+    flatten
+}
+
+puts
+
+puts "flat_map"
+avgs << report {
+  (1..size).
+    flat_map {|n| [n]}
+}
+
+puts avgs
+if avgs[0] < avgs[1]
+  puts "map then flatten faster by #{((1.0 - avgs[0]/avgs[1]) * 100).round(2)} %"
+else
+  puts "flat_map faster by #{((1.0 - avgs[1]/avgs[0]) * 100).round(2)} %"
+end
+
+__END__
+
+for each size (10, 100, 1000) showing smallest diff
+  between map-then-flatten and flat_map in at least
+  5 runs
+
+size: 10
+
+map then flatten
+   0.550000   0.000000   0.550000 (  0.547897)
+   0.570000   0.000000   0.570000 (  0.565139)
+   0.550000   0.000000   0.550000 (  0.557421)
+
+flat_map
+   0.320000   0.000000   0.320000 (  0.316801)
+   0.320000   0.010000   0.330000 (  0.325373)
+   0.330000   0.000000   0.330000 (  0.325169)
+
+flat_map faster by 42.09 %
+
+**********************************************
+
+size: 100
+
+map then flatten
+   0.390000   0.000000   0.390000 (  0.387307)
+   0.390000   0.000000   0.390000 (  0.387630)
+   0.380000   0.000000   0.380000 (  0.389421)
+
+flat_map
+   0.250000   0.000000   0.250000 (  0.259444)
+   0.270000   0.000000   0.270000 (  0.261972)
+   0.250000   0.000000   0.250000 (  0.252584)
+
+flat_map faster by 33.53 %
+
+**********************************************
+
+size: 1000
+
+map then flatten
+   0.380000   0.000000   0.380000 (  0.382788)
+   0.380000   0.000000   0.380000 (  0.372447)
+   0.370000   0.000000   0.370000 (  0.370065)
+
+flat_map
+   0.240000   0.000000   0.240000 (  0.240357)
+   0.240000   0.000000   0.240000 (  0.242325)
+   0.240000   0.000000   0.240000 (  0.240985)
+
+flat_map faster by 35.69 %

--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -11,6 +11,7 @@ end
 require 'set'
 require 'time'
 require 'rbconfig'
+require_rspec['core/flat_map']
 require_rspec['core/filter_manager']
 require_rspec['core/dsl']
 require_rspec['core/extensions/ordered']
@@ -171,7 +172,6 @@ WARNING
     def self.path_to_executable
       @path_to_executable ||= File.expand_path('../../../exe/rspec', __FILE__)
     end
-
   end
 
   MODULES_TO_AUTOLOAD = {

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -975,10 +975,10 @@ module RSpec
     private
 
       def get_files_to_run(paths)
-        paths.map do |path|
+        FlatMap.flat_map(paths) do |path|
           path = path.gsub(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
           File.directory?(path) ? gather_directories(path) : extract_location(path)
-        end.flatten.sort
+        end.sort
       end
 
       def gather_directories(path)

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -124,7 +124,7 @@ module RSpec
       def args_from_options_file(path)
         return [] unless path && File.exist?(path)
         config_string = options_file_as_erb_string(path)
-        config_string.split(/\n+/).map(&:shellsplit).flatten
+        FlatMap.flat_map(config_string.split(/\n+/), &:shellsplit)
       end
 
       def options_file_as_erb_string(path)

--- a/lib/rspec/core/flat_map.rb
+++ b/lib/rspec/core/flat_map.rb
@@ -1,0 +1,17 @@
+module RSpec
+  module Core
+    module FlatMap
+      if [].respond_to?(:flat_map)
+        def flat_map(array)
+          array.flat_map { |item| yield item }
+        end
+      else
+        def flat_map(array)
+          array.map { |item| yield item }.flatten
+        end
+      end
+
+      module_function :flat_map
+    end
+  end
+end

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -448,7 +448,7 @@ EOS
 
       # @private
       def around_each_hooks_for(example, initial_procsy=nil)
-        AroundHookCollection.new(parent_groups.map {|a| a.hooks[:around][:each]}.flatten).for(example, initial_procsy)
+        AroundHookCollection.new(FlatMap.flat_map(parent_groups) {|a| a.hooks[:around][:each]}).for(example, initial_procsy)
       end
 
     private
@@ -472,11 +472,11 @@ EOS
       end
 
       def before_each_hooks_for(example)
-        HookCollection.new(parent_groups.reverse.map {|a| a.hooks[:before][:each]}.flatten).for(example)
+        HookCollection.new(FlatMap.flat_map(parent_groups.reverse) {|a| a.hooks[:before][:each]}).for(example)
       end
 
       def after_each_hooks_for(example)
-        HookCollection.new(parent_groups.map {|a| a.hooks[:after][:each]}.flatten).for(example)
+        HookCollection.new(FlatMap.flat_map(parent_groups) {|a| a.hooks[:after][:each]}).for(example)
       end
 
       def register_hook prepend_or_append, hook, *args, &block

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -159,7 +159,7 @@ module RSpec
         end
 
         def full_description
-          build_description_from(*container_stack.reverse.map {|a| a[:description_args]}.flatten)
+          build_description_from(*FlatMap.flat_map(container_stack.reverse) {|a| a[:description_args]})
         end
 
         def container_stack

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -47,9 +47,8 @@ module RSpec
       end
 
       def example_count
-        example_groups.collect {|g| g.descendants}.flatten.inject(0) do |sum, g|
-          sum + g.filtered_examples.size
-        end
+        FlatMap.flat_map(example_groups) {|g| g.descendants}.
+          inject(0) {|sum, g| sum + g.filtered_examples.size}
       end
 
       def preceding_declaration_line(filter_line)


### PR DESCRIPTION
flat_map is over 40% faster for small arrays (see benchmarks)

Also added crude implementation of flat_map for v1.8.7
