### PR TITLE
Better formatting for the common case where multiline deprecations have a trailing newline.

### DIFF
--- a/lib/rspec/core/formatters/deprecation_formatter.rb
+++ b/lib/rspec/core/formatters/deprecation_formatter.rb
@@ -78,7 +78,7 @@ module RSpec
           def output_formatted(str)
             return str unless str.lines.count > 1
             separator = "#{'-' * 80}"
-            "#{separator}\n#{str}\n#{separator}"
+            "#{separator}\n#{str.chomp}\n#{separator}"
           end
 
           def deprecation_type_for(data)

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -29,7 +29,10 @@ module RSpec::Core::Formatters
         end
 
         it "surrounds multiline messages in fenceposts" do
-          multiline_message = "line one\nline two"
+          multiline_message = <<-EOS.gsub(/^\s+\|/, '')
+            |line one
+            |line two
+          EOS
           send_notification :deprecation, notification(:message => multiline_message)
           deprecation_stream.rewind
 


### PR DESCRIPTION
i.e. https://github.com/rspec/rspec-expectations/pull/506/files

@soulcutter @JonRowe 
