### PR TITLE
Address ruby warnings.

### DIFF
--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -7,7 +7,7 @@ describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolat
 
   it "warns when HOME env var is not set", :unless => (RUBY_PLATFORM == 'java') do
     without_env_vars 'HOME' do
-      expect_warning_with_call_site __FILE__, __LINE__ +1
+      expect_warning_with_call_site(__FILE__, __LINE__ + 1)
       RSpec::Core::ConfigurationOptions.new([]).parse_options
     end
   end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -477,7 +477,7 @@ module RSpec::Core
 
         context "after files have already been loaded" do
           it 'will warn that it will have no effect' do
-            expect_warning_with_call_site __FILE__, __LINE__ +2, /has no effect/
+            expect_warning_with_call_site(__FILE__, __LINE__ + 2, /has no effect/)
             config.load_spec_files
             config.send(setter, "rspec/**/*.spec")
           end
@@ -737,7 +737,7 @@ module RSpec::Core
 
               it "warns to install ANSICON" do
                 config.stub(:require) { raise LoadError }
-                expect_warning_with_call_site __FILE__, __LINE__ +1, /You must use ANSICON/
+                expect_warning_with_call_site(__FILE__, __LINE__ + 1, /You must use ANSICON/)
                 config.send "#{color_option}=", true
               end
 

--- a/spec/rspec/core/warnings_spec.rb
+++ b/spec/rspec/core/warnings_spec.rb
@@ -27,19 +27,19 @@ describe "RSpec deprecations and warnings" do
 
   shared_examples_for "warning helper" do |helper|
     it 'warns with the message text' do
-      expect(::Kernel).to receive(:warn).with /Message/
+      expect(::Kernel).to receive(:warn).with(/Message/)
       RSpec.send(helper, 'Message')
     end
 
     it 'sets the calling line' do
-      expect(::Kernel).to receive(:warn).with /#{__FILE__}:#{__LINE__+1}/
+      expect(::Kernel).to receive(:warn).with(/#{__FILE__}:#{__LINE__+1}/)
       RSpec.send(helper, 'Message')
     end
   end
 
   describe "#warning" do
     it 'prepends WARNING:' do
-      expect(::Kernel).to receive(:warn).with /WARNING: Message\./
+      expect(::Kernel).to receive(:warn).with(/WARNING: Message\./)
       RSpec.warning 'Message'
     end
     it_should_behave_like 'warning helper', :warning

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -36,14 +36,14 @@ module RSpecHelpers
   def expect_warning_without_call_site(expected = //)
     expect(::Kernel).to receive(:warn) do |message|
       expect(message).to match expected
-      expect(message).to_not match /Called from/
+      expect(message).to_not match(/Called from/)
     end
   end
 
   def expect_warning_with_call_site(file, line, expected = //)
     expect(::Kernel).to receive(:warn) do |message|
       expect(message).to match expected
-      expect(message).to match /Called from #{file}:#{line}/
+      expect(message).to match(/Called from #{file}:#{line}/)
     end
   end
 


### PR DESCRIPTION
```
/Users/myron/code/rspec-dev/repos/rspec-core/spec/support/helper_methods.rb:39: warning: ambiguous first argument; put parentheses or even spaces
/Users/myron/code/rspec-dev/repos/rspec-core/spec/support/helper_methods.rb:46: warning: ambiguous first argument; put parentheses or even spaces
/Users/myron/code/rspec-dev/repos/rspec-core/spec/rspec/core/configuration_options_spec.rb:10: warning: `+' after local variable is interpreted as binary operator
/Users/myron/code/rspec-dev/repos/rspec-core/spec/rspec/core/configuration_options_spec.rb:10: warning: even though it seems like unary operator
/Users/myron/code/rspec-dev/repos/rspec-core/spec/rspec/core/configuration_spec.rb:480: warning: `+' after local variable is interpreted as binary operator
/Users/myron/code/rspec-dev/repos/rspec-core/spec/rspec/core/configuration_spec.rb:480: warning: even though it seems like unary operator
/Users/myron/code/rspec-dev/repos/rspec-core/spec/rspec/core/configuration_spec.rb:740: warning: `+' after local variable is interpreted as binary operator
/Users/myron/code/rspec-dev/repos/rspec-core/spec/rspec/core/configuration_spec.rb:740: warning: even though it seems like unary operator
```

@JonRowe -- I think these warnings are from your recent `RSpec.warning` refactor.  Please be more careful about adding warnings in the future...
