### PR TITLE
Recommended approach for finding and verifying code that invalidates the message cache.

### DIFF
--- a/ignores
+++ b/ignores
@@ -1,0 +1,2 @@
+lib/rspec/core/example_group.rb:        subclass = Class.new(parent)  ### This only occurs when an example group is subclasses, at spec define time.
+lib/rspec/core/example_group.rb:        # TODO 2010-05-05: Because we don't know if const_set is thread-safe ### It's a comment

--- a/method_cache_busters.sh
+++ b/method_cache_busters.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# set -x
+
+# This list is from https://charlie.bz/blog/things-that-clear-rubys-method-cache
+
+IGNORE_FILE=/tmp/cache_busters_ignore
+cat ignores | ruby -ne 'puts $_.split(/\s+###/)[0]' > $IGNORE_FILE
+
+egrep 'def [a-z]*\..*' -R lib | grep -v "def self" | grep -v -f $IGNORE_FILE
+grep undef -R lib | grep -v -f $IGNORE_FILE
+grep alias_method -R lib
+grep remove_method -R lib | grep -v -f $IGNORE_FILE
+grep const_set -R lib | grep -v -f $IGNORE_FILE
+grep remove_const -R lib | grep -v -f $IGNORE_FILE
+egrep '\bextend\b' -R lib | grep -v -f $IGNORE_FILE
+grep 'Class.new' -R lib | grep -v -f $IGNORE_FILE
+grep private_constant -R lib | grep -v -f $IGNORE_FILE
+grep public_constant -R lib | grep -v -f $IGNORE_FILE
+grep "Marshal.load" -R lib | grep -v -f $IGNORE_FILE
+grep "OpenStruct.new" -R lib | grep -v -f $IGNORE_FILE
+


### PR DESCRIPTION
It's totally ghetto, but probably good enough. I propose we use this branch to validate, then discard it when we're done. Don't think it's worth it to keep around as a permanent spec.

As we check off usages, we copy the output into the ignores file, preferably with a comment as to why. Could also just put this in the commit message.

References https://github.com/rspec/rspec-core/issues/863

Current output:

