### PR TITLE
Prevent method redefinition warnings

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -229,7 +229,12 @@ EOS
           # We have to pass the block directly to `define_method` to
           # allow it to use method constructs like `super` and `return`.
           raise "#let or #subject called without a block" if block.nil?
-          MemoizedHelpers.module_for(self).send(:define_method, name, &block)
+          mod = MemoizedHelpers.module_for(self)
+          if mod.instance_methods(false).any? { |imethod_name| imethod_name.to_s == name.to_s }
+            mod.send(:undef_method, name)
+            undef_method(name)
+          end
+          mod.send(:define_method, name, &block)
 
           # Apply the memoization. The method has been defined in an ancestor
           # module so we can use `super` here to get the value.

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -53,6 +53,18 @@ module RSpec::Core
         expect(outer_subject_value).to eq([:parent_group])
         expect(inner_subject_value).to eq([:parent_group, :child_group])
       end
+
+      it "can be overriden without warnings in the same group" do
+        subject_value = nil
+
+        ExampleGroup.describe do
+          subject { :original }
+          subject { :overridden }
+          example { subject_value = subject }
+        end.run
+
+        expect(subject_value).to eq :overridden
+      end
     end
 
     describe "explicit subject" do


### PR DESCRIPTION
Using subject twice, (or a let) in the same describe block will cause a 
warning, this currently affects `rspec-rails` quite a lot, this fix removes
those warnings by removing the methods before redefining them.

The detection method limits the undef calls to only this scope, not nested
scopes and also should be lazily efficient?
