### PR TITLE
Add support for --exclude-dir command line option

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -246,6 +246,10 @@ module RSpec
       #                       :blue, :magenta, :cyan]`
       add_setting :detail_color
 
+      # @macro add_setting
+      # Do not load files within these directories
+      add_setting :exclude_dirs
+
       # Deprecated. This config option was added in RSpec 2 to pave the way
       # for this being the default behavior in RSpec 3. Now this option is
       # a no-op.
@@ -1216,7 +1220,13 @@ module RSpec
       def gather_directories(path)
         stripped = "{#{pattern.gsub(/\s*,\s*/, ',')}}"
         files    = pattern =~ /^#{Regexp.escape path}/ ? Dir[stripped] : Dir["#{path}/#{stripped}"]
-        files.sort
+        files.reject(&matching_exclude_dirs).sort
+      end
+
+      def matching_exclude_dirs
+        lambda do |path|
+          exclude_dirs.detect{|glob| File.fnmatch(glob, path)} if exclude_dirs
+        end
       end
 
       def extract_location(path)

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -194,6 +194,11 @@ FILTERING
           exit
         end
 
+        parser.on('--exclude-dir DIR', 'Specify directories to exclude from being loaded.') do |dir|
+          options[:exclude_dirs] ||= []
+          options[:exclude_dirs] << dir
+        end
+
         # these options would otherwise be confusing to users, so we forcibly prevent them from executing
         # --I is too similar to -I
         # -d was a shorthand for --debugger, which is removed, but now would trigger --default-path

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -513,6 +513,32 @@ module RSpec::Core
       end
     end
 
+    describe "#exclude_dirs" do
+      context "with no directories excluded" do
+        it "should include all files" do
+          dir = File.expand_path(File.dirname(__FILE__) + "/resources")
+          assign_files_or_directories_to_run dir
+          expect(config.files_to_run).to include("#{dir}/a_spec.rb")
+        end
+      end
+
+      context "with directory excluded" do
+        it "should not include files in directory" do
+          config.exclude_dirs = ["**/resources/*"]
+          dir = File.expand_path(File.dirname(__FILE__) + "/resources")
+          assign_files_or_directories_to_run dir
+          expect(config.files_to_run).to_not include("#{dir}/a_spec.rb")
+        end
+
+        it "should include files outside directory" do
+          config.exclude_dirs = ["**/foobarred/**/*"]
+          dir = File.expand_path(File.dirname(__FILE__) + "/resources")
+          assign_files_or_directories_to_run dir
+          expect(config.files_to_run).to include("#{dir}/a_spec.rb")
+        end
+      end
+    end
+
     describe "#pattern" do
       context "with single pattern" do
         before { config.pattern = "**/*_foo.rb" }

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -266,5 +266,18 @@ module RSpec::Core
       end
     end
 
+    describe '--exclude-dir' do
+      it "adds a value to the exclude_dirs array" do
+        options = Parser.parse(%w[--exclude-dir foo])
+        expect(options[:exclude_dirs]).to eq ['foo']
+      end
+
+      it "can be specified multiple times to add multiple values to the exclude_dirs array" do
+        options = Parser.parse(%w[--exclude-dir foo --exclude-dir bar])
+        expect(options[:exclude_dirs]).to eq ['foo', 'bar']
+      end
+    end
+
+
   end
 end


### PR DESCRIPTION
This will allow more fine grained control of what directories
will be loaded as part of a spec run.  Currently, all files
matching the default or specified patterns are run, and Dir#glob
will not allow complex enough pattern matching for all cases.

This follows the pattern of use of --exclude-dir for grep and egrep.
