### PR TITLE
added new section to text formatter to output a command to rerun all failed tests

### DIFF
--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -48,6 +48,7 @@ module RSpec
           output.puts "\nFinished in #{format_duration(duration)}\n"
           output.puts colorise_summary(summary_line(example_count, failure_count, pending_count))
           dump_commands_to_rerun_failed_examples
+          dump_command_to_rerun_all_failed_examples
         end
 
         # @api public
@@ -63,6 +64,25 @@ module RSpec
           failed_examples.each do |example|
             output.puts(failure_color("rspec #{RSpec::Core::Metadata::relative_path(example.location)}") + " " + detail_color("# #{example.full_description}"))
           end
+        end
+
+        # @api public
+        #
+        # Outputs single command which can be used to re-run all failed examples.
+        #
+        def dump_command_to_rerun_all_failed_examples
+          return if failed_examples.empty?
+          output.puts
+          output.puts "To re-run all failed tests run:"
+          output.puts
+
+          command = "rspec "
+
+          failed_examples.each do |example|
+            command += "#{RSpec::Core::Metadata::relative_path(example.location)} "
+          end
+
+          output.puts(command)
         end
 
         # @api public

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -31,6 +31,26 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
     end
   end
 
+  describe "#dump_command_to_rerun_all_failed_examples" do
+    it "includes a single command to re-run all failed examples" do
+      group = RSpec::Core::ExampleGroup.describe("example group") do
+        it("fails") { fail }
+        it("fails too") { fail }
+      end
+      line1 = __LINE__ - 3
+      line2 = __LINE__ - 3
+      group.run(formatter)
+      formatter.dump_command_to_rerun_all_failed_examples
+
+      line = output.string.lines.find { |line| line =~ /^rspec/ } || ""
+
+      expect(line).to include("rspec")
+      expect(line).to include("#{RSpec::Core::Metadata::relative_path("#{__FILE__}:#{line1}")}")
+      expect(line).to include("#{RSpec::Core::Metadata::relative_path("#{__FILE__}:#{line2}")}")
+    end
+  end
+
+
   describe "#dump_failures" do
     let(:group) { RSpec::Core::ExampleGroup.describe("group name") }
 
@@ -381,12 +401,12 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
   end
 
   describe "#dump_profile_slowest_example_groups" do
-    let(:group) do 
+    let(:group) do
       RSpec::Core::ExampleGroup.describe("slow group") do
         # Use a sleep so there is some measurable time, to ensure
         # the reported percent is 100%, not 0%.
         example("example") { sleep 0.01 }
-      end 
+      end
     end
     let(:rpt) { double('reporter').as_null_object }
 
@@ -433,9 +453,9 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
 
     it "depends on parent_groups to get the top level example group" do
       ex = ""
-      group.describe("group 2") do 
+      group.describe("group 2") do
         describe "group 3" do
-          ex = example("nested example 1") 
+          ex = example("nested example 1")
         end
       end
 


### PR DESCRIPTION
The new section will include a single (long) command that can be copy pasted to the terminal that will rerun all failed tests in one step.

This is needed for large test suites to fix all braking tests before doing a full run.
