### PR TITLE
Fix double escaped backtrace links in TextMateFormatter.

### DIFF
--- a/lib/rspec/core/formatters/text_mate_formatter.rb
+++ b/lib/rspec/core/formatters/text_mate_formatter.rb
@@ -6,6 +6,18 @@ module RSpec
     module Formatters
       # Formats backtraces so they're clickable by TextMate
       class TextMateFormatter < HtmlFormatter
+        class NonEscapingHtmlPrinter < RSpec::Core::Formatters::HtmlPrinter
+          def print_example_failed(pending_fixed, description, run_time, failure_id, exception, extra_content, escape_backtrace = false)
+            # Call implementation from superclass, but ignore `escape_backtrace` and always pass `false` instead.
+            super(pending_fixed, description, run_time, failure_id, exception, extra_content, false)
+          end
+        end
+
+        def initialize(output)
+          super
+          @printer = NonEscapingHtmlPrinter.new(output)
+        end
+
         def backtrace_line(line, skip_textmate_conversion=false)
           if skip_textmate_conversion
             super(line)

--- a/spec/rspec/core/formatters/text_mate_formatter_spec.rb
+++ b/spec/rspec/core/formatters/text_mate_formatter_spec.rb
@@ -72,6 +72,7 @@ module RSpec
 
             expect(actual_doc.inner_html).to eq(expected_doc.inner_html)
 
+            expect(backtrace_lines).to_not be_empty
             backtrace_lines.each do |backtrace_line|
               expect(backtrace_line['href']).to include("txmt://open?url=")
             end


### PR DESCRIPTION
This was introduced in https://github.com/rspec/rspec-core/commit/b295e165658c0cc2f72a14d8c666a552d4b9b489

The regression went unnoticed because the spec `produces HTML identical to the one we designed manually` was flawed: It did some sanity checking for each backtrace link, but it failed to fail :smirk: if there were no links at all. Which exactly is what happened when the double escape was introduced: the backtrace did no longer contain any (unescaped) links.
