### PR TITLE
use binstub if present

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -84,7 +84,7 @@ module RSpec
         @ruby_opts, @rspec_opts = nil, nil, nil
         @verbose, @fail_on_error = true, true
 
-        @rspec_path = 'rspec'
+        @rspec_path = File.exists?('bin/rspec') ? 'bin/rspec' : 'rspec'
         @pattern    = './spec{,/*/**}/*_spec.rb'
       end
 


### PR DESCRIPTION
Hey,

This updates the rake task to use `bin/rspec` if it's present.

Please see previous discussion @ https://github.com/rspec/rspec-rails/pull/914
