### PR TITLE
Remove dump_profile as a notification

### DIFF
--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -12,7 +12,7 @@ module RSpec
       # @see RSpec::Core::Reporter
       class BaseTextFormatter < BaseFormatter
         Formatters.register self, :message, :dump_summary, :dump_failures,
-                                  :dump_profile, :dump_pending, :seed
+                                  :dump_pending, :seed
 
         def message(notification)
           output.puts notification.message

--- a/lib/rspec/core/formatters/json_formatter.rb
+++ b/lib/rspec/core/formatters/json_formatter.rb
@@ -6,8 +6,7 @@ module RSpec
     module Formatters
       # @private
       class JsonFormatter < BaseFormatter
-        Formatters.register self, :message, :dump_summary, :stop, :close,
-                                  :dump_profile
+        Formatters.register self, :message, :dump_summary, :stop, :close
 
         attr_reader :output_hash
 

--- a/lib/rspec/core/formatters/legacy_formatter.rb
+++ b/lib/rspec/core/formatters/legacy_formatter.rb
@@ -77,10 +77,6 @@ module RSpec
             super(Notifications::NullNotification) if defined?(super)
           end
 
-          def dump_profile
-            super(Notifications::NullNotification) if defined?(super)
-          end
-
           def close
             super(Notifications::NullNotification) if defined?(super)
           end


### PR DESCRIPTION
`dump_profile` isn't a real notification, but a helper method, it got included accidentally
