### PR TITLE
fixes "Could not find gem 'rspec-support (= 3.0.0.pre) ruby'"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-%w[rspec rspec-expectations rspec-mocks].each do |lib|
+%w[rspec rspec-expectations rspec-mocks rspec-support].each do |lib|
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path)
     gem lib, :path => library_path


### PR DESCRIPTION
I encountered this error while trying to build this project. This PR adds `rspec-support` to `Gemfile`.

See also: https://github.com/rspec/rspec/pull/3
