### PR TITLE
Deprecate 'its' in favor of rspec-its gem as part of #1083

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,8 @@ Deprecations
   RSpec 3 will not support having this option set to `false` (Myron Marston).
 * Deprecate accessing a `let` or `subject` declaration in
   a `after(:all)` hook. (Myron Marston, Jon Rowe)
+* Deprecate built-in `its` usage in favor of `rspec-it` gem due to planned
+  removal in RSpec 3 (Peter Alfvin)
 
 ### 2.14.5 / 2013-08-13
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.14.4...v2.14.5)

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -455,6 +455,7 @@ EOS
         #     its(:age) { should eq(25) }
         #   end
         def its(attribute, &block)
+          RSpec.deprecate('Use of rspec-core\'s "its" method', :replacement => 'rspec-its gem')
           describe(attribute) do
             if Array === attribute
               let(:__its_subject) { subject[*attribute] }

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -348,6 +348,12 @@ module RSpec::Core
     end
 
     describe "#its" do
+
+      it "should issue deprecation warning" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__+1, '"its" method')
+        RSpec::Core::ExampleGroup.its(nil) {}
+      end
+
       subject do
         Class.new do
           def initialize

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -23,9 +23,10 @@ module RSpecHelpers
     end
   end
 
-  def expect_deprecation_with_call_site(file, line)
+  def expect_deprecation_with_call_site(file, line, deprecated = //)
     expect(RSpec.configuration.reporter).to receive(:deprecation) do |options|
       expect(options[:call_site]).to include([file, line].join(':'))
+      expect(options[:deprecated]).to match(deprecated)
     end
   end
 


### PR DESCRIPTION
Wasn't sure about wording and assumed that no test was required for deprecation.  In support of https://github.com/rspec/rspec-core/issues/1083
