### PR TITLE
Deprecate inexact mock_with options.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,14 @@ Enhancements:
   `expect(subject)` and can be used in an expression like:
   `it { is_expected.to read_well }`. (Myron Marston)
 
+Deprecations:
+
+* Deprecate inexact `mock_with` config options. RSpec 3 will only support
+  the exact symbols `:rspec`, `:mocha`, `:flexmock`, `:rr` or `:nothing`
+  (or any module that implements the adapter interface). RSpec 2 did
+  fuzzy matching but this will not be supported going forward.
+  (Myron Marston)
+
 Bug Fixes:
 
 * Fix failure (undefined method `path`) in end-of-run summary

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -427,14 +427,19 @@ module RSpec
         when String, Symbol
           require case framework.to_s
                   when /rspec/i
+                    deprecate_unless_mock_adapter_name_is_exact(framework, :rspec)
                     'rspec/core/mocking/with_rspec'
                   when /mocha/i
+                    deprecate_unless_mock_adapter_name_is_exact(framework, :mocha)
                     'rspec/core/mocking/with_mocha'
                   when /rr/i
+                    deprecate_unless_mock_adapter_name_is_exact(framework, :rr)
                     'rspec/core/mocking/with_rr'
                   when /flexmock/i
+                    deprecate_unless_mock_adapter_name_is_exact(framework, :flexmock)
                     'rspec/core/mocking/with_flexmock'
                   else
+                    deprecate_unless_mock_adapter_name_is_exact(framework, :nothing)
                     'rspec/core/mocking/with_absolutely_nothing'
                   end
           RSpec::Core::MockFrameworkAdapter
@@ -1355,6 +1360,11 @@ MESSAGE
 
       def built_in_orderer?(block)
         [DEFAULT_ORDERING, RANDOM_ORDERING].include?(block)
+      end
+
+      def deprecate_unless_mock_adapter_name_is_exact(name, expected)
+        return if name == expected
+        RSpec.deprecate("`config.mock_with #{name.inspect}`", :replacement => "`config.mock_with :#{expected}`")
       end
 
     end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -227,10 +227,39 @@ module RSpec::Core
       it_behaves_like "a configurable framework adapter", :mock_with
 
       [:rspec, :mocha, :rr, :flexmock].each do |framework|
-        context "with #{framework}" do
+        context "with :#{framework}" do
           it "requires the adapter for #{framework}" do
             config.should_receive(:require).with("rspec/core/mocking/with_#{framework}")
             config.mock_with framework
+          end
+
+          it "does not print a deprecation" do
+            expect(RSpec).not_to receive(:deprecate)
+            config.mock_with framework
+          end
+        end
+
+        context "with #{framework.to_s.inspect}" do
+          it "requires the adapter for #{framework}" do
+            config.should_receive(:require).with("rspec/core/mocking/with_#{framework}")
+            config.mock_with framework.to_s
+          end
+
+          it "prints a deprecation warning" do
+            expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /mock_with/)
+            config.mock_with framework.to_s
+          end
+        end
+
+        context "with :the_#{framework}_adapter" do
+          it "requires the adapter for #{framework}" do
+            config.should_receive(:require).with("rspec/core/mocking/with_#{framework}")
+            config.mock_with :"the_#{framework}_adapter"
+          end
+
+          it "prints a deprecation warning" do
+            expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /mock_with/)
+            config.mock_with :"the_#{framework}_adapter"
           end
         end
       end
@@ -253,9 +282,28 @@ module RSpec::Core
         end
       end
 
-      it "uses the null adapter when set to any unknown key" do
-        config.should_receive(:require).with('rspec/core/mocking/with_absolutely_nothing')
-        config.mock_with :crazy_new_mocking_framework_ive_not_yet_heard_of
+      context "with an unknown key" do
+        it "uses the null adapter" do
+          config.should_receive(:require).with('rspec/core/mocking/with_absolutely_nothing')
+          config.mock_with :crazy_new_mocking_framework_ive_not_yet_heard_of
+        end
+
+        it "prints a deprecation warning" do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /mock_with/)
+          config.mock_with :crazy_new_mocking_framework_ive_not_yet_heard_of
+        end
+      end
+
+      context "with :nothing" do
+        it "uses the null adapter" do
+          config.should_receive(:require).with('rspec/core/mocking/with_absolutely_nothing')
+          config.mock_with :nothing
+        end
+
+        it "does not print a deprecation warning" do
+          expect(RSpec).not_to receive(:deprecate)
+          config.mock_with :nothing
+        end
       end
 
       context 'when there are already some example groups defined' do


### PR DESCRIPTION
RSpec 3 will not do the fuzzy matching that was done before.

This adds a deprecation for the breaking change in #1188.
