### PR TITLE
Don't include any test files in the gem.

### DIFF
--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.files            = `git ls-files -- lib/*`.split("\n")
   s.files           += %w[README.md License.txt Changelog.md .yardopts .document]
-  s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
+  s.test_files       = []
   s.bindir           = 'exe'
   s.executables      = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
   s.rdoc_options     = ["--charset=UTF-8"]


### PR DESCRIPTION
I don't think anyone actually relies on that
feature and it makes the published size of the
gem more than twice as big (192 KB vs 90 KB).

Anyone got a reason we shouldn't do this?

/cc @JonRowe @xaviershay @alindeman @samphippen @soulcutter 
