### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rspec-core [![Build Status](https://secure.travis-ci.org/rspec/rspec-core.png?branch=master)](http://travis-ci.org/rspec/rspec-core) [![Code Climate](https://codeclimate.com/github/rspec/rspec-core.png)](https://codeclimate.com/github/rspec/rspec-core)
+# rspec-core [![Build Status](https://secure.travis-ci.org/rspec/rspec-core.png?branch=master)](http://travis-ci.org/rspec/rspec-core) [![Code Climate](https://codeclimate.com/github/rspec/rspec-core.png)](https://codeclimate.com/github/rspec/rspec-core) [![Inline docs](http://inch-pages.github.io/github/rspec/rspec-core.png)](http://inch-pages.github.io/github/rspec/rspec-core)
 
 rspec-core provides the structure for writing executable examples of how your
 code should behave, and an `rspec` command with tools to constrain which


### PR DESCRIPTION
I just added the badge @soulcutter requested to the README: ![Inline docs](http://inch-pages.github.io/github/rspec/rspec-core.png)

Your status page for this project is http://inch-pages.github.io/github/rspec/rspec-core

Thanks for giving this a shot!
