### PR TITLE
Avoid mangling file name command line arguments

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -6,9 +6,7 @@ module RSpec
     # @private
     class ConfigurationOptions
       def initialize(args)
-        @args = args.map {|a|
-          a.sub("default_path", "default-path").sub("line_number",  "line-number")
-        }
+        @args = args.dup
       end
 
       def configure(config)

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -311,6 +311,12 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
       )
     end
 
+    it "parses file names that look like options line-number and default-path" do
+      expect(parse_options("spec/default_path_spec.rb", "spec/line_number_spec.rb")).to include(
+        :files_or_directories_to_run => ["spec/default_path_spec.rb", "spec/line_number_spec.rb"]
+      )
+    end
+
     it "provides no files or directories if spec directory does not exist" do
       allow(FileTest).to receive(:directory?).with("spec").and_return false
       expect(parse_options()).to include(:files_or_directories_to_run => [])


### PR DESCRIPTION
This change stops RSpec from mangling file names that have substrings 'line_number' or 'default_path'.
