### PR TITLE
Fix"`skip` argument not being used as reason in formatter output

### DIFF
--- a/lib/rspec/core/pending.rb
+++ b/lib/rspec/core/pending.rb
@@ -105,7 +105,7 @@ module RSpec
         current_example = RSpec.current_example
 
         if current_example
-          Pending.mark_pending! current_example, args
+          Pending.mark_pending! current_example, args.first
           current_example.metadata[:skip] = true
           raise SkipDeclaredInExample
         else

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -504,6 +504,16 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
         group.run
         expect(blah).to be(:success)
       end
+
+      context "with a message" do
+        it "sets the example to skipped with the provided message" do
+          group = RSpec::Core::ExampleGroup.describe do
+            example { skip "lorem ipsum" }
+          end
+          group.run
+          expect(group.examples.first).to be_skipped_with("lorem ipsum")
+        end
+      end
     end
 
     context "in before(:each)" do

--- a/spec/rspec/core/pending_example_spec.rb
+++ b/spec/rspec/core/pending_example_spec.rb
@@ -1,26 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe "an example" do
-  matcher :be_pending_with do |message|
-    match do |example|
-      example.pending? && example.metadata[:execution_result][:pending_message] == message
-    end
-
-    failure_message_for_should do |example|
-      "expected: example pending with #{message.inspect}\n     got: #{example.metadata[:execution_result][:pending_message].inspect}"
-    end
-  end
-
-  matcher :be_skipped_with do |message|
-    match do |example|
-      example.skipped? && example.metadata[:execution_result][:pending_message] == message
-    end
-
-    failure_message_for_should do |example|
-      "expected: example skipped with #{message.inspect}\n     got: #{example.metadata[:execution_result][:pending_message].inspect}"
-    end
-  end
-
   context "declared pending with metadata" do
     it "uses the value assigned to :pending as the message" do
       group = RSpec::Core::ExampleGroup.describe('group') do

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -63,3 +63,23 @@ RSpec::Matchers.module_eval do
   alias_method :have_failed_with, :fail_with
   alias_method :have_passed, :pass
 end
+
+RSpec::Matchers.define :be_pending_with do |message|
+  match do |example|
+    example.pending? && example.metadata[:execution_result][:pending_message] == message
+  end
+
+  failure_message_for_should do |example|
+    "expected: example pending with #{message.inspect}\n     got: #{example.metadata[:execution_result][:pending_message].inspect}"
+  end
+end
+
+RSpec::Matchers.define :be_skipped_with do |message|
+  match do |example|
+    example.skipped? && example.metadata[:execution_result][:pending_message] == message
+  end
+
+  failure_message_for_should do |example|
+    "expected: example skipped with #{message.inspect}\n     got: #{example.metadata[:execution_result][:pending_message].inspect}"
+  end
+end


### PR DESCRIPTION
We were passing all `*args` to `self.mark_pending!` instead of the message.
