### PR TITLE
Warn on pending block

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -324,7 +324,7 @@ module RSpec
         subclass.module_eval(&example_group_block) if example_group_block
 
         # The LetDefinitions module must be included _after_ other modules
-        # to ensure that it takes precendence when there are name collisions.
+        # to ensure that it takes precedence when there are name collisions.
         # Thus, we delay including it until after the example group block
         # has been eval'd.
         MemoizedHelpers.define_helpers_on(subclass)

--- a/lib/rspec/core/pending.rb
+++ b/lib/rspec/core/pending.rb
@@ -69,7 +69,25 @@ module RSpec
       def pending(*args)
         current_example = RSpec.current_example
 
-        if current_example
+        if block_given?
+          raise ArgumentError, <<-EOS.gsub(/^\s+\|/, '')
+            |The semantics of `RSpec::Core::Pending#pending` have changed in
+            |RSpec 3.  In RSpec 2.x, it caused the example to be skipped. In
+            |RSpec 3, the rest of the example is still run but is expected to
+            |fail, and will be marked as a failure (rather than as pending) if
+            |the example passes.
+            |
+            |Passing a block within an example is now deprecated. Marking the
+            |example as pending provides the same behavior in RSpec 3 which was
+            |provided only by the block in RSpec 2.x.
+            |
+            |Move the code in the block provided to `pending` into the rest of
+            |the example body.
+            |
+            |Called from #{CallerFilter.first_non_rspec_line}.
+            |
+          EOS
+        elsif current_example
           Pending.mark_pending! current_example, args.first
         else
           raise "`pending` may not be used outside of examples, such as in " +

--- a/lib/rspec/core/pending.rb
+++ b/lib/rspec/core/pending.rb
@@ -11,7 +11,7 @@ module RSpec
         end
       end
 
-      # If Test::Unit is loaed, we'll use its error as baseclass, so that Test::Unit
+      # If Test::Unit is loaded, we'll use its error as baseclass, so that Test::Unit
       # will report unmet RSpec expectations as failures rather than errors.
       begin
         class PendingExampleFixedError < Test::Unit::AssertionFailedError; end
@@ -41,7 +41,7 @@ module RSpec
       #       # reported as "Pending: no reason given"
       #       it "is pending with no message" do
       #         pending
-      #         raise "broken" 
+      #         raise "broken"
       #       end
       #
       #       # reported as "Pending: something else getting finished"

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -499,6 +499,21 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
         expect(group.examples.first.exception.message).to \
           match(/may not be used outside of examples/)
       end
+
+      it "fails with an ArgumentError if a block is provided" do
+        group = RSpec::Core::ExampleGroup.describe('group') do
+          before(:all) do
+            pending { :no_op }
+          end
+          example { fail }
+        end
+        example = group.examples.first
+        group.run
+        expect(example).to fail_with ArgumentError
+        expect(example.exception.message).to match(
+          /Passing a block within an example is now deprecated./
+        )
+      end
     end
 
     context "in around(:each)" do

--- a/spec/rspec/core/pending_example_spec.rb
+++ b/spec/rspec/core/pending_example_spec.rb
@@ -114,4 +114,37 @@ RSpec.describe "an example" do
       expect(example).to be_pending_with('just because')
     end
   end
+
+  context "with a block" do
+    it "fails with an ArgumentError stating the syntax is deprecated" do
+      group = RSpec::Core::ExampleGroup.describe('group') do
+        it "calls pending with a block" do
+          pending("with invalid syntax") do
+            :no_op
+          end
+          fail
+        end
+      end
+      example = group.examples.first
+      group.run
+      expect(example).to fail_with ArgumentError
+      expect(example.exception.message).to match(
+        /Passing a block within an example is now deprecated./
+      )
+    end
+
+    it "does not yield to the block" do
+      example_to_have_yielded = :did_not_yield
+      group = RSpec::Core::ExampleGroup.describe('group') do
+        it "calls pending with a block" do
+          pending("just because") do
+            example_to_have_yielded = :pending_block
+          end
+          fail
+        end
+      end
+      group.run
+      expect(example_to_have_yielded).to eq :did_not_yield
+    end
+  end
 end


### PR DESCRIPTION
Not sure this is fully finished yet. I wanted to start the review process sooner rather than later.

Things which I'm not sure about:
- [x] To on my part: Add `deprecated` relish doc for this
- [x] Does this need a Changelog entry?
- [x] Should I make a similar change in a new PR for 2.99?

When going in to do testing I was a little confused on where to put the spec. There are a few places that `pending` is used in specs:
- `spec/rspec/core/example_group_spec.rb`
- `spec/rspec/core/example_spec.rb`
- `spec/rspec/core/pending_example_spec.rb`
- `spec/rspec/core/pending_spec.rb`

I first looked in `spec/rspec/core/pending_spec.rb` but there weren't really any specs in. Since this change is specific to `pending` when used in an example, I then checked `spec/rspec/core/example_spec.rb`. Some of the basic behavior was spec'd in there, but a bit of the subtle behaviors were not. I settled on `spec/rspec/core/pending_example_spec.rb` as this seemed to have specs around the majority of the example specific behavior.
