### PR TITLE
Provide assertions accessor for minitest.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -86,6 +86,7 @@ Enhancements:
   supported public API. (Myron Marston)
 * Add `--deprecation-out` CLI option which directs deprecation warnings
   to the named file. (Myron Marston)
+* Minitest 5 compatability for `expect_with :stdlib`. (Xavier Shay)
 
 Bug Fixes:
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,10 @@ platforms :ruby do
   gem 'github-markup', '0.7.2'
 end
 
+platforms :ruby_18, :jruby do
+  gem 'json'
+end
+
 platforms :jruby do
   gem "jruby-openssl"
 end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -522,8 +522,13 @@ module RSpec
             self.expecting_with_rspec = true
             ::RSpec::Matchers
           when :stdlib
+            # This require is kept here rather than in
+            # stdlib_assertions_adapter so that we can stub it out sanely in
+            # tests.
             require 'test/unit/assertions'
-            ::Test::Unit::Assertions
+
+            require 'rspec/core/stdlib_assertions_adapter'
+            ::RSpec::Core::StdlibAssertionsAdapter
           else
             raise ArgumentError, "#{framework.inspect} is not supported"
           end

--- a/lib/rspec/core/stdlib_assertions_adapter.rb
+++ b/lib/rspec/core/stdlib_assertions_adapter.rb
@@ -1,0 +1,18 @@
+module RSpec
+  module Core
+    # @private
+    module StdlibAssertionsAdapter
+      include ::Test::Unit::Assertions
+
+      # Minitest requires this accessor to be available. See
+      # https://github.com/seattlerb/minitest/blob/38f0a5fcbd9c37c3f80a3eaad4ba84d3fc9947a0/lib/minitest/assertions.rb#L8
+      #
+      # It is not required for other extension libraries, and RSpec does not
+      # report or make this information available to formatters.
+      attr_writer :assertions
+      def assertions
+        @assertions ||= 0
+      end
+    end
+  end
+end

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -40,7 +40,8 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency "rake",     "~> 10.0.0"
-  s.add_development_dependency "cucumber", "~> 1.1.9"
+  s.add_development_dependency "cucumber", "~> 1.3"
+  s.add_development_dependency "minitest", "~> 5"
   s.add_development_dependency "aruba",    "~> 0.5"
 
   s.add_development_dependency "nokogiri", "1.5.2"

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -261,10 +261,17 @@ module RSpec::Core
       end
     end
 
+    def stub_stdlib_adapter
+      stub_const("Test::Unit::Assertions", Module.new)
+      allow(config).to receive(:require).with("test/unit/assertions")
+      allow(config).to receive(:require).with("rspec/expectations")
+      allow(config).to receive(:require).
+        with("rspec/core/stdlib_assertions_adapter").and_call_original
+    end
+
     describe "#expect_with" do
       before do
-        stub_const("Test::Unit::Assertions", Module.new)
-        allow(config).to receive(:require)
+        stub_stdlib_adapter
       end
 
       it_behaves_like "a configurable framework adapter", :expect_with
@@ -284,7 +291,7 @@ module RSpec::Core
       it "supports multiple calls" do
         config.expect_with :rspec
         config.expect_with :stdlib
-        expect(config.expectation_frameworks).to eq [RSpec::Matchers, Test::Unit::Assertions]
+        expect(config.expectation_frameworks).to eq [RSpec::Matchers, RSpec::Core::StdlibAssertionsAdapter]
       end
 
       it "raises if block given with multiple args" do
@@ -326,8 +333,7 @@ module RSpec::Core
 
     describe "#expecting_with_rspec?" do
       before do
-        stub_const("Test::Unit::Assertions", Module.new)
-        allow(config).to receive(:require)
+        stub_stdlib_adapter
       end
 
       it "returns false by default" do


### PR DESCRIPTION
Fixes https://github.com/rspec/rspec-core/issues/1354

I don't have a great idea for integration testing this: latest `rubysl-test-unit` (in the `Gemfile`) is locked to minitest 4.7. For similar reasons, I haven't touched the `Test::Unit::Assertions` include suggested by @myronmarston ( https://github.com/rspec/rspec-core/blob/184b02c7673b61588129bad268eb0847bae5243a/lib/rspec/core/configuration.rb#L498-L500 )

I have confirmed that this fixes @rosenfeld's sample application.
