### PR TITLE
Pass along opts from warn_deprecation

### DIFF
--- a/lib/rspec/core/warnings.rb
+++ b/lib/rspec/core/warnings.rb
@@ -18,8 +18,8 @@ module RSpec
       # @private
       #
       # Used internally to print deprecation warnings
-      def warn_deprecation(message)
-        RSpec.configuration.reporter.deprecation :message => message
+      def warn_deprecation(message, opts = {})
+        RSpec.configuration.reporter.deprecation opts.merge( :message => message )
       end
 
       def warn_with(message, options = {})

--- a/spec/rspec/core/warnings_spec.rb
+++ b/spec/rspec/core/warnings_spec.rb
@@ -24,16 +24,21 @@ RSpec.describe "rspec warnings and deprecations" do
       expect(RSpec.configuration.reporter).to receive(:deprecation).with(hash_including :message => "this is the message")
       RSpec.warn_deprecation("this is the message")
     end
+
+    it "passes along additional options" do
+      expect(RSpec.configuration.reporter).to receive(:deprecation).with(hash_including :type => :tag)
+      RSpec.warn_deprecation("this is the message", :type => :tag)
+    end
   end
 
   describe "#warn_with" do
     context "when :use_spec_location_as_call_site => true is passed" do
-      let(:options) {
+      let(:options) do
         {
           :use_spec_location_as_call_site => true,
           :call_site                      => nil,
         }
-      }
+      end
 
       it "adds the source location of spec" do
         line = __LINE__ - 1


### PR DESCRIPTION
Needed as a counterpart to rspec/rspec-support#42 to eventually fix rspec/rspec-expectations#468
