### PR TITLE
Ensure the same version of rspec is executed.

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -114,7 +114,8 @@ module RSpec
         cmd_parts = []
         cmd_parts << RUBY
         cmd_parts << ruby_opts
-        cmd_parts << "-S" << rspec_path << "_#{Version::STRING}_"
+        cmd_parts << "-S" << rspec_path
+        cmd_parts << "_#{Version::STRING}_" if rspec_path == 'rspec'
         cmd_parts << files_to_run
         cmd_parts << rspec_opts
         cmd_parts.flatten.reject(&blank).join(" ")


### PR DESCRIPTION
- If a developer is not using bundler, but specifies the desired version of rspec via `gem 'rspec', '~> 2.10.0'`, than the version of rspec that the rake task executes should match that of the loaded rspec-core.
