### PR TITLE
Adding support for parallel execution of examples

### DIFF
--- a/features/command_line/parallel_test.feature
+++ b/features/command_line/parallel_test.feature
@@ -1,0 +1,41 @@
+Feature: `--parallel-test` option
+
+  Use the `--parallel-test` option to have RSpec print your suite's formatter output
+  without running any examples or hooks.
+
+  Scenario: Using `--parallel-test`
+    Given a file named "spec/parallel_test_spec.rb" with:
+      """ruby
+      RSpec.configure do |c|
+        c.before(:suite) { puts "before suite" }
+        c.after(:suite)  { puts "after suite"  }
+      end
+
+      RSpec.describe "parallel run" do
+        before(:context) { puts "before context" }
+        before(:example) { puts "before example" }
+
+        it "thread 0 example" do
+          fail
+        end
+
+        it "thread 1 example" do
+          pass
+        end
+
+        it "thread 2 example" do
+          pass
+        end
+
+        after(:example) { puts "after example" }
+        after(:context) { puts "after context" }
+      end
+      """
+    When I run `rspec --parallel-test 3`
+    Then the output should contain "3 examples, 1 failure"
+     And the output should contain "before suite"
+     And the output should contain "after suite"
+     And the output should contain "before context"
+     And the output should contain "after context"
+     And the output should contain "before example"
+     And the output should contain "after example"

--- a/lib/rspec/core/command_line.rb
+++ b/lib/rspec/core/command_line.rb
@@ -1,3 +1,5 @@
+require 'thread'
+
 module RSpec
   module Core
     class CommandLine
@@ -15,7 +17,8 @@ module RSpec
       #
       # @param [IO] err
       # @param [IO] out
-      def run(err, out)
+      # @param [int] num_threads
+      def run(err, out, num_threads=1)
         @configuration.error_stream = err
         @configuration.output_stream ||= out
         @options.configure(@configuration)
@@ -25,10 +28,107 @@ module RSpec
         @configuration.reporter.report(@world.example_count, @configuration.randomize? ? @configuration.seed : nil) do |reporter|
           begin
             @configuration.run_hook(:before, :suite)
-            @world.example_groups.ordered.map {|g| g.run(reporter)}.all? ? 0 : @configuration.failure_exit_code
+            group_threads = RSpec::Core::ExampleGroupThreads.new
+            @world.example_groups.ordered.map {|g| 
+              group_threads.run_example_group_as_thread(g, reporter, num_threads)
+            }
+
+            # wait for example_groups to complete
+            group_threads.wait_for_completion
+
+            # get results of testing now that we're done
+            @world.example_groups.ordered.map { |g| 
+              reporter.example_group_started(g)
+              result_for_this_group = g.succeeded?
+              results_for_descendants = g.children.ordered.map {|child| child.succeeded? }.all?
+              reporter.example_group_finished(g)
+              result_for_this_group && results_for_descendants
+            }.all? ? 0 : @configuration.failure_exit_code
           ensure
             @configuration.run_hook(:after, :suite)
           end
