### PR TITLE
Improve travis build.

### DIFF
--- a/script/test_all
+++ b/script/test_all
@@ -34,7 +34,10 @@ fi
 
 # Prepare RUBYOPT for scenarios that are shelling out to ruby,
 # and PATH for those that are using `rspec` or `rake`.
-RUBYOPT="-I${PWD}/bundle -rbundler/setup" \
-  PATH="${PWD}/bin:$PATH" \
-  bin/cucumber --strict
+# RUBYOPT="-I${PWD}/bundle -rbundler/setup" \
+#   PATH="${PWD}/bin:$PATH" \
+#   bin/cucumber
 
+# For now, use this instead, due to a bug in bundler:
+# https://github.com/carlhuda/bundler/issues/2382
+bundle exec bin/cucumber --strict


### PR DESCRIPTION
- No need to bundle install twice.
- Run cucumber using our standalone
  bundle (rather than bundle exec).
- Bundler issue #2383 has been resolved,
  no need to work around it anymore.
