### PR TITLE
Refactor CommandLine.run to allow it to be more cleanly customised

### DIFF
--- a/lib/rspec/core/command_line.rb
+++ b/lib/rspec/core/command_line.rb
@@ -17,7 +17,7 @@ module RSpec
       # @param [IO] out
       def run(err, out)
         setup(err, out)
-        run_specs
+        run_specs(@world.ordered_example_groups)
       end
 
       def setup(err, out)
@@ -28,11 +28,11 @@ module RSpec
         @world.announce_filters
       end
 
-      def run_specs
+      def run_specs(example_groups)
         @configuration.reporter.report(@world.example_count) do |reporter|
           begin
             @configuration.hooks.run(:before, :suite)
-            @world.ordered_example_groups.map {|g| g.run(reporter) }.all? ? 0 : @configuration.failure_exit_code
+            example_groups.map {|g| g.run(reporter) }.all? ? 0 : @configuration.failure_exit_code
           ensure
             @configuration.hooks.run(:after, :suite)
           end

--- a/spec/rspec/core/command_line_spec.rb
+++ b/spec/rspec/core/command_line_spec.rb
@@ -50,7 +50,7 @@ module RSpec::Core
         end
         it "passes the example group list to #run_specs" do
           command_line = build_command_line passing_spec_filename
-          expect(command_line).to receive(:run_specs).with(no_args)
+          expect(command_line).to receive(:run_specs).with(world.example_groups)
           command_line.run(err, out)
         end
       end


### PR DESCRIPTION
This refactor makes two changes, both of which are useful from gems like test-queue.
- It separates spec setup and spec running into their own methods, making them callable separately. This is useful because in test-queue and its ilk, the setup is done once in the master, but the specs are run in each worker.
- It parameterises the list of specs to be run. This makes customising that list clean (in the test-queue case, passing an iterator that reads example groups from a socket).

(This patch doesn't change any externally called methods.)

What does everyone think -- would this be a reasonable change?
