### PR TITLE
Fib the encoding to File.readlines to prevent failure on UTF-8 code lines

### DIFF
--- a/lib/rspec/core/formatters/base_formatter.rb
+++ b/lib/rspec/core/formatters/base_formatter.rb
@@ -204,8 +204,7 @@ module RSpec
           file_path, line_number = matching_line.match(/(.+?):(\d+)(|:\d+)/)[1..2]
 
           if File.exist?(file_path)
-            lines = defined?(Encoding) ? File.readlines(file_path, :encoding => 'BINARY')
-                                       : File.readlines(file_path)
+            lines = defined?(Encoding) ? File.readlines(file_path, :encoding => 'BINARY') : File.readlines(file_path)
             lines[line_number.to_i - 1] ||
               "Unable to find matching line in #{file_path}"
           else


### PR DESCRIPTION
While working on brianmario/mysql2#470 I came across this problem. I have a UTF-8 encoded Chinese character in the Ruby source file, I'm using this to test encoding support for MySQL error messages. I turned up a problem in rspec, consistent from 2.8.1 (the versions we're pinned at in mysql2) up through 2.14.7 (I was testing if this had been fixed recently, nope). With this change in place, I get the expected failed spec output.

Backtrace without this change:

```
  1) Mysql2::Error behaves like mysql2 error encoding (MySQL < 5.5) #message   should transcode from nil to ASCII-8BIT
mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/formatters/base_formatter.rb:198:in `readlines': U+5B57 from UTF-8 to US-ASCII (Encoding::UndefinedConversionError)
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/formatters/base_formatter.rb:198:in `read_failed_line'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/formatters/base_text_formatter.rb:299:in `dump_failure_info'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/formatters/base_text_formatter.rb:293:in `dump_failure'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/formatters/base_text_formatter.rb:24:in `block in dump_failures'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/formatters/base_text_formatter.rb:22:in `each'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/formatters/base_text_formatter.rb:22:in `each_with_index'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/formatters/base_text_formatter.rb:22:in `dump_failures'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:127:in `block in notify'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:126:in `each'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:126:in `notify'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:109:in `finish'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/reporter.rb:60:in `report'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/command_line.rb:25:in `run'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:80:in `run'
    from mysql2/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.14.7/lib/rspec/core/runner.rb:17:in `block in autorun'
ruby -S rspec ./spec/em/em_spec.rb ./spec/mysql2/client_spec.rb ./spec/mysql2/error_spec.rb ./spec/mysql2/result_spec.rb failed
```
