### PR TITLE
Fix formatter regression with message_lines

### DIFF
--- a/features/expectation_framework_integration/configure_expectation_framework.feature
+++ b/features/expectation_framework_integration/configure_expectation_framework.feature
@@ -66,8 +66,8 @@ Feature: configure expectation framework
     When I run `rspec example_spec.rb`
     Then the output should match:
       """
-           (Test::Unit::AssertionFailedError|Mini(T|t)est::Assertion)
-           errantly expected \[2\] to equal \[1\]
+           (Test::Unit::AssertionFailedError|Mini(T|t)est::Assertion):
+             errantly expected \[2\] to equal \[1\]
       """
     And  the output should contain "3 examples, 1 failure"
 
@@ -94,8 +94,8 @@ Feature: configure expectation framework
     When I run `rspec -b example_spec.rb`
     Then the output should match:
       """
-           MiniT|test::Assertion
-           errantly expected \[1\] to be empty
+           MiniT|test::Assertion:
+             errantly expected \[1\] to be empty
       """
     And  the output should contain "3 examples, 1 failure"
     And  the output should not contain "Warning: you should require 'minitest/autorun' instead."

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -57,9 +57,9 @@ module RSpec::Core
         @lines ||=
           begin
             lines = ["Failure/Error: #{read_failed_line.strip}"]
-            lines << exception_class_name unless exception_class_name =~ /RSpec/
+            lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
             exception.message.to_s.split("\n").each do |line|
-              lines << line if exception.message
+              lines << "  #{line}" if exception.message
             end
             if shared_group
               lines << "Shared Example Group: \"#{shared_group.metadata[:shared_group_name]}\"" +


### PR DESCRIPTION
Fixes #1522, seems I missed the importance of some string interpolation when originally extracting this. The cuke change is actually a reversion of another commit that allowed this regression to slip out.
