### PR TITLE
Remove support for pending in before(:all) hooks.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -42,6 +42,8 @@ Breaking Changes for 3.0.0:
   (Xavier Shay)
 * Pending blocks inside an example have been removed as a feature with no
   direct replacement. Use `skip` or `pending` without a block. (Xavier Shay)
+* Pending statement is no longer allowed in `before(:all)` hooks. Use `skip`
+  instead.  (Xavier Shay)
 * Remove `show_failures_in_pending_blocks` configuration option. (Xavier Shay)
 * Remove support for specifying the documentation formatter using
   's', 'n', 'spec' or 'nested'. (Jon Rowe)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -248,6 +248,16 @@ module RSpec
       end
 
       # @private
+      #
+      # Used internally to skip without actually executing the example when
+      # skip is used in before(:all)
+      def skip_with_exception(reporter, exception)
+        start(reporter)
+        Pending.mark_skipped! self, exception.argument
+        finish(reporter)
+      end
+
+      # @private
       def instance_exec_with_rescue(context = nil, &block)
         @example_group_instance.instance_exec_with_rescue(self, context, &block)
       end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -473,26 +473,16 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
     end
 
     context "in before(:all)" do
-      it "sets each example to pending" do
+      it "is forbidden" do
         group = RSpec::Core::ExampleGroup.describe do
           before(:all) { pending }
           example { fail }
           example { fail }
         end
         group.run
-        expect_pending_result(group.examples.first)
-        expect_pending_result(group.examples.last)
-      end
-
-      it 'sets example to pending when failure occurs in before(:all)' do
-        pending("Unimplemented")
-
-        group = RSpec::Core::ExampleGroup.describe do
-          before(:all) { pending; fail }
-          example {}
-        end
-        group.run
-        expect_pending_result(group.examples.first)
+        expect(group.examples.first.exception).to be
+        expect(group.examples.first.exception.message).to \
+          match(/may not be used outside of examples/)
       end
     end
 
@@ -581,13 +571,13 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
     context "in before(:all)" do
       it "sets each example to pending" do
         group = RSpec::Core::ExampleGroup.describe do
-          before(:all) { skip }
+          before(:all) { skip("not done"); fail }
           example {}
           example {}
         end
         group.run
-        expect(group.examples.first).to be_skipped
-        expect(group.examples.last).to be_skipped
+        expect(group.examples.first).to be_skipped_with("not done")
+        expect(group.examples.last).to be_skipped_with("not done")
       end
     end
 


### PR DESCRIPTION
Too messy to support properly.

@JonRowe 