+        end
+      end
+    end
+
+    class ExampleThreads
+      attr_accessor :num_threads, :thread_array, :fname, :lock
+      def initialize(num_threads)
+        @num_threads = num_threads
+        # puts "Creating ExampleThreads object with #{@num_threads} threads."
+        @thread_array = []
+        $used_threads = $used_threads || 0
+        @fname = '.examplelock'
+        if !File.exists? @fname
+          File.new(@fname, "a+") { |f| f.write "lock" }
+        end
+      end
+
+      def wait_for_available_thread
+        # puts "Global threads in use = #{$used_threads}."
+        # puts "Local threads in use = #{@thread_array.length}."
+        # wait for available thread if we've reached our global limit
+        while $used_threads.to_i >= @num_threads.to_i
+          # puts "Waiting for available thread. Running = #{$used_threads}; Max = #{@num_threads}"
+          sleep 1 #0.1
+        end
+      end
+
+      def run_example_as_thread(example, instance, reporter)
+        # puts "Setting lock for example '#{example.description}'..."
+        set_lock
+        wait_for_available_thread
+        @thread_array.push Thread.start {
+          # puts "Starting example '#{example.description}'..."
+          example.run(instance, reporter)
+          # puts "Example '#{example.description}' completed."
+          @thread_array.delete Thread.current # remove from local scope
+          $used_threads -= 1 # remove from global scope
+        }
+        $used_threads += 1 # add to global scope
+      ensure
+        # puts "Releasing lock for example '#{example.description}'..."
+        release_lock
+        # puts "Lock for '#{example.description}' released."
+      end
+
+      def wait_for_completion
+        # wait for threads to complete
+        while @thread_array.length > 0
+          # puts "Waiting for #{@thread_array.length} example threads to complete."
+          sleep 1 #0.1
+        end
+      end
+
+      def set_lock
+        (@lock = File.new(@fname,"r+")).flock(File::LOCK_EX)
+      end
+
+      def release_lock
+        @lock.flock(File::LOCK_UN)
+      end
+    end
+
+    class ExampleGroupThreads
+      attr_accessor :thread_array
+      def initialize
+        @thread_array = []
+      end
+
+      def run_example_group_as_thread(examplegroup, reporter, num_threads=1)
+        @thread_array.push Thread.start {
+          # puts "Starting examplegroup '#{examplegroup.description}'..."
+          examplegroup.run(reporter, num_threads)
+          # puts "Examplegroup '#{examplegroup.description}' completed."
+          @thread_array.delete Thread.current # remove from local scope
+        }
+      end
+
+      def wait_for_completion
+        # wait for threads to complete
+        while @thread_array.length > 0
+          # puts "Waiting for #{@thread_array.length} group threads to complete."
+          sleep 1 #0.1
         end
       end
     end

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -48,12 +48,12 @@ module RSpec
 
       NON_FORCED_OPTIONS = [
         :debug, :requires, :profile, :drb, :libs, :files_or_directories_to_run,
-        :line_numbers, :full_description, :full_backtrace, :tty
+        :line_numbers, :full_description, :full_backtrace, :tty, :parallel_test
       ].to_set
 
       MERGED_OPTIONS = [:requires, :libs].to_set
 
-      UNPROCESSABLE_OPTIONS = [:libs, :formatters, :requires].to_set
+      UNPROCESSABLE_OPTIONS = [:libs, :formatters, :requires, :parallel_test].to_set
 
       def force?(key)
         !NON_FORCED_OPTIONS.include?(key)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -53,6 +53,12 @@ module RSpec
         RSpec.configuration.format_docstrings_block.call(description)
       end
 
+      attr_accessor :succeeded
+
+      def succeeded?
+        @succeeded
+      end
+
       # @attr_reader
       #
       # Returns the first exception raised in the context of running this

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -208,6 +208,23 @@ FILTERING
           exit
         end
 
+        parser.on('--parallel-test NUMBER', 'Run the tests with the specified number of parallel threads') do |n|
+          is_valid = true
+          if (n.nil?)
+            is_valid = false
+          else
+            if (n.match(/\A[0-9]+\Z/))
+              options[:parallel_test] = n.to_i
+            else
+              is_valid = false
+            end
+          end
+          if !is_valid
+            puts parser.to_s.gsub(/^\s+(#{invalid_options.join('|')})\s*$\n/,'')
+            exit
+          end
+        end
+
         parser.on_tail('-h', '--help', "You're looking at it.") do
           puts parser
           exit

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -67,6 +67,7 @@ module RSpec
         trap_interrupt
         options = ConfigurationOptions.new(args)
         options.parse_options
+        run_local = !options.options[:drb]
 
         if options.options[:drb]
           require 'rspec/core/drb_command_line'
@@ -74,10 +75,13 @@ module RSpec
             DRbCommandLine.new(options).run(err, out)
           rescue DRb::DRbConnError
             err.puts "No DRb server is running. Running in local process instead ..."
-            CommandLine.new(options).run(err, out)
+            run_local = true
           end
-        else
-          CommandLine.new(options).run(err, out)
+        end
+
+        if run_local
+          num_threads = options.options[:parallel_test] || 1
+          CommandLine.new(options).run(err, out, num_threads)
         end
       ensure
         RSpec.reset


### PR DESCRIPTION
These changes add handling of an additional parameter "--parallel-test" that takes a number as input.  This number will then be used to limit execution of examples to the specified number of parallel threads.  To accomplish this the ExampleGroups each are started in a sub-thread which can then start up to the specified number of example threads running in parallel.  A global maximum is used to prevent going over the specified number and execution of additional threads will wait until an available thread is free for cases where the maximum number of parallel threads are in use.

Additionally, these changes ensure that Before / After Suite and Before / After All calls are executed only once per expected grouping, but that Before / After Each calls are executed before and after each example as part of the parallel thread.

The advantage of this change is that it fully supports all platforms supported by rspec (unlike parallel_tests gem which does not work correctly on all Windows systems) and the output remains serially reported so you avoid the need to stitch together test reports at the completion of testing (as can be required with solutions like parallel_tests and prspec gems where parallel execution is actually split between multiple instances of rspec).
