### PR TITLE
Error rather than warn when `let` accessed in :all hook.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,8 @@ Breaking Changes for 3.0.0:
   load whichever debugger gem you wish to use (e.g. `ruby-debug`,
   `debugger`, or `pry`) (Myron Marston).
 * Extract Autotest support to a seperate gem (Jon Rowe)
+* Raise an error when a `let` or `subject` declaration is
+  accessed in a `before(:all)` or `after(:all)` hook. (Myron Marston)
 
 Enhancements
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -373,7 +373,7 @@ WARNING
         begin
           assign_before_all_ivars(superclass.before_all_ivars, example_group_instance)
 
-          BeforeAllMemoizedHash.isolate_for_before_all(example_group_instance) do
+          AllHookMemoizedHash::Before.isolate_for_all_hook(example_group_instance) do
             run_hook(:before, :all, example_group_instance)
           end
         ensure
@@ -401,7 +401,9 @@ WARNING
         return if descendant_filtered_examples.empty?
         assign_before_all_ivars(before_all_ivars, example_group_instance)
 
-        run_hook(:after, :all, example_group_instance)
+        AllHookMemoizedHash::After.isolate_for_all_hook(example_group_instance) do
+          run_hook(:after, :all, example_group_instance)
+        end
       end
 
       # Runs all the examples in this group

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -133,64 +133,19 @@ module RSpec::Core
           expect(subject_value).to eq([4, 5, 6, :override])
         end
 
-        context 'when referenced in a `before(:all)` hook' do
-          before do
-            expect(::RSpec).to respond_to(:warn_deprecation)
-            ::RSpec.stub(:warn_deprecation)
-          end
-
-          def define_and_run_group
-            values = { :reference_lines => [] }
+        [:before, :after].each do |hook|
+          it "raises an error when referenced from `#{hook}(:all)`" do
+            result = nil
+            line   = nil
 
             ExampleGroup.describe do
-              subject { [1, 2] }
-              let(:list) { %w[ a b ] }
-
-              before(:all) do
-                subject << 3; values[:reference_lines] << __LINE__
-                values[:final_subject_value_in_before_all] = subject; values[:reference_lines] << __LINE__
-              end
-
-              example do
-                list << '1'
-                values[:list_in_ex_1] = list
-                values[:subject_value_in_example] = subject
-              end
-
-              example do
-                list << '2'
-                values[:list_in_ex_2] = list
-              end
+              subject { nil }
+              send(hook, :all) { result = (subject rescue $!) }; line = __LINE__
+              example { }
             end.run
 
-            values
-          end
-
-          it 'memoizes the value within the before(:all) hook' do
-            values = define_and_run_group
-            expect(values.fetch(:final_subject_value_in_before_all)).to eq([1, 2, 3])
-          end
-
-          it 'preserves the memoization into the individual examples' do
-            values = define_and_run_group
-            expect(values.fetch(:subject_value_in_example)).to eq([1, 2, 3])
-          end
-
-          it 'does not cause other lets to be shared across examples' do
-            values = define_and_run_group
-            expect(values.fetch(:list_in_ex_1)).to eq(%w[ a b 1 ])
-            expect(values.fetch(:list_in_ex_2)).to eq(%w[ a b 2 ])
-          end
-
-          it 'prints a warning since `subject` declarations are not intended to be used in :all hooks' do
-            msgs = []
-            ::RSpec.stub(:warn_deprecation) { |msg| msgs << msg }
-
-            values = define_and_run_group
-
-            expect(msgs).to include(*values[:reference_lines].map { |line|
-              match(/subject accessed.*#{__FILE__}:#{line}/m)
-            })
+            expect(result).to be_an(Exception)
+            expect(result.message).to match(/subject accessed.*#{hook}\(:all\).*#{__FILE__}:#{line}/m)
           end
         end
       end
@@ -589,64 +544,19 @@ module RSpec::Core
       end
     end
 
-    context 'when referenced in a `before(:all)` hook' do
-      before do
-        expect(::RSpec).to respond_to(:warn_deprecation)
-        ::RSpec.stub(:warn_deprecation)
-      end
-
-      def define_and_run_group
-        values = { :reference_lines => [] }
+    [:before, :after].each do |hook|
+      it "raises an error when referenced from `#{hook}(:all)`" do
+        result = nil
+        line   = nil
 
         ExampleGroup.describe do
-          let(:list) { [1, 2] }
-          subject { %w[ a b ] }
-
-          before(:all) do
-            list << 3; values[:reference_lines] << __LINE__
-            values[:final_list_value_in_before_all] = list; values[:reference_lines] << __LINE__
-          end
-
-          example do
-            subject << "1"
-            values[:subject_in_ex_1] = subject
-            values[:list_value_in_example] = list
-          end
-
-          example do
-            subject << "2"
-            values[:subject_in_ex_2] = subject
-          end
+          let(:foo) { nil }
+          send(hook, :all) { result = (foo rescue $!) }; line = __LINE__
+          example { }
         end.run
 
-        values
-      end
-
-      it 'memoizes the value within the before(:all) hook' do
-        values = define_and_run_group
-        expect(values.fetch(:final_list_value_in_before_all)).to eq([1, 2, 3])
-      end
-
-      it 'preserves the memoized value into the examples' do
-        values = define_and_run_group
-        expect(values.fetch(:list_value_in_example)).to eq([1, 2, 3])
-      end
-
-      it 'does not cause the subject to be shared across examples' do
-        values = define_and_run_group
-        expect(values.fetch(:subject_in_ex_1)).to eq(%w[ a b 1 ])
-        expect(values.fetch(:subject_in_ex_2)).to eq(%w[ a b 2 ])
-      end
-
-      it 'prints a warning since `let` declarations are not intended to be used in :all hooks' do
-        msgs = []
-        ::RSpec.stub(:warn_deprecation) { |msg| msgs << msg }
-
-        values = define_and_run_group
-
-        expect(msgs).to include(*values[:reference_lines].map { |line|
-          match(/let declaration `list` accessed.*#{__FILE__}:#{line}/m)
-        })
+        expect(result).to be_an(Exception)
+        expect(result.message).to match(/let declaration `foo` accessed.*#{hook}\(:all\).*#{__FILE__}:#{line}/m)
       end
     end
 


### PR DESCRIPTION
Before we were just warning of deprecation in `before(:all)` but not `after(:all)`, and this raises a warning in both now (for consistency).  We should probably add a warning for `after(:all)` to 2.99.

Anyone want to review this?
