### PR TITLE
`ExampleGroup.pending` should not blow up when given no block.

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -53,16 +53,10 @@ module RSpec
         hash
       end
 
-      if Proc.method_defined?(:source_location)
-        # @private
-        def self.backtrace_from(block)
-          [block.source_location.join(':')]
-        end
-      else
-        # @private
-        def self.backtrace_from(block)
-          caller
-        end
+      # @private
+      def self.backtrace_from(block)
+        return caller unless block.respond_to?(:source_location)
+        [block.source_location.join(':')]
       end
 
       # @private

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -913,6 +913,13 @@ module RSpec::Core
         actual = group.examples.first.exception.backtrace.first.split(':')[0..1]
         expect(actual).to eq(expected)
       end
+
+      it 'generates a pending example when no block is provided' do
+        group = RSpec.describe "group"
+        example = group.pending "just because"
+        group.run
+        expect(example).to be_pending
+      end
     end
 
     describe "pending with metadata" do


### PR DESCRIPTION
This regressed in #1391 but there wasn't a spec to catch it.  rspec/rspec-rails#954 is failing because of this regression.

/cc @JonRowe 
