### PR TITLE
Fix HashImitatable.

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -274,7 +274,14 @@ Here are all of RSpec's reserved hash keys:
 
           hash.__send__(method_name, *args, &block).tap do
             # apply mutations back to the object
-            hash.each { |name, value| __send__(:"#{name}=", value) }
+            hash.each do |name, value|
+              setter = :"#{name}="
+              if respond_to?(setter)
+                __send__(setter, value)
+              else
+                extra_hash_attributes[name] = value
+              end
+            end
           end
         end
       end

--- a/spec/rspec/core/example_execution_result_spec.rb
+++ b/spec/rspec/core/example_execution_result_spec.rb
@@ -57,6 +57,13 @@ module RSpec
             expect(er.exception).to be_a(ArgumentError)
           end
 
+          it 'can set undefined attribute keys through any hash mutation method' do
+            allow_deprecation
+            er = ExecutionResult.new
+            er.update(:status => "failed", :foo => 3)
+            expect(er.to_h).to include(:status => "failed", :foo => 3)
+          end
+
           it 'supports `merge` like a hash' do
             er = ExecutionResult.new
             er.status = "pending"


### PR DESCRIPTION
When undefined attribute keys were updated through
a method like `update` or `merge!` it was raising
a NoMethodError.

Follow up to #1376.
