### PR TITLE
Remove redundant method.

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -325,15 +325,10 @@ module RSpec
       end
 
       # @private
-      def self.assign_before_all_ivars(ivars, example_group_instance)
-        ivars.each { |ivar, val| example_group_instance.instance_variable_set(ivar, val) }
-      end
-
-      # @private
       def self.run_before_all_hooks(example_group_instance)
         return if descendant_filtered_examples.empty?
         begin
-          assign_before_all_ivars(superclass.before_all_ivars, example_group_instance)
+          set_ivars(example_group_instance, superclass.before_all_ivars)
 
           AllHookMemoizedHash::Before.isolate_for_all_hook(example_group_instance) do
             hooks.run(:before, :all, example_group_instance)
@@ -346,7 +341,7 @@ module RSpec
       # @private
       def self.run_after_all_hooks(example_group_instance)
         return if descendant_filtered_examples.empty?
-        assign_before_all_ivars(before_all_ivars, example_group_instance)
+        set_ivars(example_group_instance, before_all_ivars)
 
         AllHookMemoizedHash::After.isolate_for_all_hook(example_group_instance) do
           hooks.run(:after, :all, example_group_instance)


### PR DESCRIPTION
Poking around in the code I noticed a redundant method. I chose the more generic sounding one.
