### PR TITLE
Fix formatter regression

### DIFF
--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -156,7 +156,7 @@ module RSpec::Core
       # @return [Array(String)] the examples colorized backtrace lines
       def colorized_formatted_backtrace(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
         formatted_backtrace.map do |backtrace_info|
-          colorizer.wrap backtrace_info, RSpec.configuration.detail_color
+          colorizer.wrap "# #{backtrace_info}", RSpec.configuration.detail_color
         end
       end
 
@@ -334,7 +334,7 @@ module RSpec::Core
       #                          specific colors.
       # @return [String] A colorized summary line.
       def colorized_rerun_commands(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
-        "\nFailed Examples:\n\n" +
+        "\nFailed examples:\n\n" +
         failed_examples.map do |example|
           colorizer.wrap("rspec #{example.location}",     RSpec.configuration.failure_color) + " " +
           colorizer.wrap("# #{example.full_description}", RSpec.configuration.detail_color)

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -77,5 +77,35 @@ root
     example 3 (FAILED - 1)
 ")
     end
+
+    # The backrace is slightly different on JRuby so we skip there.
+    it 'produces the expected full output', :unless => RUBY_PLATFORM == 'java' do
+      output = run_example_specs_with_formatter("doc")
+      output.gsub!(/ +$/, '') # strip trailing whitespace
+
+      expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
+        |
+        |pending spec with no implementation
+        |  is pending (PENDING: Not yet implemented)
+        |
+        |pending command with block format
+        |  with content that would fail
+        |    is pending (PENDING: No reason given)
+        |  with content that would pass
+        |    fails (FAILED - 1)
+        |
+        |passing spec
+        |  passes
+        |
+        |failing spec
+        |  fails (FAILED - 2)
+        |
+        |a failing spec with odd backtraces
+        |  fails with a backtrace that has no file (FAILED - 3)
+        |  fails with a backtrace containing an erb file (FAILED - 4)
+        |
+        |#{expected_summary_output_for_example_specs}
+      EOS
+    end
   end
 end

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -334,14 +334,8 @@ expected: 2
 (compared using ==)
 </pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:31</pre></div>
-    <pre class="ruby"><code><span class="linenum">29</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">"</span><span class="content">failing spec</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
-<span class="linenum">30</span>  it <span class="string"><span class="delimiter">"</span><span class="content">fails</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
-<span class="offending"><span class="linenum">31</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
-<span class="linenum">32</span>  <span class="keyword">end</span>
-<span class="linenum">33</span><span class="keyword">end</span></code></pre>
-      </div>
-    </dd>
-  </dl>
+    
+  
 </div>
 <div id="div_group_7" class="example_group passed">
   <dl style="margin-left: 0px;">
@@ -352,9 +346,7 @@ expected: 2
       <div class="failure" id="failure_3">
         <div class="message"><pre>foo</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:39</pre></div>
-    <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for (erb)</span></code></pre>
-      </div>
-    </dd>
+    
     <script type="text/javascript">moveProgressBar('100.0');</script><dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace containing an erb file</span>
       <span class="duration">n.nnnns</span>
@@ -364,9 +356,15 @@ expected: 2
     <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for /foo.html.erb</span></code></pre>
       </div>
     </dd>
-  </dl>
+  
 </div>
 <script type="text/javascript">document.getElementById('duration').innerHTML = "Finished in <strong>n.nnnn seconds</strong>";</script><script type="text/javascript">document.getElementById('totals').innerHTML = "7 examples, 4 failures, 2 pending";</script>
+</dd>
+</dl>
+</div>
+</dd>
+</dl>
+</div>
 </div>
 </div>
 </body>

--- a/spec/rspec/core/formatters/html_formatter_spec.rb
+++ b/spec/rspec/core/formatters/html_formatter_spec.rb
@@ -7,6 +7,7 @@ module RSpec
   module Core
     module Formatters
       RSpec.describe HtmlFormatter do
+        include FormatterSupport
 
         let(:root) { File.expand_path("#{File.dirname(__FILE__)}/../../../..") }
         let(:expected_file) do
@@ -14,15 +15,7 @@ module RSpec
         end
 
         let(:generated_html) do
-          options = ConfigurationOptions.new(%w[spec/rspec/core/resources/formatter_specs.rb --format html --order defined])
-
-          err, out = StringIO.new, StringIO.new
-          err.set_encoding("utf-8") if err.respond_to?(:set_encoding)
-
-          runner = RSpec::Core::Runner.new(options)
-          runner.instance_variable_get("@configuration").backtrace_formatter.inclusion_patterns = []
-          runner.run(err, out)
-          html = out.string.gsub(/\d+\.\d+(s| seconds)/, "n.nnnn\\1")
+          html = run_example_specs_with_formatter('html')
 
           actual_doc = Nokogiri::HTML(html, &:noblanks)
           actual_doc.css("div.backtrace pre").each do |elem|

--- a/spec/rspec/core/formatters/progress_formatter_spec.rb
+++ b/spec/rspec/core/formatters/progress_formatter_spec.rb
@@ -40,4 +40,16 @@ RSpec.describe RSpec::Core::Formatters::ProgressFormatter do
     send_notification :start_dump, null_notification
     expect(output.string).to eq("\n")
   end
+
+  # The backrace is slightly different on JRuby so we skip there.
+  it 'produces the expected full output', :unless => RUBY_PLATFORM == 'java' do
+    output = run_example_specs_with_formatter("progress")
+    output.gsub!(/ +$/, '') # strip trailing whitespace
+
+    expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
+      |**F.FFF
+      |
+      |#{expected_summary_output_for_example_specs}
+    EOS
+  end
 end

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -1,4 +1,153 @@
 module FormatterSupport
+  def run_example_specs_with_formatter(formatter_option)
+    options = RSpec::Core::ConfigurationOptions.new(%W[spec/rspec/core/resources/formatter_specs.rb --format #{formatter_option} --order defined])
+
+    err, out = StringIO.new, StringIO.new
+    err.set_encoding("utf-8") if err.respond_to?(:set_encoding)
+
+    runner = RSpec::Core::Runner.new(options)
+    runner.instance_variable_get("@configuration").backtrace_formatter.inclusion_patterns = []
+    runner.run(err, out)
+
+    output = out.string
+    output.gsub!(/\d+(?:\.\d+)?(s| seconds)/, "n.nnnn\\1")
+
+    caller_line = RSpec::Core::Metadata.relative_path(caller.first)
+    output.lines.reject do |line|
+      # remove the direct caller as that line is different for the summary output backtraces
+      line.include?(caller_line) ||
+
+      # ignore scirpt/rspec_with_simplecov because we don't usually have it locally but
+      # do have it on travis
+      line.include?("script/rspec_with_simplecov") ||
+
+      # this line varies a bit depending on how you run the specs (via `rake` vs `rspec`)
+      line.include?('/exe/rspec:')
+    end.join
+  end
+
+  if RUBY_VERSION.to_f < 1.9
+    def expected_summary_output_for_example_specs
+      <<-EOS.gsub(/^\s+\|/, '').chomp
+        |Pending:
+        |  pending spec with no implementation is pending
+        |    # Not yet implemented
+        |    # ./spec/rspec/core/resources/formatter_specs.rb:4
+        |  pending command with block format with content that would fail is pending
+        |    # No reason given
+        |    # ./spec/rspec/core/resources/formatter_specs.rb:9
+        |
+        |Failures:
+        |
+        |  1) pending command with block format with content that would pass fails FIXED
+        |     Expected pending 'No reason given' to fail. No Error was raised.
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:16
+        |
+        |  2) failing spec fails
+        |     Failure/Error: expect(1).to eq(2)
+        |
+        |       expected: 2
+        |            got: 1
+        |
+        |       (compared using ==)
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:31
+        |     # ./spec/spec_helper.rb:77:in `run'
+        |     # ./spec/support/formatter_support.rb:10:in `run_example_specs_with_formatter'
+        |     # ./spec/spec_helper.rb:124:in `run'
+        |     # ./spec/spec_helper.rb:124
+        |     # ./spec/spec_helper.rb:82:in `instance_exec'
+        |     # ./spec/spec_helper.rb:82:in `sandboxed'
+        |     # ./spec/spec_helper.rb:81:in `sandboxed'
+        |     # ./spec/spec_helper.rb:124
+        |
+        |  3) a failing spec with odd backtraces fails with a backtrace that has no file
+        |     Failure/Error: Unable to find matching line from backtrace
+        |     RuntimeError:
+        |       foo
+        |     # (erb):1
+        |
+        |  4) a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |     Failure/Error: Unable to find matching line from backtrace
+        |     Exception:
+        |       Exception
+        |     # /foo.html.erb:1:in `<main>': foo (RuntimeError)
+        |
+        |Finished in n.nnnn seconds (files took n.nnnn seconds to load)
+        |7 examples, 4 failures, 2 pending
+        |
+        |Failed examples:
+        |
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:16 # pending command with block format with content that would pass fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:30 # failing spec fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:42 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+      EOS
+    end
+  else
+    def expected_summary_output_for_example_specs
+      <<-EOS.gsub(/^\s+\|/, '').chomp
+        |Pending:
+        |  pending spec with no implementation is pending
+        |    # Not yet implemented
+        |    # ./spec/rspec/core/resources/formatter_specs.rb:4
+        |  pending command with block format with content that would fail is pending
+        |    # No reason given
+        |    # ./spec/rspec/core/resources/formatter_specs.rb:9
+        |
+        |Failures:
+        |
+        |  1) pending command with block format with content that would pass fails FIXED
+        |     Expected pending 'No reason given' to fail. No Error was raised.
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:16
+        |
+        |  2) failing spec fails
+        |     Failure/Error: expect(1).to eq(2)
+        |
+        |       expected: 2
+        |            got: 1
+        |
+        |       (compared using ==)
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:31:in `block (2 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:77:in `run'
+        |     # ./spec/support/formatter_support.rb:10:in `run_example_specs_with_formatter'
+        |     # ./spec/spec_helper.rb:124:in `block (4 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:82:in `instance_exec'
+        |     # ./spec/spec_helper.rb:82:in `block in sandboxed'
+        |     # ./spec/spec_helper.rb:81:in `sandboxed'
+        |     # ./spec/spec_helper.rb:124:in `block (3 levels) in <top (required)>'
+        |
+        |  3) a failing spec with odd backtraces fails with a backtrace that has no file
+        |     Failure/Error: ERB.new("<%= raise 'foo' %>").result
+        |     RuntimeError:
+        |       foo
+        |     # (erb):1:in `<main>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:39:in `block (2 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:77:in `run'
+        |     # ./spec/support/formatter_support.rb:10:in `run_example_specs_with_formatter'
+        |     # ./spec/spec_helper.rb:124:in `block (4 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:82:in `instance_exec'
+        |     # ./spec/spec_helper.rb:82:in `block in sandboxed'
+        |     # ./spec/spec_helper.rb:81:in `sandboxed'
+        |     # ./spec/spec_helper.rb:124:in `block (3 levels) in <top (required)>'
+        |
+        |  4) a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |     Failure/Error: Unable to find matching line from backtrace
+        |     Exception:
+        |       Exception
+        |     # /foo.html.erb:1:in `<main>': foo (RuntimeError)
+        |
+        |Finished in n.nnnn seconds (files took n.nnnn seconds to load)
+        |7 examples, 4 failures, 2 pending
+        |
+        |Failed examples:
+        |
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:16 # pending command with block format with content that would pass fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:30 # failing spec fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:42 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+      EOS
+    end
+  end
 
   def send_notification type, notification
     reporter.notify type, notification


### PR DESCRIPTION
This addresses another formatter regression that I discovered while working on rspec/rspec-autotest#9.

This also adds regression tests for the formatters since our tests are obviously not good enough to catch this.