```
> ./method_cache_busters.sh
lib/rspec/core/example.rb:          def proc.run; call; end
lib/rspec/core/configuration.rb:        alias_method alias_name, name
lib/rspec/core/configuration.rb:        alias_method "#{alias_name}=", "#{name}="
lib/rspec/core/configuration.rb:        names.each {|name| alias_method "#{name}?", name}
lib/rspec/core/configuration.rb:      alias_method :color_enabled, :color
lib/rspec/core/configuration.rb:      alias_method :color_enabled=, :color=
lib/rspec/core/configuration.rb:      alias_method :formatter=, :add_formatter
lib/rspec/core/configuration.rb:      alias_method :alias_it_should_behave_like_to, :alias_it_behaves_like_to
lib/rspec/core/configuration.rb:      alias_method :filter_run, :filter_run_including
lib/rspec/core/configuration.rb:      alias_method :filter=, :inclusion_filter=
lib/rspec/core/configuration.rb:      alias_method :filter, :inclusion_filter
lib/rspec/core/example.rb:      alias_method :pending?, :pending
lib/rspec/core/example_group.rb:        alias_method :display_name, :description
lib/rspec/core/example_group.rb:        alias_method :describes, :described_class
lib/rspec/core/example_group.rb:        # Works like `alias_method :name, :example` with the added benefit of
lib/rspec/core/example_group.rb:        # Works like `alias_method :name, :it_behaves_like` with the added
lib/rspec/core/example_group.rb:        alias_method :context, :describe
lib/rspec/core/hooks.rb:          host.send :alias_method, :prepend, :unshift
lib/rspec/core/hooks.rb:          host.send :alias_method, :append,  :push
lib/rspec/core/hooks.rb:      alias_method :append_before, :before
lib/rspec/core/hooks.rb:      alias_method :prepend_after, :after
lib/rspec/core/memoized_helpers.rb:            alias_method :subject, name
lib/rspec/core/option_parser.rb:      alias_method :parse, :parse!
lib/rspec/core/option_parser.rb:    alias_method :parse, :parse!
lib/rspec/core/reporter.rb:    alias_method :abort, :finish
lib/rspec/core/shared_example_group.rb:      alias_method :shared_context,      :shared_examples
lib/rspec/core/shared_example_group.rb:      alias_method :share_examples_for,  :shared_examples
lib/rspec/core/shared_example_group.rb:      alias_method :shared_examples_for, :shared_examples
lib/rspec/core/shared_example_group.rb:        alias_method :shared_context,      :shared_examples
lib/rspec/core/shared_example_group.rb:        alias_method :share_examples_for,  :shared_examples
lib/rspec/core/shared_example_group.rb:        alias_method :shared_examples_for, :shared_examples
lib/rspec/core/example_group.rb:        child = const_set(
lib/rspec/core/memoized_helpers.rb:              example_group.const_set(:NamedSubjectPreventSuper, self)
lib/rspec/core/memoized_helpers.rb:          example_group.const_set(:LetDefinitions, mod)
lib/rspec/core/configuration.rb:      # @see #extend
lib/rspec/core/configuration.rb:      # Tells RSpec to extend example groups with `mod`.  Methods defined in
lib/rspec/core/configuration.rb:      # constrain the groups to extend.
lib/rspec/core/configuration.rb:      #       config.extend(UiHelpers, :type => :request)
lib/rspec/core/configuration.rb:      def extend(mod, *filters)
lib/rspec/core/configuration.rb:        include_or_extend_modules << [:extend, mod, Metadata.build_hash_from(filters)]
lib/rspec/core/configuration.rb:      # Used internally to extend a group with modules using `include` and/or
lib/rspec/core/configuration.rb:      # `extend`.
lib/rspec/core/configuration.rb:          host.extend(mod) unless (class << host; self; end) < mod
lib/rspec/core/configuration.rb:          host.extend(mod) unless (class << host; self; end).included_modules.include?(mod)
lib/rspec/core/deprecation.rb:  extend(Core::Deprecation)
lib/rspec/core/dsl.rb:extend RSpec::Core::DSL
lib/rspec/core/example.rb:        proc.extend(Procsy).with(metadata)
lib/rspec/core/example.rb:      # Used to extend a `Proc` with behavior that makes it look something like
lib/rspec/core/example.rb:          @exception.extend(NotPendingExampleFixed) unless @exception.respond_to?(:pending_fixed?)
lib/rspec/core/example_group.rb:      extend  Hooks
lib/rspec/core/example_group.rb:      extend SharedExampleGroup
lib/rspec/core/example_group.rb:        @children ||= [].extend(Extensions::Ordered::ExampleGroups)
lib/rspec/core/extensions/ordered.rb:      # Used to extend lists of examples and groups to support ordering
lib/rspec/core/filter_manager.rb:        extend(BackwardCompatibility)
lib/rspec/core/formatters/helpers.rb:      extend self
lib/rspec/core/hooks.rb:        }.extend(RegistersGlobals)
lib/rspec/core/memoized_helpers.rb:        mod.extend(ClassMethods)
lib/rspec/core/metadata.rb:          store(:example_group, {:example_group => parent_group_metadata[:example_group].extend(GroupMetadataHash)}.extend(GroupMetadataHash))
lib/rspec/core/metadata.rb:          store(:example_group, {}.extend(GroupMetadataHash))
lib/rspec/core/metadata.rb:        dup.extend(ExampleMetadataHash).configure_for_example(description, user_metadata)
lib/rspec/core/shared_context.rb:    #       extend RSpec::Core::SharedContext
lib/rspec/core/shared_example_group.rb:            RSpec.configuration.extend mod, *args
lib/rspec/core/shared_example_group.rb:            block.extend Module.new {
lib/rspec/core/shared_example_group.rb:extend RSpec::Core::SharedExampleGroup::TopLevelDSL
lib/rspec/core/world.rb:        @example_groups = [].extend(Extensions::Ordered::ExampleGroups)
lib/rspec/core/world.rb:            examples.extend(Extensions::Ordered::Examples)
```
