### PR TITLE
Execute pending examples and mark as failed if they succeed.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,11 @@ Breaking Changes for 3.0.0:
 * Remove support for deprecated `--configure` CLI option. (Myron Marston)
 * Remove support for deprecated `RSpec::Core::RakeTask#spec_opts=`.
   (Myron Marston)
+* An example group level `pending` block or `:pending` metadata now behaves the
+  same as a `pending` block inside an example: it will be executed and cause
+  a failure if it passes, otherwise it will be pending if it fails. The old
+  "never run" behaviour is still used when prefixing example/it/specify with an
+  `x`, or via a new `skip` method or `:skip` metadata option. (Xavier Shay)
 
 Enhancements:
 
@@ -41,6 +46,8 @@ Enhancements:
   pending. (Myron Marston)
 * Add `fdescribe` and `fcontext` as shortcuts to focus an example group.
   (Myron Marston)
+* Add `skip` method to not run any more of an example. (This behaviour is
+  identical to the old `pending` behaviour from RSpec 2.) (Xavier Shay)
 
 Bug Fixes:
 

--- a/features/command_line/format_option.feature
+++ b/features/command_line/format_option.feature
@@ -34,7 +34,7 @@ Feature: --format option
         end
 
         it "does something that is pending", :pending => true do
-          expect(5).to be > 3
+          expect(5).to be < 3
         end
       end
       """

--- a/features/hooks/around_hooks.feature
+++ b/features/hooks/around_hooks.feature
@@ -230,6 +230,7 @@ Feature: around hooks
 
         it "should be detected as pending" do
           pending
+          fail
         end
       end
       """

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -59,11 +59,39 @@ module RSpec
           define_method(name) do |*all_args, &block|
             desc, *args = *all_args
             options = Metadata.build_hash_from(args)
-            options.update(:pending => RSpec::Core::Pending::NOT_YET_IMPLEMENTED) unless block
+            options.update(:skip => RSpec::Core::Pending::NOT_YET_IMPLEMENTED) unless block
             options.update(extra_options)
+
+            # Metadata inheritance normally happens in `Example#initialize`,
+            # but for `:pending` specifically we need it earlier.
+            pending_metadata = options[:pending] || metadata[:pending]
+
+            if pending_metadata
+              options, block = ExampleGroup.pending_metadata_and_block_for(
+                options.merge(:pending => pending_metadata),
+                block
+              )
+            end
+
             examples << RSpec::Core::Example.new(self, desc, options, block)
             examples.last
           end
+        end
+
+        def pending_metadata_and_block_for(options, block)
+          if String === options[:pending]
+            reason = options[:pending]
+          else
+            options[:pending] = true
+            reason = RSpec::Core::Pending::NO_REASON_GIVEN
+          end
+
+          # This will fail if no block is provided, which is effectively the
+          # same as failing the example so it will be marked correctly as
+          # pending.
+          callback = Proc.new { pending(reason) { instance_exec(&block) } }
+
+          return options, callback
         end
 
         # Defines an example within a group.
@@ -100,18 +128,21 @@ module RSpec
         # @see example
         define_example_method :fit,     :focused => true, :focus => true
 
+        # Shortcut to define an example with :skip => 'Temporarily skipped with xexample'
+        # @see example
+        define_example_method :xexample, :skip => 'Temporarily skipped with xexample'
+        # Shortcut to define an example with :skip => 'Temporarily skipped with xit'
+        # @see example
+        define_example_method :xit,      :skip => 'Temporarily skipped with xit'
+        # Shortcut to define an example with :skip => 'Temporarily skipped with xspecify'
+        # @see example
+        define_example_method :xspecify, :skip => 'Temporarily skipped with xspecify'
+        # Shortcut to define an example with :skip => true
+        # @see example
+        define_example_method :skip,     :skip => true
         # Shortcut to define an example with :pending => true
         # @see example
         define_example_method :pending,  :pending => true
