### PR TITLE
Don't warn about shared example group args when it has a default arg.

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -182,7 +182,7 @@ module RSpec
         find_and_eval_shared("examples", name, *args, &block)
       end
 
-      if RUBY_VERSION.to_f >= 1.9
+      if Proc.method_defined?(:parameters) # for >= 1.9
         # Warn when submitting the name of more than one example group to
         # include_examples, it_behaves_like, etc.
         #
@@ -191,7 +191,7 @@ module RSpec
         #
         # See https://github.com/rspec/rspec-core/issues/1066 for background.
         def self.warn_unexpected_args(label, name, args, shared_block)
-          if !args.empty? && shared_block.arity == 0
+          if !args.empty? && shared_block.parameters.count == 0
             if shared_example_groups[args.first]
               warn <<-WARNING
 shared #{label} support#{'s' if /context/ =~ label.to_s} the name of only one example group, received #{[name, *args].inspect}

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1056,7 +1056,7 @@ module RSpec::Core
           expect(group.run).to be_truthy
         end
 
-        it "warns when num args submitted doesn't match arity of shared block", :if => RUBY_VERSION.to_f >= 1.9 do
+        it "warns when extra args are submitted to a zero-arity shared block", :if => RUBY_VERSION.to_f >= 1.9 do
           group = ExampleGroup.describe
           group.shared_examples("named this") {}
 
@@ -1077,6 +1077,18 @@ module RSpec::Core
             expect(message).to match(/called from #{__FILE__}:#{__LINE__ + 2}/)
           }
           group.send(name, "named this", "named that")
+        end
+
+        it 'does not warn when the shared example group has a default arg', :if => RUBY_VERSION.to_f >= 1.9 do
+          group = ExampleGroup.describe
+
+          # 1.8.7 can't parse blocks with arg defaults, so we have to eval it
+          # to delay when it is parsed.
+          eval('group.shared_examples("named this") { |opts={}| }')
+
+          expect(group).not_to receive(:warn)
+
+          group.send(name, "named this", :foo => 1)
         end
       end
     end


### PR DESCRIPTION
This was creating a confusing warning.

Fixes #1148.
