### PR TITLE
Automatically wrap multiline deprecation messages (for 2.99)

### DIFF
--- a/lib/rspec/core/formatters/deprecation_formatter.rb
+++ b/lib/rspec/core/formatters/deprecation_formatter.rb
@@ -81,7 +81,7 @@ module RSpec
           def output_formatted(str)
             return str unless str.lines.count > 1
             separator = "#{'-' * 80}"
-            "#{separator}\n#{str}\n#{separator}"
+            "#{separator}\n#{str.chomp}\n#{separator}"
           end
 
           def deprecation_type_for(data)

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -40,7 +40,10 @@ module RSpec::Core::Formatters
         end
 
         it "surrounds multiline messages in fenceposts" do
-          multiline_message = "line one\nline two"
+          multiline_message = <<-EOS.gsub(/^\s+\|/, '')
+            |line one
+            |line two
+          EOS
           formatter.deprecation(:message => multiline_message)
           deprecation_stream.rewind
 


### PR DESCRIPTION
This is #1350 and #1453 backported to 2.99.

Fixes #1497.

I need to find all the places the multiline message call sites and make sure they don't have their own fence posting before we can merge this, so it may not make the RC release (I won't hold it up for it).

/cc @xaviershay @soulcutter 
