### PR TITLE
Fail build if any warnings are introduced.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ end
 Spork.prefork do
   require 'rspec/autorun'
   require 'aruba/api'
+  require 'support/invocation_counter'
 
   if RUBY_PLATFORM == 'java'
     # Works around https://jira.codehaus.org/browse/JRUBY-5678
@@ -124,6 +125,10 @@ Spork.prefork do
     c.include Aruba::Api, :example_group => {
       :file_path => /spec\/command_line/
     }
+
+    warn_counter = InvocationCounter.new(:warn)
+    c.before(:suite) { warn_counter.hook!(Object) }
+    c.after(:suite)  { expect(warn_counter.count).to eq(0) }
 
     # Use the doc formatter when running individual files.
     # This is too verbose when running all spec files but

--- a/spec/support/invocation_counter.rb
+++ b/spec/support/invocation_counter.rb
@@ -1,0 +1,22 @@
+# A deliberately naive class to count the number of times any particular method
+# is called.
+class InvocationCounter
+  def initialize(method_name)
+    @method_name = method_name
+    @count       = 0
+  end
+
+  def hook!(klass)
+    parent = self
+    hooker = Module.new do
+      define_method(parent.method_name) do |*args|
+        parent.count += 1
+        super(*args)
+      end
+    end
+    klass.send :include, hooker
+  end
+
+  attr_accessor :count
+  attr_reader :method_name
+end


### PR DESCRIPTION
If this proves to work, we should move to rspec-support and use on all
project specs and features (potentially exposing it as a public API?).

@myronmarston thoughts?It's kind of dirty.
