### PR TITLE
Fix failure in end-of-run summary for the error stream.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### 3.0.0.beta2 Development
+[full changelog](http://github.com/rspec/rspec-core/compare/v3.0.0.beta1...master)
+
+Bug Fixes:
+
+* Fix failure (undefined method `path`) in end-of-run summary
+  when `raise_errors_for_deprecations!` is configured. (Myron Marston)
+
 ### 3.0.0.beta1 / 2013-11-07
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.99.0.beta1...v3.0.0.beta1)
 

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -86,6 +86,27 @@ module RSpec::Core::Formatters
         end
       end
 
+      context "with an Error deprecation_stream" do
+        let(:deprecation_stream) { DeprecationFormatter::RaiseErrorStream.new }
+
+        it 'prints a summary of the number of deprecations found' do
+          expect { formatter.deprecation(:deprecated => 'foo') }.to raise_error(RSpec::Core::DeprecationError)
+
+          formatter.deprecation_summary
+
+          expect(summary_stream.string).to eq("\n1 deprecation found.\n")
+        end
+
+        it 'pluralizes the count when it is greater than 1' do
+          expect { formatter.deprecation(:deprecated => 'foo') }.to raise_error(RSpec::Core::DeprecationError)
+          expect { formatter.deprecation(:deprecated => 'bar') }.to raise_error(RSpec::Core::DeprecationError)
+
+          formatter.deprecation_summary
+
+          expect(summary_stream.string).to eq("\n2 deprecations found.\n")
+        end
+      end
+
       context "with an IO deprecation_stream" do
         let(:deprecation_stream) { StringIO.new }
 


### PR DESCRIPTION
We were getting an "undefined method `path'" error.

While I'm at it, I prevented the RAISE_ERROR_CONFIG_NOTICE
from being printed when that config option is being used.

Fixes #1170.
