### PR TITLE
Remove reference to loading rails in spec helper documentation.

### DIFF
--- a/lib/rspec/core/project_initializer/spec_helper.rb
+++ b/lib/rspec/core/project_initializer/spec_helper.rb
@@ -5,9 +5,10 @@
 #
 # Given that it is always loaded, you are encouraged to keep this file as
 # light-weight as possible. Requiring heavyweight dependencies from this file
-# (such as loading up an entire rails app) will add to the boot time of your
-# test suite on EVERY test run, even for an individual file that may not need
-# all of that loaded.
+# will add to the boot time of your test suite on EVERY test run, even for an
+# individual file that may not need all of that loaded. Instead, make a
+# separate helper file that requires this one and then use it only in the specs
+# that actually need it.
 #
 # The `.rspec` file also contains a few flags that are not defaults but that
 # users commonly want.


### PR DESCRIPTION
We haven't updated rspec-rails to not do this yet, and we should be
consistent. Added an extra sentence suggesting the direction we are
moving.

Related: writing that sentence without using "require" three times was a
difficult exercise.

We can revert this (or at least add back the rails suggestion) once https://github.com/rspec/rspec-rails/issues/990 is addressed.

@myronmarston @alindeman 
