### PR TITLE
Cleanup `rspec --help`

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -210,12 +210,19 @@ FILTERING
           exit
         end
 
+        # these options would otherwise be confusing to users, so we forcibly prevent them from executing
+        # --I is too similar to -I
+        # -d was a shorthand for --debugger, which is removed, but now would trigger --default_path
+        invalid_options = %w[-d --I]
+
         parser.on_tail('-h', '--help', "You're looking at it.") do
-          puts parser
+          # removing the blank invalid options from the output
+          puts parser.to_s.gsub(/^\s+(#{invalid_options.join('|')})\s*$\n/,'')
           exit
         end
 
-        %w[-d --I].each do |option|
+        # this prevents usage of the invalid_options
+        invalid_options.each do |option|
           parser.on(option) do
             raise OptionParser::InvalidOption.new
           end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -3,6 +3,7 @@ require 'pp'
 require 'stringio'
 
 RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
+
   let(:example_group) do
     RSpec::Core::ExampleGroup.describe('group description')
   end
@@ -18,18 +19,8 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
     end
   end
 
-  def capture_stdout
-    orig_stdout = $stdout
-    $stdout = StringIO.new
-    yield
-    $stdout.string
-  ensure
-    $stdout = orig_stdout
-  end
-
   it "can be pretty printed" do
-    output = ignoring_warnings { capture_stdout { pp example_instance } }
-    expect(output).to include("RSpec::Core::Example")
+    expect { ignoring_warnings { pp example_instance }}.to output(/RSpec::Core::Example/).to_stdout
   end
 
   describe "#exception" do

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 module RSpec::Core
   RSpec.describe OptionParser do
+
     let(:output_file){ mock File }
 
     before do
@@ -43,6 +44,18 @@ module RSpec::Core
           parser.parse([option])
         end
       end
+    end
+
+    it "won't display invalid options in the help output" do
+      def generate_help_text
+        parser = Parser.new
+        allow(parser).to receive(:exit)
+        parser.parse(["--help"])
+      end
+
+      useless_lines = /^\s*--?\w+\s*$\n/
+
+      expect { generate_help_text }.to_not output(useless_lines).to_stdout
     end
 
     describe "--default_path" do


### PR DESCRIPTION
Notice the utilities section:

```
  **** Utility ****

    -v, --version                    Display the version.
    -d
        --I
    -h, --help                       You're looking at it.
```

`-d` and `--I` are there because of the invalid option handling you added, @JonRowe.  Can you see if there's a way to hide them?