-        # Shortcut to define an example with :pending => 'Temporarily disabled with xexample'
-        # @see example
-        define_example_method :xexample, :pending => 'Temporarily disabled with xexample'
-        # Shortcut to define an example with :pending => 'Temporarily disabled with xit'
-        # @see example
-        define_example_method :xit,      :pending => 'Temporarily disabled with xit'
-        # Shortcut to define an example with :pending => 'Temporarily disabled with xspecify'
-        # @see example
-        define_example_method :xspecify, :pending => 'Temporarily disabled with xspecify'
 
         # Works like `alias_method :name, :example` with the added benefit of
         # assigning default metadata to the generated example.
@@ -270,11 +301,11 @@ module RSpec
 
       # Shortcut to temporarily make an example group pending.
       # @see example_group
-      alias_example_group_to :xdescribe, :pending => "Temporarily disabled with xdescribe"
+      alias_example_group_to :xdescribe, :skip => "Temporarily skipped with xdescribe"
 
       # Shortcut to temporarily make an example group pending.
       # @see example_group
-      alias_example_group_to :xcontext,  :pending => "Temporarily disabled with xcontext"
+      alias_example_group_to :xcontext,  :skip => "Temporarily skipped with xcontext"
 
       # Shortcut to define an example group with `:focus` => true
       # @see example_group

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1456,6 +1456,5 @@ module RSpec::Core
         expect(value_2).to be(value_1)
       end
     end
-
   end
 end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -888,26 +888,48 @@ module RSpec::Core
       end
     end
 
-    %w[pending xit xspecify xexample].each do |method_name|
-      describe "::#{method_name}" do
-        before do
-          @group = ExampleGroup.describe
-          @group.send(method_name, "is pending") { }
+    describe ".pending" do
+      let(:group) { ExampleGroup.describe { pending { fail } } }
+
+      it "generates a pending example" do
+        group.run
+        expect(group.examples.first).to be_pending
+      end
+
+      it "sets the pending message" do
+        group.run
+        expect(group.examples.first.metadata[:execution_result][:pending_message]).to eq(RSpec::Core::Pending::NO_REASON_GIVEN)
+      end
+    end
+
+    describe ".skip" do
+      let(:group) { ExampleGroup.describe { skip("skip this") { } } }
+
+      it "generates a skipped example" do
+        group.run
+        expect(group.examples.first).to be_skipped
+      end
+
+      it "sets the pending message" do
+        group.run
+        expect(group.examples.first.metadata[:execution_result][:pending_message]).to eq(RSpec::Core::Pending::NO_REASON_GIVEN)
+      end
+    end
+
+    %w[xit xspecify xexample].each do |method_name|
+      describe ".#{method_name}" do
+        let(:group) { ExampleGroup.describe.tap {|x|
+          x.send(method_name, "is pending") { }
+        }}
+
+        it "generates a skipped example" do
+          group.run
+          expect(group.examples.first).to be_skipped
         end
 
-        it "generates a pending example" do
-          @group.run
-          expect(@group.examples.first).to be_pending
-        end
-
-        it "sets the pending message", :if => method_name == 'pending' do
-          @group.run
-          expect(@group.examples.first.metadata[:execution_result][:pending_message]).to eq(RSpec::Core::Pending::NO_REASON_GIVEN)
-        end
-
-        it "sets the pending message", :unless => method_name == 'pending' do
-          @group.run
-          expect(@group.examples.first.metadata[:execution_result][:pending_message]).to eq("Temporarily disabled with #{method_name}")
+        it "sets the pending message" do
+          group.run
+          expect(group.examples.first.metadata[:execution_result][:pending_message]).to eq("Temporarily skipped with #{method_name}")
         end
       end
     end
@@ -930,7 +952,7 @@ module RSpec::Core
           expect(extract_execution_results(group)).to match([
             a_hash_including(
               :status => "pending",
-              :pending_message => "Temporarily disabled with #{method_name}"
+              :pending_message => "Temporarily skipped with #{method_name}"
             )
           ] * 2)
         end
@@ -964,6 +986,33 @@ module RSpec::Core
             expect(executed_descriptions).to eq(["focused example"])
           end
         end
