### PR TITLE
Move private methods from RSpec to RSpec.world.

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -41,30 +41,6 @@ module RSpec
   extend RSpec::Core::Warnings
 
   # @private
-  def self.wants_to_quit
-  # Used internally to determine what to do when a SIGINT is received
-    world.wants_to_quit
-  end
-
-  # @private
-  # Used internally to determine what to do when a SIGINT is received
-  def self.wants_to_quit=(maybe)
-    world.wants_to_quit=(maybe)
-  end
-
-  # @private
-  # Internal container for global non-configuration data
-  def self.world
-    @world ||= RSpec::Core::World.new
-  end
-
-  # @private
-  # Used internally to set the global object
-  def self.world=(new_world)
-    @world = new_world
-  end
-
-  # @private
   # Used internally to ensure examples get reloaded between multiple runs in
   # the same process.
   def self.reset
@@ -107,12 +83,6 @@ module RSpec
     yield configuration if block_given?
   end
 
-  # @private
-  # Used internally to clear remaining groups when fail_fast is set
-  def self.clear_remaining_example_groups
-    world.example_groups.clear
-  end
-
   # The example being executed.
   #
   # The primary audience for this method is library authors who need access
@@ -145,8 +115,15 @@ module RSpec
   end
 
   # @private
-  def self.windows_os?
-    RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/
+  # Internal container for global non-configuration data
+  def self.world
+    @world ||= RSpec::Core::World.new
+  end
+
+  # @private
+  # Used internally to set the global object
+  def self.world=(new_world)
+    @world = new_world
   end
 
   module Core

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -524,7 +524,7 @@ module RSpec
 
       def color=(bool)
         if bool
-          if RSpec.windows_os? and not ENV['ANSICON']
+          if RSpec.world.windows_os? and not ENV['ANSICON']
             RSpec.warning "You must use ANSICON 1.31 or later (http://adoxa.3eeweb.com/ansicon/) to use colour on Windows"
             @color = false
           else

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -420,8 +420,8 @@ module RSpec
 
       # Runs all the examples in this group
       def self.run(reporter)
-        if RSpec.wants_to_quit
-          RSpec.clear_remaining_example_groups if top_level?
+        if RSpec.world.wants_to_quit
+          RSpec.world.clear_remaining_example_groups if top_level?
           return
         end
         reporter.example_group_started(self)
@@ -434,7 +434,7 @@ module RSpec
         rescue Pending::SkipDeclaredInExample => ex
           for_filtered_examples(reporter) {|example| example.skip_with_exception(reporter, ex) }
         rescue Exception => ex
-          RSpec.wants_to_quit = true if fail_fast?
+          RSpec.world.wants_to_quit = true if fail_fast?
           for_filtered_examples(reporter) {|example| example.fail_with_exception(reporter, ex) }
         ensure
           run_after_all_hooks(new)
@@ -462,11 +462,11 @@ module RSpec
       # @private
       def self.run_examples(reporter)
         ordering_strategy.order(filtered_examples).map do |example|
-          next if RSpec.wants_to_quit
+          next if RSpec.world.wants_to_quit
           instance = new
           set_ivars(instance, before_all_ivars)
           succeeded = example.run(instance, reporter)
-          RSpec.wants_to_quit = true if fail_fast? && !succeeded
+          RSpec.world.wants_to_quit = true if fail_fast? && !succeeded
           succeeded
         end.all?
       end

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -62,8 +62,8 @@ module RSpec
 
       def self.trap_interrupt
         trap('INT') do
-          exit!(1) if RSpec.wants_to_quit
-          RSpec.wants_to_quit = true
+          exit!(1) if RSpec.world.wants_to_quit
+          RSpec.world.wants_to_quit = true
           STDERR.puts "\nExiting... Interrupt again to exit immediately."
         end
       end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -8,6 +8,8 @@ module RSpec
       include RSpec::Core::Hooks
 
       attr_reader :example_groups, :filtered_examples
+
+      # Used internally to determine what to do when a SIGINT is received
       attr_accessor :wants_to_quit
 
       def initialize(configuration=RSpec.configuration)
@@ -21,6 +23,17 @@ module RSpec
             examples
           end
         }
+      end
+
+      # @private
+      # Used internally to clear remaining groups when fail_fast is set
+      def clear_remaining_example_groups
+        example_groups.clear
+      end
+
+      # @private
+      def windows_os?
+        RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/
       end
 
       # @api private

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -41,7 +41,7 @@ module RSpec::Core
     end
 
     describe "#format_backtrace" do
