### PR TITLE
Store execution result as a symbol rather than a string.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -66,8 +66,9 @@ Enhancements:
   (e.g. via `--formatter`). (Myron Marston)
 * Support legacy colour definitions in `LegacyFormatterAdaptor`. (Jon Rowe)
 * Migrate `execution_result` (exposed by metadata) from a hash to a
-  first-class object with appropriate attributes. It retains deprecated
-  hash behavior for backwards compatibility. (Myron Marston)
+  first-class object with appropriate attributes. `status` is now
+  stored and returned as a symbol rather than a string. It retains
+  deprecated hash behavior for backwards compatibility. (Myron Marston)
 * Provide console code helper for formatters. (Jon Rowe)
 * Use raw ruby hashes for the metadata hashes rather than a subclass of
   a hash. Computed metadata entries are now computed in advance rather

--- a/lib/rspec/core/formatters/json_formatter.rb
+++ b/lib/rspec/core/formatters/json_formatter.rb
@@ -83,7 +83,7 @@ module RSpec
           {
             :description => example.description,
             :full_description => example.full_description,
-            :status => example.execution_result.status,
+            :status => example.execution_result.status.to_s,
             :file_path => example.metadata[:file_path],
             :line_number  => example.metadata[:line_number],
             :run_time => example.execution_result.run_time

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -265,7 +265,7 @@ module RSpec
         define_method(method_name) do |*args, &block|
           issue_deprecation(method_name, *args)
 
-          hash = to_h
+          hash = hash_for_delegation
           self.class.hash_attribute_names.each do |name|
             hash.delete(name) unless instance_variable_defined?(:"@#{name}")
           end
@@ -319,6 +319,10 @@ module RSpec
 
       def set_value(name, value)
         __send__(:"#{name}=", value)
+      end
+
+      def hash_for_delegation
+        to_h
       end
 
       def issue_deprecation(method_name, *args)

--- a/spec/rspec/core/example_execution_result_spec.rb
+++ b/spec/rspec/core/example_execution_result_spec.rb
@@ -6,11 +6,11 @@ module RSpec
       RSpec.describe ExecutionResult do
         it "supports ruby 2.1's `to_h` protocol" do
           er = ExecutionResult.new
-          er.status = "pending"
+          er.run_time = 17
           er.pending_message = "just because"
 
           expect(er.to_h).to include(
-            :status => "pending",
+            :run_time => 17,
             :pending_message => "just because"
           )
         end
@@ -30,16 +30,16 @@ module RSpec
         describe "backwards compatibility" do
           it 'supports indexed access like a hash' do
             er = ExecutionResult.new
-            er.status = "failed"
+            er.started_at = (started_at = ::Time.utc(2014, 3, 1, 12, 30))
             expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /execution_result/)
-            expect(er[:status]).to eq("failed")
+            expect(er[:started_at]).to eq(started_at)
           end
 
           it 'supports indexed updates like a hash' do
             er = ExecutionResult.new
             expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /execution_result/)
-            er[:status] = "passed"
-            expect(er.status).to eq("passed")
+            er[:started_at] = (started_at = ::Time.utc(2014, 3, 1, 12, 30))
+            expect(er.started_at).to eq(started_at)
           end
 
           it 'can get and set user defined attributes like with a hash' do
@@ -52,33 +52,33 @@ module RSpec
           it 'supports `update` like a hash' do
             er = ExecutionResult.new
             expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /execution_result/)
-            er.update(:status => "failed", :exception => ArgumentError.new)
-            expect(er.status).to eq("failed")
+            er.update(:pending_message => "some message", :exception => ArgumentError.new)
+            expect(er.pending_message).to eq("some message")
             expect(er.exception).to be_a(ArgumentError)
           end
 
           it 'can set undefined attribute keys through any hash mutation method' do
             allow_deprecation
             er = ExecutionResult.new
-            er.update(:status => "failed", :foo => 3)
-            expect(er.to_h).to include(:status => "failed", :foo => 3)
+            er.update(:pending_message => "msg", :foo => 3)
+            expect(er.to_h).to include(:pending_message => "msg", :foo => 3)
           end
 
           it 'supports `merge` like a hash' do
             er = ExecutionResult.new
-            er.status = "pending"
+            er.exception = ArgumentError.new
             er.pending_message = "just because"
 
             expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /execution_result/)
-            merged = er.merge(:status => "failed", :foo => 3)
+            merged = er.merge(:exception => NotImplementedError.new, :foo => 3)
 
             expect(merged).to include(
-              :status => "failed",
+              :exception => an_instance_of(NotImplementedError),
               :pending_message => "just because",
               :foo => 3
             )
 
-            expect(er.status).to eq("pending")
+            expect(er.exception).to be_an(ArgumentError)
           end
 
           it 'supports blocks for hash methods that support one' do
@@ -93,9 +93,47 @@ module RSpec
           specify '#fetch treats unset properties the same as a hash does' do
             allow_deprecation
             er = ExecutionResult.new
