### PR TITLE
Make -d correctly list itself as an invalid option

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -48,10 +48,6 @@ module RSpec::Core
           options[:libs] << dir
         end
 
-        parser.on('--I') do
-          raise OptionParser::InvalidOption.new
-        end
-
         parser.on('-r', '--require PATH', 'Require a file.') do |path|
           options[:requires] ||= []
           options[:requires] << path
@@ -225,6 +221,12 @@ FILTERING
         parser.on_tail('-h', '--help', "You're looking at it.") do
           puts parser
           exit
+        end
+
+        %w[-d --I].each do |option|
+          parser.on(option) do
+            raise OptionParser::InvalidOption.new
+          end
         end
 
       end

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -27,7 +27,10 @@ module RSpec::Core
     end
 
     {
-      '--init' => ['-i','--I'],
+      '--init'         => ['-i','--I'],
+      '--default-path' => ['-d'],
+      '--dry-run'      => ['-d'],
+      '--drb-port'     => ['-d'],
     }.each do |long, shorts|
       shorts.each do |option|
         it "won't parse #{option} as a shorthand for #{long}" do


### PR DESCRIPTION
Add `-d` to the list of invalid options since we removed the `--debugger` flag.

May help with issues like rspec/rspec-rails#918
