### PR TITLE
Fixe a regression in 2.14.6 w/ Fivemat formatter.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,17 @@
 ### 2.14.7 Development
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.14.6...v2.14.7)
 
+Bug fixes:
+
+* Fix regression in 2.14.6 that broke the Fivemat formatter.
+  It depended upon either
+  `example.execution_result[:exception].pending_fixed?` (which
+  was removed in 2.14.6 to fix an issue with frozen error objects)
+  or `RSpec::Core::PendingExampleFixedError` (which was renamed
+  to `RSpec::Core::Pending::PendingExampleFixedError` in 2.8.
+  This fix makes a constant alias for the old error name.
+  (Myron Marston)
+
 ### 2.14.6 / 2013-10-15
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.14.5...v2.14.6)
 

--- a/lib/rspec/core/pending.rb
+++ b/lib/rspec/core/pending.rb
@@ -105,5 +105,9 @@ module RSpec
         raise PendingDeclaredInExample.new(message)
       end
     end
+
+    # Alias the error for compatibility with extension gems (e.g. formatters)
+    # that depend on the const name of the error in RSpec <= 2.8.
+    PendingExampleFixedError = Pending::PendingExampleFixedError
   end
 end


### PR DESCRIPTION
In https://github.com/tpope/fivemat/blob/v1.2.1/lib/fivemat/rspec.rb#L43-L49,
Fivemat has two ways to check for pending example fixed:
- example.execution_result[:exception].pending_fixed?
  (but we removed this in #1106 because it broke when dealing with frozen exceptions)
- RSpec::Core::PendingExampleFixedError === exception
  (but this const was renamed in b5d10ccbe3a590adc67d807acb565be3657e51bf).

The `RSpec::Core::PendingExampleFixedError` line in Fivemat was
never hit in recent releases because `example.execution_result[:exception]`
responded to `pending_fixed?` -- until 2.14.6.

@dchelimsky -- do you remember the motivation for renaming the error class in b5d10ccbe3a590adc67d807acb565be3657e51bf ?  The commit message doesn't give a rationale.  I don't think this should break anything (and fixes the Fivemat problem) but wanted to check with you.
