### PR TITLE
Added option to disable all monkey patching

### DIFF
--- a/features/configuration/zero_monkey_patching_mode.feature
+++ b/features/configuration/zero_monkey_patching_mode.feature
@@ -1,0 +1,99 @@
+@allow-disabled-should-syntax
+Feature: Zero monkey patching mode
+
+  Use the `disable_monkey_patching!` configuration option to
+  disable all monkey patching done by RSpec (stops exposing
+  DSL globally, disabling should syntax for rspec-mocks and
+  rspec-expectations):
+
+  ```ruby
+    RSpec.configure { |c| c.disable_monkey_patching! }
+  ```
+
+  Background:
+    Given a file named "spec/example_describe_spec.rb" with:
+      """ruby
+      require 'spec_helper'
+
+      describe "specs here" do
+        it "passes" do
+        end
+      end
+      """
+    Given a file named "spec/example_should_spec.rb" with:
+      """ruby
+      require 'spec_helper'
+
+      RSpec.describe "another specs here" do
+        it "passes with monkey patched expectations" do
+          x = 25
+          x.should eq 25
+          x.should_not be > 30
+        end
+
+        it "passes with monkey patched mocks" do
+          x = double("thing")
+          x.stub(:hello => [:world])
+          x.should_receive(:count).and_return(5)
+          x.should_not_receive(:all)
+          (x.hello * x.count).should eq([:world] * 5)
+        end
+      end
+      """
+    Given a file named "spec/example_expect_spec.rb" with:
+      """ruby
+      require 'spec_helper'
+
+      RSpec.describe "specs here too" do
+        it "passes in zero monkey patching mode" do
+          x = double("thing")
+          allow(x).to receive(:hello).and_return([:world])
+          expect(x).to receive(:count).and_return(5)
+          expect(x).not_to receive(:all)
+          expect(x.hello * x.count).to eq([:world] * 5)
+        end
+
+        it "passes in zero monkey patching mode" do
+          x = 25
+          expect(x).to eq(25)
+          expect(x).not_to be > 30
+        end
+      end
+      """
+
+  Scenario: By default RSpec allows monkey patching
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      """
+    When I run `rspec spec/example_should_spec.rb`
+    Then the examples should all pass
+
+  Scenario: In zero monkey patching mode, the monkey patched methods are undefined
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.disable_monkey_patching!
+      end
+      """
+    When I run `rspec spec/example_should_spec.rb`
+    Then the output should contain all of these:
+      | undefined method `should'   |
+      | unexpected message :stub    |
+    When I run `rspec spec/example_describe_spec.rb`
+    Then the output should contain "undefined method `describe'"
+
+  Scenario: Regardless of setting expect syntax works on mocks and expectations
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      """
+    When I run `rspec spec/example_expect_spec.rb`
+    Then the examples should all pass
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.disable_monkey_patching!
+      end
+      """
+    When I run `rspec spec/example_expect_spec.rb`
+    Then the examples should all pass
+

--- a/features/support/require_expect_syntax_in_aruba_specs.rb
+++ b/features/support/require_expect_syntax_in_aruba_specs.rb
@@ -1,6 +1,6 @@
 if defined?(Cucumber)
   require 'shellwords'
-  Before do
+  Before('~@allow-disabled-should-syntax') do
     set_env('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
   end
 else

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 require 'tmpdir'
+require 'rspec/support/spec/in_sub_process'
 
 module RSpec::Core
 
   RSpec.describe Configuration do
+    include RSpec::Support::InSubProcess
 
     let(:config) { Configuration.new }
     let(:exclusion_filter) { config.exclusion_filter.rules }
@@ -1515,6 +1517,106 @@ module RSpec::Core
         expect(value_1).to be_an(RSpec::Core::Example)
         expect(value_1.description).to eq("works")
         expect(value_2).to be(value_1)
+      end
+    end
+
+    describe '#disable_monkey_patching!' do
+      let!(:config) { RSpec.configuration }
+      let!(:expectations) { RSpec::Expectations }
+      let!(:mocks) { RSpec::Mocks }
+
+      def in_fully_monkey_patched_rspec_environment
+        in_sub_process do
+          config.expose_dsl_globally = true
+          mocks.configuration.syntax = [:expect, :should]
+          mocks.configuration.patch_marshal_to_support_partial_doubles = true
+          expectations.configuration.syntax = [:expect, :should]
+
+          yield
+        end
+      end
+
+      it 'stops exposing the DSL methods globally' do
+        in_fully_monkey_patched_rspec_environment do
+          mod = Module.new
+          expect {
+            config.disable_monkey_patching!
+          }.to change { mod.respond_to?(:describe) }.from(true).to(false)
+        end
+      end
+
+      it 'stops using should syntax for expectations' do
+        in_fully_monkey_patched_rspec_environment do
+          obj = Object.new
+          config.expect_with :rspec
+          expect {
+            config.disable_monkey_patching!
+          }.to change { obj.respond_to?(:should) }.from(true).to(false)
+        end
+      end
+
+      it 'stops using should syntax for mocks' do
+        in_fully_monkey_patched_rspec_environment do
+          obj = Object.new
+          config.mock_with :rspec
+          expect {
+            config.disable_monkey_patching!
+          }.to change { obj.respond_to?(:should_receive) }.from(true).to(false)
+        end
+      end
+
+      it 'stops patching of Marshal' do
+        in_fully_monkey_patched_rspec_environment do
+          expect {
+            config.disable_monkey_patching!
+          }.to change { Marshal.respond_to?(:dump_with_rspec_mocks) }.from(true).to(false)
+        end
+      end
+
+      context 'when user did not configure mock framework' do
+        def emulate_not_configured_mock_framework
+          in_fully_monkey_patched_rspec_environment do
+            allow(config).to receive(:rspec_mocks_loaded?).and_return(false, true)
+            config.instance_variable_set :@mock_framework, nil
+            ExampleGroup.send :remove_class_variable, :@@example_groups_configured
+
+            yield
+          end
+        end
+
+        it 'disables monkey patching after example groups being configured' do
+          emulate_not_configured_mock_framework do
+            obj = Object.new
+            config.disable_monkey_patching!
+
+            expect {
+              ExampleGroup.ensure_example_groups_are_configured
+            }.to change { obj.respond_to?(:should_receive) }.from(true).to(false)
+          end
+        end
+      end
+
+      context 'when user did not configure expectation framework' do
+        def emulate_not_configured_expectation_framework
+          in_fully_monkey_patched_rspec_environment do
+            allow(config).to receive(:rspec_expectations_loaded?).and_return(false, true)
+            config.instance_variable_set :@expectation_frameworks, []
+            ExampleGroup.send :remove_class_variable, :@@example_groups_configured
+
+            yield
+          end
+        end
+
+        it 'disables monkey patching after example groups being configured' do
+          emulate_not_configured_expectation_framework do
+            obj = Object.new
+            config.disable_monkey_patching!
+
+            expect {
+              ExampleGroup.ensure_example_groups_are_configured
+            }.to change { obj.respond_to?(:should) }.from(true).to(false)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Related to #1433 
- [x] Add config option to disable all monkey patching
- [x] Fix for 1.8.7
- [x] Add doc-comments for introduced methods
- [x] Add cucumber scenarios
- [x] Move specs from `disable_monkey_patching_spec.rb` to `configuration_spec.rb`
- [x] Fix feature to support 1.8.7 syntax
