### PR TITLE
Add deprecation for `described_class` change coming in 3.0.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,10 @@ Deprecations:
 
 * Deprecate `RSpec::Core::Pending::PendingDeclaredInExample`, use
   `SkipDeclaredInExample` instead. (Xavier Shay)
+* Issue a deprecation when `described_class` is accessed from within
+  a nested `describe <SomeClass>` example group, since `described_class`
+  will return the innermost described class in RSpec 3 rather than the
+  outermost described class, as it behaved in RSpec 2. (Myron Marston)
 
 ### 2.99.0.beta2 / 2014-02-17
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.99.0.beta1...v2.99.0.beta2)


### PR DESCRIPTION
This is the 2.99 counterpoint to #1361.

/cc @JonRowe 
