### PR TITLE
Specifying a seed does not force ordering to be random

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -72,7 +72,7 @@ module RSpec::Core
         end
 
         parser.on('--seed SEED', Integer, 'Equivalent of --order rand:SEED.') do |seed|
-          options[:order] = "rand:#{seed}"
+          options[:seed] = seed
         end
 
         parser.on('--fail-fast', 'Abort the run on first failure.') do |o|

--- a/spec/command_line/order_spec.rb
+++ b/spec/command_line/order_spec.rb
@@ -138,6 +138,16 @@ describe 'command line', :ui do
 
       run_command 'spec/order_spec.rb --order defined -f doc'
 
+      expect(stdout.string).to match(
+        /group 1.*group 1 example 1.*group 1 example 2.*group 1-1.*group 1-2.*group 2.*/m
+      )
+    end
+  end
+
+  describe '--order defined with --seed' do
+    it 'uses the defined order' do
+      run_command 'spec/order_spec.rb --order defined --seed 2 -f doc'
+
       expect(stdout.string).not_to match(/Randomized/)
 
       expect(stdout.string).to match(

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -88,7 +88,7 @@ describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolat
       ["--failure-exit-code", "37", :failure_exit_code, 37],
       ["--default_path", "behavior", :default_path, "behavior"],
       ["--order", "rand", :order, "rand"],
-      ["--seed", "37", :order, "rand:37"],
+      ["--seed", "37", :seed, 37],
       ["--drb-port", "37", :drb_port, 37]
     ].each do |cli_option, cli_value, config_key, config_value|
       it "forces #{config_key}" do

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -199,9 +199,9 @@ module RSpec::Core
     end
 
     describe "--seed" do
-      it "sets the order to rand:SEED" do
+      it "sets the seed to the specified value" do
         options = Parser.parse!(%w[--seed 123])
-        expect(options[:order]).to eq("rand:123")
+        expect(options[:seed]).to eq(123)
       end
     end
 


### PR DESCRIPTION
If seeds are going to be used for randomization, it makes sense to decouple seeding and ordering. For example, I may want my specs to run in the default order, but reproduce randomness during the run.
