### PR TITLE
Integrate with the new rspec-mocks lifecycle

### DIFF
--- a/lib/rspec/core/mocking_adapters/rspec.rb
+++ b/lib/rspec/core/mocking_adapters/rspec.rb
@@ -14,7 +14,7 @@ module RSpec
         end
 
         def setup_mocks_for_rspec
-          ::RSpec::Mocks.setup(self)
+          ::RSpec::Mocks.setup
         end
 
         def verify_mocks_for_rspec

--- a/spec/support/sandboxed_mock_space.rb
+++ b/spec/support/sandboxed_mock_space.rb
@@ -23,8 +23,11 @@ module RSpec
     # example completes.
     class SandboxedMockSpace < ::RSpec::Mocks::Space
       def self.sandboxed
-        orig_space = RSpec::Mocks.space
-        RSpec::Mocks.space = RSpec::Core::SandboxedMockSpace.new
+        sandboxed_space = RSpec::Core::SandboxedMockSpace.new
+        RSpec::Mocks.send(:remove_const, "ERROR_SPACE")
+        RSpec::Mocks.const_set("ERROR_SPACE", sandboxed_space)
+        RSpec::Mocks.send(:remove_const, "MOCK_SPACE")
+        RSpec::Mocks.const_set("MOCK_SPACE", sandboxed_space)
 
         RSpec::Core::Example.class_eval do
           alias_method :orig_run, :run
@@ -43,7 +46,10 @@ module RSpec
           remove_method :orig_run
         end
 
-        RSpec::Mocks.space = orig_space
+        RSpec::Mocks.send(:remove_const, "MOCK_SPACE")
+        RSpec::Mocks.const_set("MOCK_SPACE", RSpec::Mocks::Space.new)
+        RSpec::Mocks.send(:remove_const, "ERROR_SPACE")
+        RSpec::Mocks.const_set("ERROR_SPACE", RSpec::Mocks::ErrorSpace.new)
       end
 
       class Sandbox


### PR DESCRIPTION
This wants to be merged after https://github.com/rspec/rspec-mocks/pull/449 but makes -core work with the changes in -mocks for that pull request.
