### PR TITLE
added new output to diaplay command to rerun all failed tests

### DIFF
--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -55,6 +55,7 @@ module RSpec
                       " (files took #{format_duration(summary.load_time)} to load)\n"
           output.puts summary.colorize_with ConsoleCodes
           dump_commands_to_rerun_failed_examples
+          dump_command_to_rerun_all_failed_examples
         end
 
         # @api public
@@ -70,6 +71,25 @@ module RSpec
           failed_examples.each do |example|
             output.puts(failure_color("rspec #{RSpec::Core::Metadata::relative_path(example.location)}") + " " + detail_color("# #{example.full_description}"))
           end
+        end
+
+        # @api public
+        #
+        # Outputs single command which can be used to re-run all failed examples.
+        #
+        def dump_command_to_rerun_all_failed_examples
+          return if failed_examples.empty?
+          output.puts
+          output.puts "To re-run all failed tests run:"
+          output.puts
+
+          command = "rspec "
+
+          failed_examples.each do |example|
+            command += "#{RSpec::Core::Metadata::relative_path(example.location)} "
+          end
+
+          output.puts(command)
         end
 
         # @api public

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     end
   end
 
+  describe "#dump_command_to_rerun_all_failed_examples" do
+    it "includes a single command to re-run all failed examples" do
+      group = RSpec::Core::ExampleGroup.describe("example group") do
+        it("fails") { fail }
+        it("fails too") { fail }
+      end
+      line1 = __LINE__ - 3
+      line2 = __LINE__ - 3
+      group.run(reporter)
+      formatter.dump_command_to_rerun_all_failed_examples
+
+      line = output.string.lines.find { |line| line =~ /^rspec/ } || ""
+
+      expect(line).to include("rspec")
+      expect(line).to include("#{RSpec::Core::Metadata::relative_path("#{__FILE__}:#{line1}")}")
+      expect(line).to include("#{RSpec::Core::Metadata::relative_path("#{__FILE__}:#{line2}")}")
+    end
+  end
+
+
   describe "#dump_failures" do
     let(:group) { RSpec::Core::ExampleGroup.describe("group name") }
 


### PR DESCRIPTION
Added a new output section to the base formatter that will output a single command to rerun all failed tests.

We have a huge testsuite that runs for a long time period.
When something brakes our code we'd like to be able to rerun all failed tests with a single command without effort until all our tests are running, without having to rerun the whole testsuite.
Therefor we will need to rerun the whole testsuite only after fixing all problems, to check for regressions.

This small patch adds that functionality. Copy&Pasting the last output line enables one to rerun all failing tests with a few clicks, without the overhead of passing tests.
