### PR TITLE
Deprecate RSpec::Core::PendingExampleFixedError.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,8 @@ Deprecations
   a `after(:all)` hook. (Myron Marston, Jon Rowe)
 * Deprecate built-in `its` usage in favor of `rspec-it` gem due to planned
   removal in RSpec 3 (Peter Alfvin)
+* Deprecate `RSpec::Core::PendingExampleFixedError` in favor of
+  `RSpec::Core::Pending::PendingExampleFixedError` (Myron Marston).
 
 ### 2.14.7 / 2013-10-29
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.14.6...v2.14.7)

--- a/lib/rspec/core/pending.rb
+++ b/lib/rspec/core/pending.rb
@@ -107,6 +107,11 @@ module RSpec
 
     # Alias the error for compatibility with extension gems (e.g. formatters)
     # that depend on the const name of the error in RSpec <= 2.8.
-    PendingExampleFixedError = Pending::PendingExampleFixedError
+    def self.const_missing(name)
+      return super unless name == :PendingExampleFixedError
+
+      RSpec.deprecate("RSpec::Core::PendingExampleFixedError", :replacement => "RSpec::Core::Pending::PendingExampleFixedError")
+      Pending::PendingExampleFixedError
+    end
   end
 end

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -86,4 +86,23 @@ describe RSpec do
       RSpec::NotAConst
     }.to raise_error(NameError, /RSpec::NotAConst/)
   end
+
+  describe "::Core::PendingExampleFixedError" do
+    before { allow_deprecation }
+
+    it 'is an alternate reference to RSpec::Core::Pending::PendingExampleFixedError' do
+      expect(::RSpec::Core::PendingExampleFixedError).to be(::RSpec::Core::Pending::PendingExampleFixedError)
+    end
+
+    it 'prints a deprecation warning' do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /PendingExampleFixedError/)
+      ::RSpec::Core::PendingExampleFixedError
+    end
+
+    specify 'the const_missing hook allows other undefined consts to raise errors as normal' do
+      expect {
+        ::RSpec::Core::SomeUndefinedConst
+      }.to raise_error(NameError, /uninitialized constant RSpec::Core::SomeUndefinedConst/)
+    end
+  end
 end


### PR DESCRIPTION
This is the analog of #1129 but for 2.99.
