### PR TITLE
Introduce config.set_proc_title

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -44,6 +44,8 @@ require_rspec['core/example_group']
 module RSpec
   autoload :SharedContext, 'rspec/core/shared_context'
 
+  PROCESS_TITLE = $0.dup
+
   # @private
   def self.wants_to_quit
   # Used internally to determine what to do when a SIGINT is received

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -205,6 +205,10 @@ module RSpec
         RSpec.deprecate("RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=")
       end
 
+      # @macro add_setting
+      # Set process title to be the current example location.
+      add_setting :set_proc_title
+
       # @private
       add_setting :tty
       # @private
@@ -250,6 +254,7 @@ module RSpec
         @fixed_color = :blue
         @detail_color = :cyan
         @profile_examples = false
+        @set_proc_title = false
         @requires = []
         @libs = []
       end

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -101,6 +101,7 @@ module RSpec
       # the instance of {ExampleGroup}.
       # @param example_group_instance the instance of an ExampleGroup subclass
       def run(example_group_instance, reporter)
+        set_proc_title if RSpec.configuration.set_proc_title?
         @example_group_instance = example_group_instance
         RSpec.current_example = self
 
@@ -138,6 +139,7 @@ module RSpec
 
         finish(reporter)
       ensure
+        restore_proc_title if RSpec.configuration.set_proc_title?
         RSpec.current_example = nil
       end
 
@@ -306,6 +308,16 @@ An error occurred #{context}
 
       def record(results={})
         execution_result.update(results)
+      end
+
+      def set_proc_title
+        proc_title  = "rspec #{self.location}"
+        proc_title += " # #{self.full_description}" unless RSpec.configuration.set_proc_title == :simple
+        $0 = proc_title
+      end
+
+      def restore_proc_title
+        $0 = RSpec::PROCESS_TITLE
       end
     end
   end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1497,5 +1497,16 @@ module RSpec::Core
       end
     end
 
+    describe '#set_proc_title' do
+      it 'defaults to false' do
+        expect(config.set_proc_title).to eq false
+      end
+
+      it 'is configurable' do
+        config.set_proc_title = true
+        expect(config.set_proc_title).to eq true
+      end
+    end
+
   end
 end


### PR DESCRIPTION
`config.set_proc_title` is a setting to enable a feature of example to set the
title of process of rspec to be the current example location.

If config.set_proc_title set to true, the process title is set to the current
example location and the full description of the example.

If config.set_proc_title set to `:simple`, the process title is set to the
current example location.
