### PR TITLE
Refactor: store current_example in a local.

### DIFF
--- a/lib/rspec/core/pending.rb
+++ b/lib/rspec/core/pending.rb
@@ -76,7 +76,9 @@ module RSpec
       #         # ...
       #       end
       def pending(*args)
-        return self.class.before(:each) { pending(*args) } unless RSpec.current_example
+        current_example = RSpec.current_example
+
+        return self.class.before(:each) { pending(*args) } unless current_example
 
         options = args.last.is_a?(Hash) ? args.pop : {}
         message = args.first || NO_REASON_GIVEN
@@ -85,17 +87,17 @@ module RSpec
           return block_given? ? yield : nil
         end
 
-        RSpec.current_example.metadata[:pending] = true
-        RSpec.current_example.metadata[:execution_result][:pending_message] = message
+        current_example.metadata[:pending] = true
+        current_example.metadata[:execution_result][:pending_message] = message
         if block_given?
           begin
             result = begin
                        yield
-                       RSpec.current_example.example_group_instance.instance_eval { verify_mocks_for_rspec }
+                       current_example.example_group_instance.instance_eval { verify_mocks_for_rspec }
                      end
-            RSpec.current_example.metadata[:pending] = false
+            current_example.metadata[:pending] = false
           rescue Exception => e
-            RSpec.current_example.execution_result[:exception] = e
+            current_example.execution_result[:exception] = e
           ensure
             teardown_mocks_for_rspec
           end


### PR DESCRIPTION
- There's no need to call `RSpec.current_example`
  many times in this method.
- This wasn't working correctly for specs that
  create an example group and run it (from within
  the spec itself), as that caused `RSpec.current_example`
  to get cleared when the locally created example
  group completed, even though the spec that created
  the example group had not yet completed.  For an
  example of this, see this rspec-its PR:

https://github.com/rspec/rspec-its/pull/1#discussion_r6677739
