### PR TITLE
Backtrace is incorrectly cleaned when RSpec is installed in the current working directory

### DIFF
--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -93,6 +93,20 @@ module RSpec::Core
           expect(BacktraceFormatter.new.format_backtrace(backtrace).drop(4).join).to match(/Showing full backtrace/)
         end
       end
+
+      context "when rspec is installed in the current working directory" do
+        it "excludes lines from rspec libs by default", :unless => RSpec.windows_os? do
+          backtrace = [
+            "#{Dir.getwd}/.bundle/path/to/rspec-expectations/lib/rspec/expectations/foo.rb:37",
+            "#{Dir.getwd}/.bundle/path/to/rspec-expectations/lib/rspec/matchers/foo.rb:37",
+            "#{Dir.getwd}/my_spec.rb:5",
+            "#{Dir.getwd}/.bundle/path/to/rspec-mocks/lib/rspec/mocks/foo.rb:37",
+            "#{Dir.getwd}/.bundle/path/to/rspec-core/lib/rspec/core/foo.rb:37"
+          ]
+
+          expect(BacktraceFormatter.new.format_backtrace(backtrace)).to eq(["./my_spec.rb:5"])
+        end
+      end
     end
 
     describe "#full_backtrace=true" do


### PR DESCRIPTION
TL;DR: RSpec’s backtrace cleaner used to remove all RSpec-related lines from the backtrace, but as of 3.0.0.beta1 it no longer does.

I have `BUNDLE_PATH` set to `.bundle/gems`, so when I run `bundle install`, RSpec gets installed in `.bundle` inside my project’s working directory. Pre-3.0.0.beta1, the RSpec-related lines would be cleaned from a backtrace whenever my specs raised an exception, but as of 3.0.0.beta1 they aren’t, because those lines mention files in the current working directory.

A related problem was first raised in #798, which resulted in the backtrace cleaner being introduced in #843. At the time, @myronmarston [commented](https://github.com/rspec/rspec-core/pull/843#issuecomment-15376843):

> there's a way of using bundler (that [I personally recommend](http://myronmars.to/n/dev-blog/2012/03/faster-test-boot-times-with-bundler-standalone)) that causes all gems to be installed in a subdirectory of your project root...which means that the change here will cause backtraces to always contain all lines from all gems for folks who use bundler like I do. That's bad.
> 
> The simplest fix I can think of is to only default `backtrace_inclusion_patterns` to the current directory if it's really needed, i.e. if the current directory matches any of the exclusion patterns

This was the solution that #843 eventually used, and everything worked fine until @dchelimsky committed af0b271c92ad2a3336eb70be7bf2c0de4325a568 a few months later, which cleaned up the backtrace formatting logic to unconditionally include all lines from the working directory regardless of exclusion patterns.

So right now I must set `config.backtrace_inclusion_patterns = []` in every RSpec 3 project to avoid my backtraces being hopelessly noisy. I’d rather not do this.

Although I haven’t noticed other gems cluttering up my backtrace, I think my problem with RSpec-related lines is a special case of gem-related lines appearing in backtraces.

(This is a pull request (vs an issue) so that I can include a failing test. My test directly contradicts [this one](https://github.com/rspec/rspec-core/blob/a5e283d3c6d3ab4f8436d085d499601f67d3a3a3/spec/rspec/core/backtrace_formatter_spec.rb#L37-L40), so I can’t simply make it pass.)
