### PR TITLE
Improve the deprecation for `-d` and `--debugger` slightly

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -573,10 +573,13 @@ module RSpec
       end
 
       def debug=(bool)
-        if bool
-          # Usually this is called automatically by the --debug CLI option, so the
-          # deprecation message doesn't mention `RSpec::Core::Configuration#debug=`
+        if bool == :cli
           RSpec.deprecate("RSpec's built-in debugger support",
+                          :replacement => "a CLI option like `-rruby-debug` or `-rdebugger`",
+                          :call_site => nil)
+          bool = true
+        elsif bool
+          RSpec.deprecate("RSpec::Core::Configuration#debug=",
                           :replacement => "a CLI option like `-rruby-debug` or `-rdebugger`")
         else
           # ...but the only way to call this with a false value is to

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -81,7 +81,7 @@ module RSpec::Core
         end
 
         parser.on('-d', '--debugger', 'Enable debugging.') do |o|
-          options[:debug] = true
+          options[:debug] = :cli
         end
 
         parser.on('--fail-fast', 'Abort the run on first failure.') do |o|

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -105,7 +105,7 @@ describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolat
     it "sets debug directly" do
       opts = config_options_object("--debug")
       config = RSpec::Core::Configuration.new
-      config.should_receive(:debug=).with(true)
+      config.should_receive(:debug=).with(:cli)
       opts.configure(config)
     end
 
@@ -224,8 +224,8 @@ describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolat
 
   describe "--debug, -d" do
     it "sets :debug => true" do
-      expect(parse_options("--debug")).to include(:debug => true)
-      expect(parse_options("-d")).to include(:debug => true)
+      expect(parse_options("--debug")).to include(:debug => :cli)
+      expect(parse_options("-d")).to include(:debug => :cli)
     end
   end
 


### PR DESCRIPTION
The deprecation for the debugger functionality currently blows up when executed from the cli,
so this tidies this up slightly.