-            expect { er.fetch(:status) }.to raise_error(fetch_not_found_error_class)
-            er.status = "foo"
-            expect(er.fetch(:status)).to eq("foo")
+            expect { er.fetch(:pending_message) }.to raise_error(fetch_not_found_error_class)
+            er.pending_message = "some msg"
+            expect(er.fetch(:pending_message)).to eq("some msg")
+          end
+
+          describe "status" do
+            it 'returns a string when accessed like a hash' do
+              er = ExecutionResult.new
+              expect(er[:status]).to eq(nil)
+              er.status = :failed
+              expect(er[:status]).to eq("failed")
+            end
+
+            it "sets the status to a symbol when assigned as a string via the hash interface" do
+              er = ExecutionResult.new
+              er[:status] = "failed"
+              expect(er.status).to eq(:failed)
+              er[:status] = nil
+              expect(er.status).to eq(nil)
+            end
+
+            it "is presented as a string when included in returned hashes" do
+              er = ExecutionResult.new
+              er.status = :failed
+              expect(er.merge(:foo => 3)).to include(:status => "failed", :foo => 3)
+
+              er.status = nil
+              expect(er.merge(:foo => 3)).to include(:status => nil, :foo => 3)
+            end
+
+            it "is updated to a symbol when updated as a string via `update`" do
+              er = ExecutionResult.new
+              er.update(:status => "passed")
+              expect(er.status).to eq(:passed)
+            end
+
+            it 'is presented as a symbol in `to_h`' do
+              er = ExecutionResult.new
+              er.status = :failed
+              expect(er.to_h).to include(:status => :failed)
+            end
           end
         end
       end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -866,7 +866,7 @@ module RSpec::Core
         it "allows the example to pass" do
           group.run
           example = group.examples.first
-          expect(example.execution_result.status).to eq("passed")
+          expect(example.execution_result.status).to eq(:passed)
         end
 
         it "rescues any error(s) and prints them out" do
@@ -1028,7 +1028,7 @@ module RSpec::Core
 
           expect(extract_execution_results(group).map(&:to_h)).to match([
             a_hash_including(
-              :status => "pending",
+              :status => :pending,
               :pending_message => "Temporarily skipped with #{method_name}"
             )
           ] * 2)
@@ -1080,11 +1080,11 @@ module RSpec::Core
 
         expect(extract_execution_results(group).map(&:to_h)).to match([
           a_hash_including(
-            :status => "failed",
+            :status => :failed,
             :pending_message => "No reason given"
           ),
           a_hash_including(
-            :status => "pending",
+            :status => :pending,
             :pending_message => "unimplemented"
           )
         ])

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -414,7 +414,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
   describe "#pending" do
     def expect_pending_result(example)
       expect(example).to be_pending
-      expect(example.execution_result.status).to eq("pending")
+      expect(example.execution_result.status).to eq(:pending)
       expect(example.execution_result.pending_message).to be
     end
 

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -276,7 +276,7 @@ module RSpec::Core
               end
             end.run
 
-            expect(ex.execution_result.status).to eq("failed")
+            expect(ex.execution_result.status).to eq(:failed)
             expect(ex.execution_result.exception.message).to match(/super.*not supported/)
           end
 

--- a/spec/rspec/core/pending_example_spec.rb
+++ b/spec/rspec/core/pending_example_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "an example" do
       example = group.examples.first
       example.run(group.new, double.as_null_object)
       expect(example).to be_pending_with('because')
-      expect(example.execution_result.status).to eq('pending')
+      expect(example.execution_result.status).to eq(:pending)
     end
 
     it "does not mutate the :pending attribute of the user metadata when handling mock expectation errors" do
@@ -88,7 +88,7 @@ RSpec.describe "an example" do
       expect(called).to eq(true)
       result = example.execution_result
       expect(result.pending_fixed).to eq(true)
-      expect(result.status).to eq("failed")
+      expect(result.status).to eq(:failed)
     end
 
     it "does not mutate the :pending attribute of the user metadata when the rest of the example passes" do

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -30,10 +30,10 @@ RSpec::Matchers.define :fail_with do |exception_klass|
   end
 
   def failure_reason(example, exception_klass)
-    result = example.metadata[:execution_result]
+    result = example.execution_result
     case
       when example.metadata[:pending] then "was pending"
-      when result.status != 'failed' then result.status
+      when result.status != :failed then result.status
       when !result.exception.is_a?(exception_klass) then "failed with a #{result.exception.class}"
       else nil
     end
@@ -53,7 +53,7 @@ RSpec::Matchers.define :pass do
     result = example.metadata[:execution_result]
     case
       when example.metadata[:pending] then "was pending"
-      when result.status != 'passed' then result.status
+      when result.status != :passed then result.status
       else nil
     end
   end
@@ -66,7 +66,9 @@ end
 
 RSpec::Matchers.define :be_pending_with do |message|
   match do |example|
-    example.pending? && example.execution_result.pending_message == message
+    example.pending? &&
+    example.execution_result.status == :pending &&
+    example.execution_result.pending_message == message
   end
 
   failure_message_for_should do |example|
@@ -76,7 +78,9 @@ end
 
 RSpec::Matchers.define :be_skipped_with do |message|
   match do |example|
-    example.skipped? && example.execution_result.pending_message == message
+    example.skipped? &&
+    example.pending? &&
+    example.execution_result.pending_message == message
   end
 
   failure_message_for_should do |example|


### PR DESCRIPTION
It makes more semantic sense and can safe a bit of memory.

Strings are still returned from the deprecated hash
interface for backwards compatibility.

Note: I didn't provide a deprecation warning since
the hash interface is already deprecated. When extension
authors update to use the new interface they'll notice
it's a symbol and will deal with it appropriately.

Fixes #1436.
