### PR TITLE
Place deprecation formatter first

### DIFF
--- a/features/configuration/read_options_from_file.feature
+++ b/features/configuration/read_options_from_file.feature
@@ -45,7 +45,7 @@ Feature: read command line configuration options from files
       """ruby
       describe "formatter set in custom options file" do
         it "sets formatter" do
-          RSpec.configuration.formatters.first.
+          RSpec.configuration.formatters[1].
             should be_a(RSpec::Core::Formatters::DocumentationFormatter)
         end
       end
@@ -82,7 +82,7 @@ Feature: read command line configuration options from files
       """ruby
       describe "formatter" do
         it "is set to documentation" do
-          RSpec.configuration.formatters.first.should be_an(RSpec::Core::Formatters::DocumentationFormatter)
+          RSpec.configuration.formatters[1].should be_an(RSpec::Core::Formatters::DocumentationFormatter)
         end
       end
       """

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -670,7 +670,7 @@ EOM
           (raise ArgumentError, "Formatter '#{formatter_to_use}' unknown - maybe you meant 'documentation' or 'progress'?.")
 
         paths << output_stream if paths.empty?
-        formatters << formatter_class.new(*paths.map {|p| String === p ? file_at(p) : p})
+        formatters << formatter_class.new(*files_or_strings_from(*paths))
       end
 
       alias_method :formatter=, :add_formatter
@@ -682,7 +682,7 @@ EOM
       def reporter
         @reporter ||= begin
                         add_formatter('progress') if formatters.empty?
-                        add_formatter(RSpec::Core::Formatters::DeprecationFormatter, deprecation_stream, output_stream)
+                        @formatters.unshift RSpec::Core::Formatters::DeprecationFormatter.new(*files_or_strings_from(deprecation_stream, output_stream))
                         Reporter.new(*formatters)
                       end
       end
@@ -1351,6 +1351,10 @@ MESSAGE
       def file_at(path)
         FileUtils.mkdir_p(File.dirname(path))
         File.new(path, 'w')
+      end
+
+      def files_or_strings_from(*paths)
+        paths.map {|p| String === p ? file_at(p) : p}
       end
 
       def order_and_seed_from_seed(value, force = false)


### PR DESCRIPTION
This should reorder the deprecation output, as a potential solution to #1339.
