### PR TITLE
Add :parent_example_group to RESERVED_KEYS.

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -231,6 +231,7 @@ module RSpec
       RESERVED_KEYS = [
         :description,
         :example_group,
+        :parent_example_group,
         :execution_result,
         :file_path,
         :full_description,


### PR DESCRIPTION
It's managed by us so users shouldn't pass that metadata.
