### PR TITLE
Mock framework should be available in around hooks

### DIFF
--- a/features/mock_framework_integration/use_any_framework.feature
+++ b/features/mock_framework_integration/use_any_framework.feature
@@ -33,6 +33,14 @@ Feature: mock with an alternative framework
           def verify_expectors
             expectors.each {|d| d.verify}
           end
+
+          def setup!
+            @setup_done = true
+          end
+
+          def setup?
+            !!@setup_done
+          end
         end
 
         def initialize
@@ -65,7 +73,7 @@ Feature: mock with an alternative framework
 
         module RSpecAdapter
           def setup_mocks_for_rspec
-            # no setup necessary
+            Expector.setup!
           end
 
           def verify_mocks_for_rspec
@@ -88,6 +96,11 @@ Feature: mock with an alternative framework
       end
 
       describe Expector do
+        around do |example|
+          expect(Expector).to be_setup
+          example.run
+        end
+
         it "passes when message is received" do
           expector = Expector.new
           expector.expect(:foo)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -237,6 +237,7 @@ An error occurred #{context}
     private
 
       def with_around_each_hooks(&block)
+        @example_group_instance.setup_mocks_for_rspec
         if around_each_hooks.empty?
           yield
         else
@@ -277,7 +278,6 @@ An error occurred #{context}
       end
 
       def run_before_each
-        @example_group_instance.setup_mocks_for_rspec
         @example_group_class.hooks.run(:before, :each, self)
       end
 


### PR DESCRIPTION
**Problem**: sometimes, the mocking framework is not available in the `around` hooks. On further inspection, we can see this only happens if the spec containing such an `around` hook is run first, before any other specs.

**Reason**: `setup_mocks_for_rspec` is called only after the `around` hook has started, and before the `before` hooks have run. Therefore, if the first spec to run has an `around` hook, this won't have access to the mocking framework. If this spec is run later instead, the mocking framework will have been activated by the time the `around` hook is reached.

**The test case**: I am providing one, but I'm not sure that's the place where you would want it. If you have any feedback, I'll be happy to relocate it.

**Versions affected**: this pull request is against master, but I initially experienced this problem with 2.14.7, where the patch is almost the same. If this is pull request is ok, I'll be happy to create another one for 2-14-maintenance, or whatever else necessary.
