### PR TITLE
We only want to print out command if verbose is set

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -92,14 +92,14 @@ module RSpec
         command = spec_command
 
         begin
-          report($stdout, command, verbose)
+          $stdout.puts(command}) if verbose
           success = system(command)
         rescue
           $stderr.puts failure_message if failure_message
         end
         
         if fail_on_error && !success
-          report($stderr, "#{command} failed", verbose)
+          $stderr.puts("#{command} failed") if verbose
           exit($?.exitstatus)
         end
       end
@@ -126,10 +126,6 @@ module RSpec
 
       def blank
         lambda {|s| s.nil? || s == ""}
-      end
-      
-      def report(output, message, verbose)
-        output.puts(message) if verbose
       end
     end
   end


### PR DESCRIPTION
I've added this because I've noticed that on spec directories where there are a lot of files the header of the test and the footer of the test tend to be extremely verbose.

You can only stop the header from printing out (`verbose = false`) but not the footer. In addition I've moved the other failure messages to `$stderr`.

It's looking more and more like this logging functionality should be moved to another object for composability ease.

I do need some help figure out where to write these tests.
