### PR TITLE
Remove the automatic call to RSpec.reset.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -53,6 +53,11 @@ Breaking Changes for 3.0.0:
 * Rename `RSpec::Core::Configuration#warnings` to
   `RSpec::Core::Configuration#warnings?` since it's a boolean flag.
   (Myron Marston)
+* RSpec's global state is no longer reset after a spec run. This gives
+  more flexibility to alternate runners to decide when and if they
+  want the state reset. Alternate runners are now responsible for
+  calling this (or doing a similar reset) if they are going to run
+  the spec suite multiple times in the same process. (Sam Phippen)
 
 Enhancements:
 

--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -40,9 +40,11 @@ module RSpec
 
   extend RSpec::Core::Warnings
 
-  # @private
-  # Used internally to ensure examples get reloaded between multiple runs in
+  # Used to ensure examples get reloaded between multiple runs in
   # the same process.
+  #
+  # Users must invoke this if they want to have the configuration reset when
+  # they use runner multiple times within the same process.
   def self.reset
     @world = nil
     @configuration = nil

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -109,8 +109,6 @@ module RSpec
         else
           CommandLine.new(options).run(err, out)
         end
-      ensure
-        RSpec.reset
       end
     end
   end

--- a/spec/command_line/order_spec.rb
+++ b/spec/command_line/order_spec.rb
@@ -207,5 +207,7 @@ RSpec.describe 'command line', :ui, :slow do
     in_current_dir do
       RSpec::Core::Runner.run(cmd.split, stderr, stdout)
     end
+  ensure
+    RSpec.reset
   end
 end

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -95,13 +95,6 @@ module RSpec::Core
       let(:err) { StringIO.new }
       let(:out) { StringIO.new }
 
-      it "tells RSpec to reset" do
-        allow(CommandLine).to receive_messages(:new => double.as_null_object)
-        allow(RSpec.configuration).to receive_messages(:files_to_run => [], :warn => nil)
-        expect(RSpec).to receive(:reset)
-        RSpec::Core::Runner.run([], err, out)
-      end
-
       context "with --drb or -X" do
         before(:each) do
           @options = RSpec::Core::ConfigurationOptions.new(%w[--drb --drb-port 8181 --color])


### PR DESCRIPTION
I was auditing the open issues and saw that #621 is still open.  @samphippen's fix in #703 was closed without being merged.

I'm resurrecting this because as far as I can tell, the reset doesn't
provide any useful value to folks running specs
the normal way via the `rspec` command, and it
takes a bit of extra time to do so. It also limits
flexibility as alternate runners can't prevent RSpec
from calling this if they do not want it, but by
us no longer calling it, they can now decide if they
want things reset and can call it at the appropriate time.

In #703, @dchelimsky said:

> I'm concerned by the implications of #621 (comment). @sandro's issue was that clearing the config between runs blew away config that wasn't going to get reloaded. Right now we have no concept of config settings that should be persistent vs those that should be clearable. I'm not even sure we can do that in a universally correct way. I'll ponder this a bit and follow up if anything hits me, but I don't recommend merging this yet as it solves one problem by creating another IMO.

As far as I can tell, this change doesn't actually create any problems, it just gives more control to alternate runners.  Am I misunderstanding something, @dchelimsky?

As far as the specific problem surfaced in #621 -- it sounds like the problem is that `spec_helper` is being required and ruby won't re-evaluate it. If users want it to be loaded multiple times I think `load` is a better tool for it than `require`.  I think that differentiating between persistent and non-persistent settings is complex and out of scope for rspec-core since I can't imagine how we'd do that well and the use case for it is pretty narrow.

Thoughts on others about this?  Mostly I want to resolve the issue once and for all, and this seems like a worthwhile enough change to merge.
