### PR TITLE
Add #described_module as alias to #described_class

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -48,6 +48,7 @@ module RSpec
         alias_method :display_name, :description
         # @private
         alias_method :describes, :described_class
+        alias_method :described_module, :described_class
 
         # @private
         # @macro [attach] define_example_method

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -78,11 +78,12 @@ module RSpec
             store(:line_number, line_number)
           when :execution_result
             store(:execution_result, {})
-          when :describes, :described_class
+          when :describes, :described_class, :described_module
             klass = described_class
             store(:described_class, klass)
             # TODO (2011-11-07 DC) deprecate :describes as a key
             store(:describes, klass)
+            store(:described_module, klass)
           when :full_description
             store(:full_description, full_description)
           when :description
@@ -142,7 +143,7 @@ module RSpec
 
         def described_class
           container_stack.each do |g|
-            [:described_class, :describes].each do |key|
+            [:described_class, :described_module, :describes].each do |key|
               if g.has_key?(key)
                 value = g[key]
                 return value unless value.nil?

--- a/script/ignores
+++ b/script/ignores
@@ -15,6 +15,7 @@ lib/rspec/core/configuration.rb:      alias_method :filter, :inclusion_filter
 lib/rspec/core/example.rb:      alias_method :pending?, :pending
 lib/rspec/core/example_group.rb:        alias_method :display_name, :description
 lib/rspec/core/example_group.rb:        alias_method :describes, :described_class
+lib/rspec/core/example_group.rb:        alias_method :described_module, :described_class
 lib/rspec/core/example_group.rb:        # Works like `alias_method :name, :example` with the added benefit of
 lib/rspec/core/example_group.rb:        # Works like `alias_method :name, :it_behaves_like` with the added
 lib/rspec/core/example_group.rb:        alias_method :context, :describe

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -260,7 +260,7 @@ module RSpec
         end
       end
 
-      [:described_class, :describes].each do |key|
+      [:described_class, :described_module, :describes].each do |key|
         describe key do
           context "with a String" do
             it "returns nil" do


### PR DESCRIPTION
When the module is being described, it would be more readable and less confusing to use #described_module than existing #described_class
