### PR TITLE
fixed warnings from ruby 2.1.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ task :default => [:spec, :cucumber]
 
 task :verify_private_key_present do
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
-  unless File.exists?(private_key)
+  unless File.exist?(private_key)
     raise "Your private key is not present. This gem should not be built without that."
   end
 end

--- a/lib/rspec/core/ruby_project.rb
+++ b/lib/rspec/core/ruby_project.rb
@@ -24,7 +24,7 @@ module RSpec
       end
 
       def find_first_parent_containing(dir)
-        ascend_until {|path| File.exists?(File.join(path, dir))}
+        ascend_until {|path| File.exist?(File.join(path, dir))}
       end
 
       def ascend_until

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.7'
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
-  if File.exists?(private_key)
+  if File.exist?(private_key)
     s.signing_key = private_key
     s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end


### PR DESCRIPTION
some warnings occured from ruby 2.1.0 or later. This patch fix this problem.

warnings are followings:

```
warning: File.exists? is a deprecated name, use File.exist? instead
```