-      it "excludes lines from rspec libs by default", :unless => RSpec.windows_os? do
+      it "excludes lines from rspec libs by default", :unless => RSpec.world.windows_os? do
         backtrace = [
           "/path/to/rspec-expectations/lib/rspec/expectations/foo.rb:37",
           "/path/to/rspec-expectations/lib/rspec/matchers/foo.rb:37",
@@ -53,7 +53,7 @@ module RSpec::Core
         expect(BacktraceFormatter.new.format_backtrace(backtrace)).to eq(["./my_spec.rb:5"])
       end
 
-      it "excludes lines from rspec libs by default", :if => RSpec.windows_os? do
+      it "excludes lines from rspec libs by default", :if => RSpec.world.windows_os? do
         backtrace = [
           "\\path\\to\\rspec-expectations\\lib\\rspec\\expectations\\foo.rb:37",
           "\\path\\to\\rspec-expectations\\lib\\rspec\\matchers\\foo.rb:37",
@@ -95,7 +95,7 @@ module RSpec::Core
       end
 
       context "when rspec is installed in the current working directory" do
-        it "excludes lines from rspec libs by default", :unless => RSpec.windows_os? do
+        it "excludes lines from rspec libs by default", :unless => RSpec.world.windows_os? do
           backtrace = [
             "#{Dir.getwd}/.bundle/path/to/rspec-expectations/lib/rspec/expectations/foo.rb:37",
             "#{Dir.getwd}/.bundle/path/to/rspec-expectations/lib/rspec/matchers/foo.rb:37",

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -396,12 +396,12 @@ module RSpec::Core
           expect(config.files_to_run).to eq([      "spec/rspec/core/resources/a_spec.rb"])
         end
 
-        it "loads files in Windows", :if => RSpec.windows_os? do
+        it "loads files in Windows", :if => RSpec.world.windows_os? do
           assign_files_or_directories_to_run "C:\\path\\to\\project\\spec\\sub\\foo_spec.rb"
           expect(config.files_to_run).to eq([      "C:/path/to/project/spec/sub/foo_spec.rb"])
         end
 
-        it "loads files in Windows when directory is specified", :if => RSpec.windows_os? do
+        it "loads files in Windows when directory is specified", :if => RSpec.world.windows_os? do
           assign_files_or_directories_to_run "spec\\rspec\\core\\resources"
           expect(config.files_to_run).to eq([      "spec/rspec/core/resources/a_spec.rb"])
         end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -621,13 +621,13 @@ module RSpec::Core
         expect(order).to eq([1,2,3])
       end
 
-      it "does not set RSpec.wants_to_quit in case of an error in before all (without fail_fast?)" do
+      it "does not set RSpec.world.wants_to_quit in case of an error in before all (without fail_fast?)" do
         group = ExampleGroup.describe
         group.before(:all) { raise "error in before all" }
         group.example("example") {}
 
         group.run
-        expect(RSpec.wants_to_quit).to be_falsey
+        expect(RSpec.world.wants_to_quit).to be_falsey
       end
 
       it "runs the before eachs in order" do
@@ -1260,20 +1260,20 @@ module RSpec::Core
           expect(examples_run.length).to eq(2)
         end
 
-        it "sets RSpec.wants_to_quit flag if encountering an exception in before(:all)" do
+        it "sets RSpec.world.wants_to_quit flag if encountering an exception in before(:all)" do
           group.before(:all) { raise "error in before all" }
           group.example("equality") { expect(1).to eq(2) }
           expect(group.run).to be_falsey
-          expect(RSpec.wants_to_quit).to be_truthy
+          expect(RSpec.world.wants_to_quit).to be_truthy
         end
       end
 
-      context "with RSpec.wants_to_quit=true" do
+      context "with RSpec.world.wants_to_quit=true" do
         let(:group) { RSpec::Core::ExampleGroup.describe }
 
         before do
-          allow(RSpec).to receive(:wants_to_quit) { true }
-          allow(RSpec).to receive(:clear_remaining_example_groups)
+          allow(RSpec.world).to receive(:wants_to_quit) { true }
+          allow(RSpec.world).to receive(:clear_remaining_example_groups)
         end
 
         it "returns without starting the group" do
@@ -1283,7 +1283,7 @@ module RSpec::Core
 
         context "at top level" do
           it "purges remaining groups" do
-            expect(RSpec).to receive(:clear_remaining_example_groups)
+            expect(RSpec.world).to receive(:clear_remaining_example_groups)
             group.run(reporter)
           end
         end
@@ -1291,7 +1291,7 @@ module RSpec::Core
         context "in a nested group" do
           it "does not purge remaining groups" do
             nested_group = group.describe
-            expect(RSpec).not_to receive(:clear_remaining_example_groups)
+            expect(RSpec.world).not_to receive(:clear_remaining_example_groups)
             nested_group.run(reporter)
           end
         end


### PR DESCRIPTION
Fixes #1338.

It seemed weird to move the private setters (`configuration=`, `world=`, `reset`) off the `RSpec` constant, so I left them there.

No changelog entry since this is a private refactoring.

@myronmarston @JonRowe 
