### PR TITLE
Fix spec name in features.

### DIFF
--- a/features/hooks/before_and_after_hooks.feature
+++ b/features/hooks/before_and_after_hooks.feature
@@ -46,7 +46,7 @@ Feature: before and after hooks
             expect(@thing.widgets.count).to eq(0)
           end
 
-          it "can get accept new widgets" do
+          it "can accept new widgets" do
             @thing.widgets << Object.new
           end
 
@@ -80,7 +80,7 @@ Feature: before and after hooks
             expect(@thing.widgets.count).to eq(0)
           end
 
-          it "can get accept new widgets" do
+          it "can accept new widgets" do
             @thing.widgets << Object.new
           end
 


### PR DESCRIPTION
There was some awkward double verb usage in some spec names in the cucumber features. I chose what I thought sounded better.
