### PR TITLE
Fix warnings.

### DIFF
--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -173,5 +173,5 @@ module RSpec
     end
   end
 
-  instance_eval &Core::SharedExampleGroup::TopLevelDSL.definitions
+  instance_eval(&Core::SharedExampleGroup::TopLevelDSL.definitions)
 end


### PR DESCRIPTION
When running the specs before #1214 and #1215, I noticed there were some warnings emitted during the spec run. This fixes those.
