### PR TITLE
Tag slow specs.

### DIFF
--- a/spec/command_line/order_spec.rb
+++ b/spec/command_line/order_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe 'command line', :ui do
+RSpec.describe 'command line', :ui, :slow do
   let(:stderr) { StringIO.new }
   let(:stdout) { StringIO.new }
 

--- a/spec/rspec/core/drb_command_line_spec.rb
+++ b/spec/rspec/core/drb_command_line_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "::DRbCommandLine", :type => :drb, :unless => RUBY_PLATFORM == 'j
     end
   end
 
-  context "with server running" do
+  context "with server running", :slow do
     class SimpleDRbSpecServer
       def self.run(argv, err, out)
         options = RSpec::Core::ConfigurationOptions.new(argv)

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     end
   end
 
-  describe "#dump_profile_slowest_examples" do
+  describe "#dump_profile_slowest_examples", :slow do
     example_line_number = nil
 
     before do
@@ -294,7 +294,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     end
   end
 
-  describe "#dump_profile_slowest_example_groups" do
+  describe "#dump_profile_slowest_example_groups", :slow do
     let(:group) do
       RSpec::Core::ExampleGroup.describe("slow group") do
         # Use a sleep so there is some measurable time, to ensure

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -14,7 +14,7 @@ module RSpec::Core::Formatters
 
     describe "#deprecation" do
 
-      context "with a File deprecation_stream" do
+      context "with a File deprecation_stream", :slow do
         let(:deprecation_stream) { File.open("#{Dir.tmpdir}/deprecation_summary_example_output", "w+") }
 
         it "prints a message if provided, ignoring other data" do
@@ -53,7 +53,7 @@ module RSpec::Core::Formatters
     end
 
     describe "#deprecation_summary" do
-      context "with a File deprecation_stream" do
+      context "with a File deprecation_stream", :slow do
         let(:deprecation_stream) { File.open("#{Dir.tmpdir}/deprecation_summary_example_output", "w") }
 
         it "prints a count of the deprecations" do

--- a/spec/rspec/core/formatters/helpers_spec.rb
+++ b/spec/rspec/core/formatters/helpers_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RSpec::Core::Formatters::Helpers do
     context 'with mathn loaded' do
       include MathnIntegrationSupport
 
-      it "returns 'x minutes xx.x seconds' formatted string" do
+      it "returns 'x minutes xx.x seconds' formatted string", :slow do
         with_mathn_loaded do
           expect(helper.format_duration(133.7)).to eq("2 minutes 13.7 seconds")
         end

--- a/spec/rspec/core/formatters/html_formatter_spec.rb
+++ b/spec/rspec/core/formatters/html_formatter_spec.rb
@@ -65,7 +65,7 @@ module RSpec
             select  {|e| e =~ /formatter_specs\.rb/}
         end
 
-        describe 'produced HTML' do
+        describe 'produced HTML', :slow do
           def build_and_verify_formatter_output
             Dir.chdir(root) do
               actual_doc = Nokogiri::HTML(generated_html)
@@ -96,7 +96,7 @@ module RSpec
           context 'with mathn loaded' do
             include MathnIntegrationSupport
 
-            it "produces HTML identical to the one we designed manually" do
+            it "produces HTML identical to the one we designed manually", :slow do
               with_mathn_loaded { build_and_verify_formatter_output }
             end
           end

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
     end
   end
 
-  describe "#dump_profile_slowest_examples" do
+  describe "#dump_profile_slowest_examples", :slow do
 
     before do
       group = RSpec::Core::ExampleGroup.describe("group") do
@@ -139,7 +139,7 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
     end
   end
 
-  describe "#dump_profile_slowest_example_groups" do
+  describe "#dump_profile_slowest_example_groups", :slow do
     let(:group) do
       RSpec::Core::ExampleGroup.describe("slow group") do
         # Use a sleep so there is some measurable time, to ensure
@@ -162,7 +162,7 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
       end
     end
 
-    context "with multiple example groups" do
+    context "with multiple example groups", :slow do
       before do
         group2 = RSpec::Core::ExampleGroup.describe("fast group") do
           example("example 1") { sleep 0.004 }

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -54,7 +54,7 @@ module RSpec::Core
     end
 
     context 'with custom exit status' do
-      it 'returns the correct status on exit' do
+      it 'returns the correct status on exit', :slow do
         with_isolated_stderr do
           expect($stderr).to receive(:puts) { |cmd| expect(cmd).to match(/-e "exit\(2\);".* failed/) }
           expect(task).to receive(:exit).with(2)

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -40,7 +40,9 @@ module RSpec::Core
       end
     end
 
-    describe "#running_in_drb?" do
+    # This is intermittently slow because this method calls out to the network
+    # interface.
+    describe "#running_in_drb?", :slow do
       it "returns true if drb server is started with 127.0.0.1" do
         allow(::DRb).to receive(:current_server).and_return(double(:uri => "druby://127.0.0.1:0000/"))
 

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe RSpec do
 
   # This is hard to test :(. Best way I could come up with was starting
   # fresh ruby process w/o this stuff already loaded.
-  it "loads mocks and expectations when the constants are referenced" do
+  it "loads mocks and expectations when the constants are referenced", :slow do
     code = "$LOAD_PATH.replace(#{$LOAD_PATH.inspect}); " +
            'require "rspec"; ' +
            "puts RSpec::Mocks.name; " +


### PR DESCRIPTION
In a new project, I would have split these "integration" tests out from
"unit" tests. That still may be worthwhile, but this is the first step
regardless.

You can exclude these specs with `bundle exec rspec --tag ~@slow`, which for me cuts reported spec runtime down to 3.9s (from 6.52s).

As an aside while doing this, I noticed that 2.1 is about 10% slower than 2.0. I tried some naive GC tuning (literally just spamming different settings without actually measuring anything) and didn't make anything better. More investigation required.

@myronmarston 
