### PR TITLE
Add newlines after too many deprecations warnings

### DIFF
--- a/lib/rspec/core/formatters/deprecation_formatter.rb
+++ b/lib/rspec/core/formatters/deprecation_formatter.rb
@@ -127,23 +127,24 @@ module RSpec
             if @seen_deprecations[deprecation_message] < TOO_MANY_USES_LIMIT
               @deprecation_messages[deprecation_message] << deprecation_message.to_s
             elsif @seen_deprecations[deprecation_message] == TOO_MANY_USES_LIMIT
-              @deprecation_messages[deprecation_message] << deprecation_message.too_many_warnings_message + "\n\n"
+              @deprecation_messages[deprecation_message] << deprecation_message.too_many_warnings_message
             end
           end
 
           def deprecation_summary
-            messages = @deprecation_messages.values.flatten
-            return unless messages.any?
+            return unless @deprecation_messages.any?
 
-            print_deferred_deprecation_warnings(messages)
+            print_deferred_deprecation_warnings
 
             summary_stream.puts "\n#{pluralize(deprecation_formatter.count, 'deprecation warning')} total"
           end
 
-          def print_deferred_deprecation_warnings(messages)
+          def print_deferred_deprecation_warnings
             deprecation_stream.puts "\nDeprecation Warnings:\n\n"
-            messages.each do |msg|
-              deprecation_stream.puts msg
+            @deprecation_messages.keys.sort_by(&:type).each do |deprecation|
+              messages = @deprecation_messages[deprecation]
+              messages.each { |msg| deprecation_stream.puts msg }
+              deprecation_stream.puts
             end
           end
         end

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -75,6 +75,25 @@ module RSpec::Core::Formatters
       context "with an IO deprecation_stream" do
         let(:deprecation_stream) { StringIO.new }
 
+        it "groups similar deprecations together" do
+          formatter.deprecation(:deprecated => 'i_am_deprecated')
+          formatter.deprecation(:deprecated => 'i_am_a_different_deprecation')
+          formatter.deprecation(:deprecated => 'i_am_deprecated')
+          formatter.deprecation_summary
+
+          expected = <<-EOS.gsub(/^\s+\|/, '')
+            |
+            |Deprecation Warnings:
+            |
+            |i_am_a_different_deprecation is deprecated.
+            |
+            |i_am_deprecated is deprecated.
+            |i_am_deprecated is deprecated.
+            |
+          EOS
+          expect(deprecation_stream.string).to eq expected
+        end
+
         it "limits the deprecation warnings after 3 calls" do
           5.times { formatter.deprecation(:deprecated => 'i_am_deprecated') }
           formatter.deprecation_summary


### PR DESCRIPTION
This is for #1147

I liked your heredoc pipe trick from a recent commit, so I re-used it here.

I was also considering just adding a newline between deprecations of different types (regardless of whether or not there is a `too_many_warnings_message`. Currently deprecation messages are stored in a hash of `deprecation type => array of messages` and we just flatten all the values to print them, but we could easily iterate over the keys and add newlines after each deprecation type.

What do you think?

cc @myronmarston 
