### PR TITLE
warn when the name of more than one example group is submitted to `include_examples` and it's aliases

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -184,16 +184,16 @@ module RSpec
         # groups in one call) to rspec-2 (which does not).
         #
         # See https://github.com/rspec/rspec-core/issues/1066 for background.
-        def self.warn_unexpected_args(name, args, shared_block)
+        def self.warn_unexpected_args(label, name, args, shared_block)
           if !args.empty? && shared_block.arity == 0
             if shared_example_groups[args.first]
               warn <<-WARNING
-shared examples support the name of only one example group, received #{[name, *args].inspect}
+shared #{label} support#{'s' if /context/ =~ label.to_s} the name of only one example group, received #{[name, *args].inspect}
 called from #{CallerFilter.first_non_rspec_line}"
 WARNING
             else
                 warn <<-WARNING
-shared examples #{name.inspect} expected #{shared_block.arity} args, got #{args.inspect}
+shared #{label} #{name.inspect} expected #{shared_block.arity} args, got #{args.inspect}
 called from #{CallerFilter.first_non_rspec_line}"
 WARNING
             end
@@ -213,7 +213,7 @@ WARNING
         raise ArgumentError, "Could not find shared #{label} #{name.inspect}" unless
           shared_block = shared_example_groups[name]
 
-        warn_unexpected_args(name, args, shared_block)
+        warn_unexpected_args(label, name, args, shared_block)
 
         module_exec(*args, &shared_block)
         module_eval(&customization_block) if customization_block

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1049,7 +1049,7 @@ module RSpec::Core
           group.shared_examples("named that") {}
 
           expect(group).to receive(:warn) {|message|
-            expect(message).to match(/shared examples support the name of only one example group, received \["named this", "named that"\]/)
+            expect(message).to match(/shared (context|examples) supports? the name of only one example group, received \["named this", "named that"\]/)
             expect(message).to match(/called from #{__FILE__}:#{__LINE__ + 2}/)
           }
           group.send(name, "named this", "named that")


### PR DESCRIPTION
This fixes #1066 for Ruby >= 1.9.
