### PR TITLE
Fix search of a spec files in rake task

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -85,7 +85,7 @@ module RSpec
         @verbose, @fail_on_error = true, true
 
         @rspec_path = 'rspec'
-        @pattern    = './spec{,/*/**}/*_spec.rb'
+        @pattern    = './spec/**/*/*_spec.rb'
       end
 
       def run_task(verbose)


### PR DESCRIPTION
Fix a issue https://github.com/rspec/rspec-core/issues/1113

apply more a sensitive pattern to find a spec files inside the symlink folders

More details here http://stackoverflow.com/questions/357754/can-i-traverse-symlinked-directories-in-ruby-with-a-glob
