### PR TITLE
Add deprecation warning for `treat_symbols_as_metadata_keys_with_true_values`.

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -227,7 +227,9 @@ module RSpec
       # for this being the default behavior in RSpec 3. Now this option is
       # a no-op.
       def treat_symbols_as_metadata_keys_with_true_values=(value)
-        RSpec.deprecate("RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=")
+        RSpec.deprecate("RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=",
+                        :message => "RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=" +
+                                    "is deprecated, it is now set to true as default and setting it to false has no effect.")
       end
 
       # @private


### PR DESCRIPTION
Add a custom message to notify users that this is now the default behavior.

I wanted to add a spec that tested the message but when I was looking at the [corresponding spec](https://github.com/rspec/rspec-core/blob/master/spec/rspec/core/configuration_spec.rb#L1003-L1008), I could not figure out what was going on with `expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)`. Let me know how I can update the spec to verify that the custom message is being shown.

For https://github.com/rspec/rspec-core/issues/1166.
