### PR TITLE
Deprecate RSpec::Core::Example#options.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ Deprecations:
 * Deprecate `RSpec::Core::FilterManager::DEFAULT_EXCLUSIONS`,
   `RSpec::Core::FilterManager::STANDALONE_FILTERS` and use of
   `#empty_without_conditional_filters?` on those filters. (Sergey Pchelincev)
+* Deprecate `RSpec::Core::Example#options` in favor of
+  `RSpec::Core::Example#metadata`. (Myron Marston)
 
 ### 2.99.0.beta2 / 2014-02-17
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.99.0.beta1...v2.99.0.beta2)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -85,6 +85,8 @@ module RSpec
 
       # @deprecated access options via metadata instead
       def options
+        RSpec.deprecate("`RSpec::Core::Example#options`",
+                        :replacement => "`RSpec::Core::Example#metadata`")
         @options
       end
 

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -719,6 +719,7 @@ module RSpec::Core
       it "has access to example options within before(:each)" do
         group = ExampleGroup.describe
         option = nil
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /options/)
         group.before(:each) {|ex| option = ex.options[:data] }
         group.example("no-op", :data => :sample) { }
         group.run
@@ -728,6 +729,7 @@ module RSpec::Core
       it "has access to example options within after(:each)" do
         group = ExampleGroup.describe
         option = nil
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /options/)
         group.after(:each) {|ex| option = ex.options[:data] }
         group.example("no-op", :data => :sample) { }
         group.run


### PR DESCRIPTION
This adds a deprecation for #1391.
