### PR TITLE
Add deprecation warning for `warnings`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,8 @@ Deprecations:
 * Deprecate filtering by `:line_number` (e.g. `--line-number` from the
   CLI). Use location filtering instead. (Myron Marston)
 * Deprecate `--default_path` as an alternative to `--default-path`. (Jon Rowe)
+* Deprecate `RSpec::Core::Configuration#warnings` in favor of
+  `RSpec::Core::Configuration#warnings?`. (Myron Marston)
 
 ### 2.99.0.beta2 / 2014-02-17
 [full changelog](http://github.com/rspec/rspec-core/compare/v2.99.0.beta1...v2.99.0.beta2)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1175,8 +1175,14 @@ EOM
         $VERBOSE = !!value
       end
 
-      def warnings
+      def warnings?
         $VERBOSE
+      end
+
+      def warnings
+        RSpec.deprecate("`RSpec::Core::Configuration#warnings`",
+                        :replacement => "`RSpec::Core::Configuration#warnings?`")
+        warnings?
       end
 
       # Exposes the current running example via the named

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1813,7 +1813,12 @@ module RSpec::Core
         expect($VERBOSE).to eq false
       end
 
-      it 'returns the verbosity setting' do
+      it 'returns the verbosity setting as a predicate' do
+        expect(config.warnings?).to eq $VERBOSE
+      end
+
+      it 'warns when using the deprecated `warnings` reader' do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warnings/)
         expect(config.warnings).to eq $VERBOSE
       end
 


### PR DESCRIPTION
It's a boolean value and should be presented as a predicate.

Followup to #1445.
