### PR TITLE
Fix a regression in our metadata backwards compatibility

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -149,6 +149,11 @@ module RSpec
       class ExampleHash < HashPopulator
         def self.create(group_metadata, user_metadata, description, block)
           example_metadata = group_metadata.dup
+          group_metadata = Hash.new(&ExampleGroupHash.backwards_compatibility_default_proc do |hash|
+            hash[:parent_example_group]
+          end)
+          group_metadata.update(example_metadata)
+
           example_metadata[:example_group] = group_metadata
           example_metadata.delete(:parent_example_group)
 
@@ -184,14 +189,18 @@ module RSpec
         end
 
         def self.hash_with_backwards_compatibility_default_proc
-          Hash.new do |hash, key|
+          Hash.new(&backwards_compatibility_default_proc { |hash| hash })
+        end
+
+        def self.backwards_compatibility_default_proc(&example_group_selector)
+          Proc.new do |hash, key|
             case key
             when :example_group
               RSpec.deprecate("The `:example_group` key in an example group's metadata hash",
                               :replacement => "the example group's hash directly for the " +
                               "computed keys and `:parent_example_group` to access the parent " +
                               "example group metadata")
-              LegacyExampleGroupHash.new(hash)
+              LegacyExampleGroupHash.new(example_group_selector.call(hash))
             when :example_group_block
               RSpec.deprecate("`metadata[:example_group_block]`",
                               :replacement => "`metadata[:block]`")

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -117,6 +117,8 @@ module RSpec
           end
 
           a[:description] = "new description"
+
+          pending "Cannot maintain this and provide full `:example_group` backwards compatibility (see GH #1490):("
           expect(b[:description]).to eq("new description")
         end
 
@@ -473,11 +475,12 @@ module RSpec
             RSpec.describe "Level 1" do
               describe "Level 2" do
                 describe "Level 3" do
-                  inner_metadata = metadata
+                  inner_metadata = example("Level 4").metadata
                 end
               end
             end
 
+            expect(inner_metadata[:description]).to eq("Level 4")
             expect(inner_metadata[:example_group][:description]).to eq("Level 3")
             expect(inner_metadata[:example_group][:example_group][:description]).to eq("Level 2")
             expect(inner_metadata[:example_group][:example_group][:example_group][:description]).to eq("Level 1")


### PR DESCRIPTION
```
Fix metadata backwards compat to handle deep nesting.

This is a bit confusing, but the behavior in 2.x was:

* a group's `metadata` did not have it's computed
  keys directly available; they were exposed off of
  the `:example_group` subhash.
* The `:example_group` subhash had a `:example_group`
  key that exposed the parent group's metadata
  (both user metadata and computed keys).

Before this, we were inserting extra `:example_group`
subhashes between the layers.
```
