### PR TITLE
Remove superfluous bars in deprecation warning

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -63,7 +63,7 @@ module RSpec
           module_eval(<<-END_RUBY, __FILE__, __LINE__)
             def #{name}(desc=nil, *args, &block)
               if #{name.inspect} == :pending
-                RSpec.warn_deprecation(<<-EOS.gsub(/^\s+\|/, ''))
+                RSpec.warn_deprecation(<<-EOS.gsub(/^\s+\\|/, ''))
                   |The semantics of `RSpec::Core::ExampleGroup#pending` are changing in RSpec 3.
                   |In RSpec 2.x, it caused the example to be skipped. In RSpec 3, the example will
                   |still be run but is expected to fail, and will be marked as a failure (rather


### PR DESCRIPTION
Currently the deprecation warning for `RSpec::Core::ExampleGroup#pending` includes superfluous bars:

```
|The semantics of `RSpec::Core::ExampleGroup#pending` are changing in RSpec 3.
|In RSpec 2.x, it caused the example to be skipped. In RSpec 3, the example will
|still be run but is expected to fail, and will be marked as a failure (rather
|than as pending) if the example passes, just like how `pending` with a block
|from within an example already works.
|
|To keep the same skip semantics, change `pending` to `skip`.  Otherwise, if you
|want the new RSpec 3 behavior, you can safely ignore this warning and continue
|to upgrade to RSpec 3 without addressing it.
|
|Called from /Users/me/some-project/spec/models/admin_user_spec.rb:4:in `block in <top (
required)>'.
|
```

The `RSpec.warn_deprecation` is already in a here document, so the regexp needs double escape.
