### PR TITLE
Prevent spec from issuing confusing output.

### DIFF
--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -54,6 +54,7 @@ module RSpec::Core
       let(:out) { StringIO.new }
 
       it "tells RSpec to reset" do
+        CommandLine.stub(:new => double.as_null_object)
         RSpec.configuration.stub(:files_to_run => [], :warn => nil)
         RSpec.should_receive(:reset)
         RSpec::Core::Runner.run([], err, out)


### PR DESCRIPTION
On ruby 2.0.0, `rspec --seed 1325` would issue confusing
output where the end-of-run summary is printed twice.
See the following example output below.

This spec was the culprit. It's not actually concerned
with running the command line so we might as well stub it out.

Run options:
  include {:focus=>true}
  exclude {:ruby=>#Proc:./spec/spec_helper.rb:152}

All examples were filtered out; ignoring {:focus=>true}
.....No examples found.

Finished in 0.00006 seconds
0 examples, 0 failures

Deprecation Warnings:

Using `stub` from the old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/myron/code/rspec-dev/repos/rspec-core/spec/rspec/core/runner_spec.rb:57:in `block (3 levels) in module:Core'.

1 deprecation warning total

Randomized with seed 5055

...................................................................................................................................*.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Pending:
  ::DRbCommandLine with server running outputs colorized text when running with --colour option
    # figure out a way to tell the output to say it's tty
    # ./spec/rspec/core/drb_command_line_spec.rb:97

Finished in 2.18 seconds
1126 examples, 0 failures, 1 pending

Randomized with seed 1325
