### PR TITLE
A few improvements to the mocks/expectations part of the build.

### DIFF
--- a/script/test_all
+++ b/script/test_all
@@ -45,6 +45,7 @@ bundle exec bin/cucumber --strict
 script/prevent_runtime_method_cache_busters
 
 # Test against other RSpec gems.
+unset BUNDLE_GEMFILE
 
 # Delete the directory for idempotency when running locally
 export TMPDIR="/tmp"
@@ -61,7 +62,7 @@ cd $TMPDIR/rspec-ci
 
 # The steps to test the gems are the same, this function does them.
 function test_gem {
-    git clone git://github.com/rspec/rspec-$1
+    git clone git://github.com/rspec/rspec-$1 --depth 1
     cd rspec-$1
     pwd
     git fetch origin
@@ -70,9 +71,8 @@ function test_gem {
     bundle_flags=`cat .travis.yml  | grep bundler_args | tr -d '"' | grep -o " .*"`
 
     bundle install $bundle_flags
-    bundle exec rspec -b
+    bin/rspec -b
     cd ../
-    rm -rf rspec-$1
 }
 
 # Test rspec-mocks and rspec-expectations.


### PR DESCRIPTION
- Our `bundle install` was installing core's bundle, even for mocks
  or expectations, because travis has exported the BUNDLE_GEMFILE
  env var. We need to unset it so that the correct bundle is installed.
- Clone the repos at a lower depth for faster cloning.
- Use `bin/rspec` just like our normal builds do. Before this wouldn't
  work because of the BUNDLE_GEMFILE issue.
- No need to delete the dir after the build.

/cc @samphippen 
