### PR TITLE
Properly attribute backport random code

### DIFF
--- a/lib/rspec/core/backport_random.rb
+++ b/lib/rspec/core/backport_random.rb
@@ -1,6 +1,33 @@
-# This code was (mostly) ported from the backports gem (https://github.com/marcandre/backports).
-# The goal is to provide a random number generator in Ruby versions that do not have one.
-# This was added to support localization of random spec ordering.
+# This code was (mostly) ported from the backports gem found at
+# https://github.com/marcandre/backports which is subject to this license:
+#
+# =============================================================================
+#
+# Copyright (c) 2009 Marc-Andre Lafortune
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# =============================================================================
+#
+# The goal is to provide a random number generator in Ruby versions that do
+# not have one. This was added to support localization of random spec ordering.
 #
 # These were in multiple files in backports, but merged into one here.
 


### PR DESCRIPTION
Include relevant parts of license from backports as attribution for #1418.
Fixes #1418.
