### PR TITLE
Include the spec location in warnings if we can't generate a call site.

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -16,7 +16,6 @@ require_rspec['core/version']
 
 require 'rspec/support/caller_filter'
 require 'rspec/core/warnings'
-require 'rspec/support/warnings'
 
 require_rspec['core/flat_map']
 require_rspec['core/filter_manager']
@@ -44,6 +43,8 @@ require_rspec['core/example_group']
 
 module RSpec
   autoload :SharedContext, 'rspec/core/shared_context'
+
+  extend RSpec::Core::Warnings
 
   # @private
   def self.wants_to_quit

--- a/lib/rspec/core/warnings.rb
+++ b/lib/rspec/core/warnings.rb
@@ -1,22 +1,38 @@
+require "rspec/support/warnings"
+
 module RSpec
+  module Core
+    module Warnings
+      # @private
+      #
+      # Used internally to print deprecation warnings
+      def deprecate(deprecated, data = {})
+        RSpec.configuration.reporter.deprecation(
+          {
+            :deprecated => deprecated,
+            :call_site => CallerFilter.first_non_rspec_line
+          }.merge(data)
+        )
+      end
 
-  # @private
-  #
-  # Used internally to print deprecation warnings
-  def self.deprecate(deprecated, data = {})
-    RSpec.configuration.reporter.deprecation(
-      {
-        :deprecated => deprecated,
-        :call_site => CallerFilter.first_non_rspec_line
-      }.merge(data)
-    )
+      # @private
+      #
+      # Used internally to print deprecation warnings
+      def warn_deprecation(message)
+        RSpec.configuration.reporter.deprecation :message => message
+      end
+
+      def warn_with(message, options = {})
+        if options[:use_spec_location_as_call_site]
+          message += "." unless message.end_with?(".")
+
+          if RSpec.current_example
+            message += " Warning generated from spec at `#{RSpec.current_example.location}`."
+          end
+        end
+
+        super(message, options)
+      end
+    end
   end
-
-  # @private
-  #
-  # Used internally to print deprecation warnings
-  def self.warn_deprecation(message)
-    RSpec.configuration.reporter.deprecation :message => message
-  end
-
 end

--- a/spec/rspec/core/warnings_spec.rb
+++ b/spec/rspec/core/warnings_spec.rb
@@ -26,4 +26,42 @@ RSpec.describe "rspec warnings and deprecations" do
     end
   end
 
+  describe "#warn_with" do
+    context "when :use_spec_location_as_call_site => true is passed" do
+      let(:options) {
+        {
+          :use_spec_location_as_call_site => true,
+          :call_site                      => nil,
+        }
+      }
+
+      it "adds the source location of spec" do
+        line = __LINE__ - 1
+        file_path = RSpec::Core::Metadata.relative_path(__FILE__)
+        expect(Kernel).to receive(:warn).with(/The warning. Warning generated from spec at `#{file_path}:#{line}`./)
+
+        RSpec.warn_with("The warning.", options)
+      end
+
+      it "appends a period to the supplied message if one is not present" do
+        line = __LINE__ - 1
+        file_path = RSpec::Core::Metadata.relative_path(__FILE__)
+        expect(Kernel).to receive(:warn).with(/The warning. Warning generated from spec at `#{file_path}:#{line}`./)
+
+        RSpec.warn_with("The warning", options)
+      end
+
+      context "when there is no current example" do
+        before do
+          allow(RSpec).to receive(:current_example).and_return(nil)
+        end
+
+        it "adds no message about the spec location" do
+          expect(Kernel).to receive(:warn).with(/The warning\.$/)
+
+          RSpec.warn_with("The warning.", options)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Whilst investigating https://github.com/rspec/rspec-mocks/pull/496 I came across the problem where it wasn't clear where the warning was being issued from, and that the caller filter would fail because we're outside of user code at that point.

This patch makes it so that RSpec core's warn_with will include the location of the spec that's running if the call site is explicitly nil. This means that we can add warnings outside a user's testing block and still hopefully point them in the correct direction.
