### PR TITLE
Deprecate `describes` and `display_name`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,10 @@ Deprecations:
   but in RSpec 3 it'll be treated as the described object. To continue
   having it treated as metadata, pass a description before the symbol or
   hash. (Myron Marston)
+* Deprecate `RSpec::Core::ExampleGroup.display_name` in favor of
+  `RSpec::Core::ExampleGroup.description`. (Myron Marston)
+* Deprecate `RSpec::Core::ExampleGroup.describes` in favor of
+  `RSpec::Core::ExampleGroup.described_class`. (Myron Marston)
 
 ### 2.99.0.beta2 / 2014-02-17
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.99.0.beta1...v2.99.0.beta2)

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -49,9 +49,20 @@ module RSpec
         end
 
         delegate_to_metadata :described_class, :file_path
-        alias_method :display_name, :description
+
         # @private
-        alias_method :describes, :described_class
+        def display_name
+          RSpec.deprecate('`RSpec::Core::ExampleGroup.display_name`',
+                          :replacement => "`RSpec::Core::ExampleGroup.description`")
+          description
+        end
+
+        # @private
+        def describes
+          RSpec.deprecate('`RSpec::Core::ExampleGroup.describes`',
+                          :replacement => "`RSpec::Core::ExampleGroup.described_class`")
+          described_class
+        end
 
         # @private
         # @macro [attach] define_example_method

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1282,5 +1282,17 @@ module RSpec::Core
         end.to raise_error(ArgumentError,%q|Could not find shared examples "shared stuff"|)
       end
     end
+
+    describe "deprecated methods" do
+      specify ".describes is deprecated" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /describes/)
+        expect(self.class.describes).to eq(self.class.described_class)
+      end
+
+      specify ".display_name is deprecated" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /display_name/)
+        expect(self.class.display_name).to eq(self.class.description)
+      end
+    end
   end
 end


### PR DESCRIPTION
2.99 deprecations for methods removed in #1406.
