### PR TITLE
Speculative fix for before(:all) pending failures.

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -241,8 +241,9 @@ module RSpec
       #
       # Used internally to set an exception and fail without actually executing
       # the example when an exception is raised in before(:all).
-      def fail_with_exception(reporter, exception)
+      def fail_with_exception(reporter, exception, before)
         start(reporter)
+        before.each {|x| x.call(self) }
         set_exception(exception)
         finish(reporter)
       end

--- a/lib/rspec/core/pending.rb
+++ b/lib/rspec/core/pending.rb
@@ -62,6 +62,14 @@ module RSpec
           Pending.mark_pending! current_example, args.first
         else
           self.class.before(:each) { pending(*args) }
+
+          # Since there is no current example, we are in an :all callback. In
+          # the case of failure of that callback, each example is "fake"
+          # executed (see Example#fail_with_exception) and failed. We need to
+          # be able to hook into that call to mark the example as pending.
+          internal_hooks_for_group_callbacks << lambda do |example|
+            Pending.mark_pending! example, args.first
+          end
         end
       end
 

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -485,8 +485,6 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       end
 
       it 'sets example to pending when failure occurs in before(:all)' do
-        pending("Unimplemented")
-
         group = RSpec::Core::ExampleGroup.describe do
           before(:all) { pending; fail }
           example {}


### PR DESCRIPTION
I'm not happy with this yet, but not sure a good way to do it :( There's some pollution of ivars going on that I don't like, and the naming is terrible.

Also what is expected behaviour if `pending` is called in `after(:all)` (failure or otherwise)? I thinking it should not even be defined at that time (or if it is, raise a "can't do that" error).

We should probably ship beta2 without this, since we're getting into pretty esoteric usage.

@JonRowe @myronmarston 
