### PR TITLE
Fix failure in end-of-run summary for the error stream (for 2.99)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### 2.99.0.beta2 Development
+[full changelog](http://github.com/rspec/rspec-core/compare/v2.99.0.beta1...2-99-maintenance)
+
+Bug Fixes:
+
+* Fix failure (undefined method `path`) in end-of-run summary
+  when `raise_errors_for_deprecations!` is configured. (Myron Marston)
+
 ### 2.99.0.beta1 / 2013-11-07
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.14.7...v2.99.0.beta1)
 

--- a/lib/rspec/core/formatters/deprecation_formatter.rb
+++ b/lib/rspec/core/formatters/deprecation_formatter.rb
@@ -16,7 +16,9 @@ module RSpec
 
         def printer
           @printer ||= case deprecation_stream
-                       when File, RaiseErrorStream
+                       when File
+                         ImmediatePrinter.new(FileStream.new(deprecation_stream), summary_stream, self)
+                       when RaiseErrorStream
                          ImmediatePrinter.new(deprecation_stream, summary_stream, self)
                        else
                          DelayedPrinter.new(deprecation_stream, summary_stream, self)
@@ -99,18 +101,10 @@ module RSpec
         end
 
         class ImmediatePrinter
-          include ::RSpec::Core::Formatters::Helpers
-
           attr_reader :deprecation_stream, :summary_stream, :deprecation_formatter
 
           def initialize(deprecation_stream, summary_stream, deprecation_formatter)
             @deprecation_stream = deprecation_stream
-
-            # In one of my test suites, I got lots of duplicate output in the
-            # deprecation file (e.g. 200 of the same deprecation, even though
-            # the `puts` below was only called 6 times). Setting `sync = true`
-            # fixes this (but we really have no idea why!).
-            @deprecation_stream.sync = true
 
             @summary_stream = summary_stream
             @deprecation_formatter = deprecation_formatter
@@ -122,10 +116,8 @@ module RSpec
           end
 
           def deprecation_summary
-            if deprecation_formatter.count > 0
-              summary_stream.puts "\n#{pluralize(deprecation_formatter.count, 'deprecation')} logged to #{deprecation_stream.path}"
-              deprecation_stream.puts RAISE_ERROR_CONFIG_NOTICE
-            end
+            return if deprecation_formatter.count.zero?
+            deprecation_stream.summarize(summary_stream, deprecation_formatter.count)
           end
         end
 
@@ -180,12 +172,38 @@ module RSpec
 
         # Not really a stream, but is usable in place of one.
         class RaiseErrorStream
+          include ::RSpec::Core::Formatters::Helpers
+
           def puts(message)
             raise DeprecationError, message
           end
 
-          def sync=(value)
-            # no-op
+          def summarize(summary_stream, deprecation_count)
+            summary_stream.puts "\n#{pluralize(deprecation_count, 'deprecation')} found."
+          end
+        end
+
+        # Wraps a File object and provides file-specific operations.
+        class FileStream
+          include ::RSpec::Core::Formatters::Helpers
+
+          def initialize(file)
+            @file = file
+
+            # In one of my test suites, I got lots of duplicate output in the
+            # deprecation file (e.g. 200 of the same deprecation, even though
+            # the `puts` below was only called 6 times). Setting `sync = true`
+            # fixes this (but we really have no idea why!).
+            @file.sync = true
+          end
+
+          def puts(*args)
+            @file.puts(*args)
+          end
+
+          def summarize(summary_stream, deprecation_count)
+            summary_stream.puts "\n#{pluralize(deprecation_count, 'deprecation')} logged to #{@file.path}"
+            puts RAISE_ERROR_CONFIG_NOTICE
           end
         end
 

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -108,6 +108,27 @@ module RSpec::Core::Formatters
         end
       end
 
+      context "with an Error deprecation_stream" do
+        let(:deprecation_stream) { DeprecationFormatter::RaiseErrorStream.new }
+
+        it 'prints a summary of the number of deprecations found' do
+          expect { formatter.deprecation(:deprecated => 'foo') }.to raise_error(RSpec::Core::DeprecationError)
+
+          formatter.deprecation_summary
+
+          expect(summary_stream.string).to eq("\n1 deprecation found.\n")
+        end
+
+        it 'pluralizes the count when it is greater than 1' do
+          expect { formatter.deprecation(:deprecated => 'foo') }.to raise_error(RSpec::Core::DeprecationError)
+          expect { formatter.deprecation(:deprecated => 'bar') }.to raise_error(RSpec::Core::DeprecationError)
+
+          formatter.deprecation_summary
+
+          expect(summary_stream.string).to eq("\n2 deprecations found.\n")
+        end
+      end
+
       context "with an IO deprecation_stream" do
         let(:deprecation_stream) { StringIO.new }
 


### PR DESCRIPTION
We were getting an "undefined method `path'" error.

While I'm at it, I prevented the RAISE_ERROR_CONFIG_NOTICE
from being printed when that config option is being used.

Fixes #1170.
