### PR TITLE
Remove an use of `and_return { value }`

### DIFF
--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -61,7 +61,7 @@ module RSpec
             (example_metadata[:line_number] + 2) => example_metadata[:line_number] + 2,
           }}
           before do
-            expect(world).to receive(:preceding_declaration_line).at_least(:once).and_return do |v|
+            expect(world).to receive(:preceding_declaration_line).at_least(:once) do |v|
               preceeding_declaration_lines[v]
             end
           end


### PR DESCRIPTION
This fixes [the failing example](https://travis-ci.org/rspec/rspec-mocks/jobs/18401280#L2244) caused by [the removal of `and_return { value }`](https://github.com/rspec/rspec-mocks/pull/561).