+      end
+    end
+
+    describe "setting pending metadata in parent" do
+      def extract_execution_results(group)
+        group.examples.map do |ex|
+          ex.metadata.fetch(:execution_result)
+        end
+      end
+
+      it 'marks every example as pending' do
+        group = ExampleGroup.describe(:pending => true) do
+          it("passes") { }
+          it("fails", :pending => 'unimplemented')  { fail }
+        end
+        group.run
+
+        expect(extract_execution_results(group)).to match([
+          a_hash_including(
+            :status => "failed",
+            :pending_message => "No reason given"
+          ),
+          a_hash_including(
+            :status => "pending",
+            :pending_message => "unimplemented"
+          )
+        ])
       end
     end
 

--- a/spec/rspec/core/formatters/base_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_formatter_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe RSpec::Core::Formatters::BaseFormatter do
       end
 
       it "doesn't hang when file exists" do
-        pending("This issue still exists on JRuby, but should be resolved shortly: https://github.com/rspec/rspec-core/issues/295", :if => RUBY_PLATFORM == 'java')
         exception = double(:Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"])
 
         example = double(:Example, :file_path => __FILE__)

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -58,7 +58,7 @@ root
       group = RSpec::Core::ExampleGroup.describe(" root ")
       context1 = group.describe(" nested ")
       context1.example(" example 1 ") {}
-      context1.example(" example 2 ", :pending => true){}
+      context1.example(" example 2 ", :pending => true){ fail }
       context1.example(" example 3 ") { fail }
 
       group.run(reporter)

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
     group = RSpec::Core::ExampleGroup.describe("one apiece") do
       it("succeeds") { expect(1).to eq 1 }
       it("fails") { fail "eek" }
-      it("pends") { pending "world peace" }
+      it("pends") { pending "world peace"; fail "eek" }
     end
     succeeding_line = __LINE__ - 4
     failing_line = __LINE__ - 4
@@ -31,7 +31,9 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
     end
 
     # grab the actual backtrace -- kind of a cheat
-    failing_backtrace = formatter.output_hash[:examples][1][:exception][:backtrace]
+    examples = formatter.output_hash[:examples]
+    failing_backtrace = examples[1][:exception][:backtrace]
+    pending_backtrace = examples[2][:exception][:backtrace]
     this_file = relative_path(__FILE__)
 
     expected = {
@@ -51,7 +53,11 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
           :file_path => this_file,
           :line_number => failing_line,
           :run_time => formatter.output_hash[:examples][1][:run_time],
-          :exception => {:class => "RuntimeError", :message => "eek", :backtrace => failing_backtrace}
+          :exception => {
+            :class     => "RuntimeError",
+            :message   => "eek",
+            :backtrace => failing_backtrace
+          }
         },
         {
           :description => "pends",
@@ -59,7 +65,12 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
           :status => "pending",
           :file_path => this_file,
           :line_number => pending_line,
-          :run_time => formatter.output_hash[:examples][2][:run_time]
+          :run_time => formatter.output_hash[:examples][2][:run_time],
+          :exception => {
+            :class     => "RuntimeError",
+            :message   => "eek",
+            :backtrace => pending_backtrace
+          }
         },
       ],
       :summary => {

--- a/spec/support/in_sub_process.rb
+++ b/spec/support/in_sub_process.rb
@@ -1,8 +1,8 @@
 module InSubProcess
   if RUBY_PLATFORM == 'java'
     def in_sub_process
-      pending "This spec requires forking to work properly, " +
-              "and JRuby does not support forking"
+      skip "This spec requires forking to work properly, " +
+           "and JRuby does not support forking"
     end
   else
     # Useful as a way to isolate a global change to a subprocess.


### PR DESCRIPTION
This is a backwards incompatible change that makes the behaviour of
pending consisent with the current behaviour for when it is called
inside an example with a block.

The old "never run this example" behaviour is still available via the
"x" family of methods, the `:skip` metadata option, or the new `skip`
method.

Implements #1208.
