### PR TITLE
Fix exit status on LoadError

### DIFF
--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -109,8 +109,10 @@ module RSpec
         else
           CommandLine.new(options).run(err, out)
         end
-      ensure
         RSpec.reset
+      rescue Exception
+        RSpec.reset
+        return 1
       end
     end
   end

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -102,6 +102,15 @@ module RSpec::Core
         RSpec::Core::Runner.run([], err, out)
       end
 
+      context "with a LoadError" do
+        it "exits with status 1" do
+          allow(CommandLine).to receive(:new).and_raise(LoadError)
+          expect(RSpec).to receive(:reset)
+          status = RSpec::Core::Runner.run([], err, out)
+          expect(status).to eq(1)
+        end
+      end
+
       context "with --drb or -X" do
         before(:each) do
           @options = RSpec::Core::ConfigurationOptions.new(%w[--drb --drb-port 8181 --color])


### PR DESCRIPTION
Currently if a spec triggers a LoadError by calling `require` with a
nonexistent file, RSpec will exit with status 0 instead of 1. This can
allow entire spec suites to be skipped without notice in a CI
environment.

This patch rescues such errors and correctly exits with status 1.

@myronmarston @xaviershay
