### PR TITLE
Add the json gem for all versions of ruby, not just 1.8.x.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :documentation do
   gem 'github-markup', '0.7.2'
 end
 
-platforms :ruby_18, :jruby do
+platforms :ruby, :jruby do
   gem 'json'
 end
 


### PR DESCRIPTION
- This was necessary to get the specs running on ruby 2.0.0p353.
