### PR TITLE
Move duplicated methods to `BaseFormatter`

### DIFF
--- a/lib/rspec/core/formatters/base_formatter.rb
+++ b/lib/rspec/core/formatters/base_formatter.rb
@@ -190,6 +190,17 @@ module RSpec
           configuration.backtrace_formatter.format_backtrace(backtrace, example.metadata)
         end
 
+        # @api public
+        #
+        # Outputs summary with number of examples, failures and pending.
+        #
+        def summary_line(example_count, failure_count, pending_count)
+          summary = pluralize(example_count, "example")
+          summary << ", " << pluralize(failure_count, "failure")
+          summary << ", #{pending_count} pending" if pending_count > 0
+          summary
+        end
+
       protected
 
         def configuration

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -103,17 +103,6 @@ module RSpec
           end
         end
 
-        # @api public
-        #
-        # Outputs summary with number of examples, failures and pending.
-        #
-        def summary_line(example_count, failure_count, pending_count)
-          summary = pluralize(example_count, "example")
-          summary << ", " << pluralize(failure_count, "failure")
-          summary << ", #{pending_count} pending" if pending_count > 0
-          summary
-        end
-
         def dump_pending
           unless pending_examples.empty?
             output.puts

--- a/lib/rspec/core/formatters/json_formatter.rb
+++ b/lib/rspec/core/formatters/json_formatter.rb
@@ -31,13 +31,6 @@ module RSpec
           dump_profile unless mute_profile_output?(failure_count)
         end
 
-        def summary_line(example_count, failure_count, pending_count)
-          summary = pluralize(example_count, "example")
-          summary << ", " << pluralize(failure_count, "failure")
-          summary << ", #{pending_count} pending" if pending_count > 0
-          summary
-        end
-
         def stop
           super
           @output_hash[:examples] = examples.map do |example|


### PR DESCRIPTION
Move duplicated methods to `BaseFormatter`
