### PR TITLE
Force Nokogiri to format meaningful whitespace.

### DIFF
--- a/spec/rspec/core/formatters/html_formatter_spec.rb
+++ b/spec/rspec/core/formatters/html_formatter_spec.rb
@@ -24,7 +24,7 @@ module RSpec
           command_line.run(err, out)
           html = out.string.gsub(/\d+\.\d+(s| seconds)/, "n.nnnn\\1")
 
-          actual_doc = Nokogiri::HTML(html)
+          actual_doc = Nokogiri::HTML(html, &:noblanks)
           actual_doc.css("div.backtrace pre").each do |elem|
             # This is to minimize churn on backtrace lines that we do not
             # assert on anyway.
@@ -83,11 +83,11 @@ module RSpec
         describe 'produced HTML', :slow, :if => RUBY_VERSION >= '2.0.0' do
           def build_and_verify_formatter_output
             Dir.chdir(root) do
-              actual_doc = Nokogiri::HTML(generated_html)
+              actual_doc = Nokogiri::HTML(generated_html, &:noblanks)
               actual_backtraces = extract_backtrace_from(actual_doc)
               actual_doc.css("div.backtrace").remove
 
-              expected_doc = Nokogiri::HTML(expected_html)
+              expected_doc = Nokogiri::HTML(expected_html, &:noblanks)
               expected_backtraces = extract_backtrace_from(expected_doc)
               expected_doc.search("div.backtrace").remove
 


### PR DESCRIPTION
It is still unclear why some systems successfully match the fixture with
the generated HTML, while others fail. However, according to the
following resources, Nokogiri is whitespace sensitive:
- https://groups.google.com/forum/#!topic/nokogiri-talk/P6p46mnhERE
- https://stackoverflow.com/questions/3886059

To quote the above resources:

> In XML, whitespace can be considered meaningful. If you parse a
> document that contains whitespace nodes, libxml2 will assume that
> whitespace nodes are meaningful and will not insert them for you.
> 
> You can tell libxml2 that whitespace is not meaningful by passing the
> "noblanks" flag to the parser.

Here we use the block form and tell Nokogiri to run `noblanks` on the
result. We also could pass in the options in the args, but that would
require a more verbose call to handle the unused args:

```
Nokogiri::HTML(
  html,
  _url = nil,
  _encoding = nil,
  Nokogiri::XML::ParseOptions::NOBLANKS
)
```
