### PR TITLE
Fix `NoMethodError`.

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -380,7 +380,8 @@ module RSpec
 
       def initialize(metadata)
         @metadata = metadata
-        self[:example_group] = metadata[:parent_example_group][:example_group]
+        parent_group_metadata = metadata.fetch(:parent_example_group) { {} }[:example_group]
+        self[:example_group] = parent_group_metadata if parent_group_metadata
       end
 
       def to_h


### PR DESCRIPTION
This worked on 2.99 but was raising a `NoMethodError: [] for NilClass` on master:

``` Ruby
RSpec.describe "group" do
  example("ex").metadata[:example_group][:example_group]
end
```
