### PR TITLE
Fix usage of mocks across scopes.

### DIFF
--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1842,13 +1842,16 @@ module RSpec::Core
       [:example, :running_example].each do |name|
         it "silences the deprecation warning for ##{name} when configured to expose via that name" do
           RSpec.configuration.expose_current_running_example_as name
-          allow(RSpec).to receive(:deprecate)
 
-          ExampleGroup.describe "Group" do
-            specify { __send__(name) }
+          result = ExampleGroup.describe "Group" do
+            specify {
+              allow(RSpec).to receive(:deprecate)
+              __send__(name)
+              expect(RSpec).to_not have_received(:deprecate)
+            }
           end.run
 
-          expect(RSpec).to_not have_received(:deprecate)
+          expect(result).to eq(true)
         end
       end
     end

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -147,8 +147,6 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
     end
 
     context 'for #share_as' do
-      before { allow(RSpec).to receive(:deprecate) }
-
       it 'outputs the name and location' do
 
         group.share_as :FooBar do
@@ -286,8 +284,6 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
       end
 
       context 'for #share_as' do
-        before { allow(RSpec).to receive(:deprecate) }
-
         it 'outputs the name and location' do
 
           group.share_as :FooBar2 do
@@ -475,7 +471,6 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
     describe "##{name}" do
       before do
         allow(RSpec.configuration).to receive(:color_enabled?) { true }
-        allow(RSpec).to receive(:deprecate)
       end
 
       it "prints the text using the color code for #{name}" do


### PR DESCRIPTION
These specs were previously infinitely recursing due to a recent
deprecation added to this behaviour.

Speculative fix for #1269, this might not be the best way. The base formatter allows didn't appear to do anything, and I confirmed the configuration spec change fails if a deprecation is received.
