### PR TITLE
Using a legacy formatter as default no longer causes an infinite loop.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -132,6 +132,8 @@ Bug Fixes:
 * Ensure the currently running installation of RSpec is used when
   the rake task shells out to `rspec`, even if a newer version is also
   installed. (Postmodern)
+* Using a legacy formatter as default no longer causes an infinite loop.
+  (Xavier Shay)
 
 ### 3.0.0.beta2 / 2014-02-17
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.0.0.beta1...v3.0.0.beta2)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -923,6 +923,19 @@ module RSpec::Core
         end
       end
 
+      context 'using a legacy formatter as default' do
+        # Generating warnings during formatter initialisation triggers the
+        # ProxyReporter code path.
+        it 'remembers changes' do
+          legacy_formatter = Class.new
+
+          config = RSpec.configuration
+          config.default_formatter = legacy_formatter
+          config.reporter
+          expect(config.default_formatter).to eq(legacy_formatter)
+        end
+      end
+
       def used_formatters
         config.reporter # to force freezing of formatters
         config.formatters


### PR DESCRIPTION
This spec should probably verify a warning was emitted, but I couldn't
quite figure that part out.

Fixes #1507 

@myronmarston @JonRowe 
