### PR TITLE
Remove sleeps from formatter specs

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -71,6 +71,10 @@ module RSpec
       # running this example.
       attr_reader :example_group_instance
 
+      # @attr_accessor
+      # @private
+      attr_accessor :clock
+
       # Creates a new instance of Example.
       # @param example_group_class the subclass of ExampleGroup in which this Example is declared
       # @param description the String passed to the `it` method (or alias)
@@ -81,6 +85,7 @@ module RSpec
         @metadata  = @example_group_class.metadata.for_example(description, metadata)
         @example_group_instance = @exception = nil
         @pending_declared_in_example = false
+        @clock = RSpec::Core::Time
       end
 
       # @deprecated access options via metadata instead
@@ -248,7 +253,7 @@ An error occurred #{context}
 
       def start(reporter)
         reporter.example_started(self)
-        record :started_at => RSpec::Core::Time.now
+        record :started_at => clock.now
       end
 
       def finish(reporter)
@@ -272,7 +277,7 @@ An error occurred #{context}
       end
 
       def record_finished(status, results={})
-        finished_at = RSpec::Core::Time.now
+        finished_at = clock.now
         record results.merge(:status => status, :finished_at => finished_at, :run_time => (finished_at - execution_result[:started_at]).to_f)
       end
 

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -260,10 +260,11 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
 
     before do
       group = RSpec::Core::ExampleGroup.describe("group") do
-        # Use a sleep so there is some measurable time, to ensure
-        # the reported percent is 100%, not 0%.
-        example("example") { sleep 0.001 }
-        example_line_number = __LINE__ - 1
+        example("example") do |example|
+          # make it look slow without actually taking up precious time
+          example.clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+        end
+        example_line_number = __LINE__ - 4
       end
       group.run(reporter)
 
@@ -297,9 +298,10 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
   describe "#dump_profile_slowest_example_groups", :slow do
     let(:group) do
       RSpec::Core::ExampleGroup.describe("slow group") do
-        # Use a sleep so there is some measurable time, to ensure
-        # the reported percent is 100%, not 0%.
-        example("example") { sleep 0.01 }
+        example("example") do |example|
+          # make it look slow without actually taking up precious time
+          example.clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+        end
       end
     end
 
@@ -320,8 +322,8 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     context "with multiple example groups" do
       before do
         group2 = RSpec::Core::ExampleGroup.describe("fast group") do
-          example("example 1") { sleep 0.004 }
-          example("example 2") { sleep 0.007 }
+          example("example 1") { }
+          example("example 2") { }
         end
         group2.run(reporter)
 

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -113,9 +113,7 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
 
     before do
       group = RSpec::Core::ExampleGroup.describe("group") do
-        # Use a sleep so there is some measurable time, to ensure
-        # the reported percent is 100%, not 0%.
-        example("example") { sleep 0.001 }
+        example("example") { }
       end
       group.run(reporter)
 
@@ -142,9 +140,10 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
   describe "#dump_profile_slowest_example_groups", :slow do
     let(:group) do
       RSpec::Core::ExampleGroup.describe("slow group") do
-        # Use a sleep so there is some measurable time, to ensure
-        # the reported percent is 100%, not 0%.
-        example("example") { sleep 0.01 }
+        example("example") do |example|
+          # make it look slow without actually taking up precious time
+          example.clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+        end
       end
     end
 
@@ -165,8 +164,8 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
     context "with multiple example groups", :slow do
       before do
         group2 = RSpec::Core::ExampleGroup.describe("fast group") do
-          example("example 1") { sleep 0.004 }
-          example("example 2") { sleep 0.007 }
+          example("example 1") { }
+          example("example 2") { }
         end
         group2.run(reporter)
 


### PR DESCRIPTION
I'm not sure stubbing is the best way to fix this, let me know if you have a better idea.

Also something is failing for me in `command_line/order_spec.rb` which can't possibly be related, can it?
