### PR TITLE
Simplify caller filter, remove circular dependency.

### DIFF
--- a/lib/rspec/core/caller_filter.rb
+++ b/lib/rspec/core/caller_filter.rb
@@ -5,17 +5,7 @@ module RSpec
   # internal method that raised an error.
   class CallerFilter
 
-    RSPEC_LIBS = %w[
-      core
-      mocks
-      expectations
-      matchers
-      rails
-    ]
-
-    ADDITIONAL_TOP_LEVEL_FILES = %w[ autorun ]
-
-    LIB_REGEX = %r{/lib/rspec/(#{(RSPEC_LIBS + ADDITIONAL_TOP_LEVEL_FILES).join('|')})(\.rb|/)}
+    LIB_REGEX = %r{/lib/rspec/}
 
     if RUBY_VERSION >= '2.0.0'
       def self.first_non_rspec_line

--- a/spec/rspec/core/caller_filter_spec.rb
+++ b/spec/rspec/core/caller_filter_spec.rb
@@ -44,13 +44,23 @@ module RSpec
         end
       end
 
-      it "does not match other ruby files" do
+      it "does not match spec files" do
         files = %w[
-          /path/to/lib/rspec/some-extension/foo.rb
           /path/to/spec/rspec/core/some_spec.rb
         ]
 
         expect(unmatched_from files).to eq(files)
+      end
+
+      it "matches rspec extensions" do
+        # Since extensions often modify core methods, it is most useful to
+        # exclude them from filtered traces to reveal the actual source line
+        # that is triggering a deprecation or exception.
+        files = %w[
+          /path/to/lib/rspec/some-extension/foo.rb
+        ]
+
+        expect(unmatched_from files).to eq([])
       end
     end
   end


### PR DESCRIPTION
For the common cases I can think of (particularly `rspec-fire`), this is a more desirable behaviour.
