### PR TITLE
Autotest fix

### DIFF
--- a/lib/autotest/discover.rb
+++ b/lib/autotest/discover.rb
@@ -1,1 +1,10 @@
-Autotest.add_discovery { "rspec2" } if File.exist?("./.rspec")
+begin
+  # try to load rspec/autotest so we can check if the constant is defined below.
+  require 'rspec/autotest'
+rescue LoadError
+  # ignore. We print a deprecation warning later.
+end
+
+if File.exist?("./.rspec") && !defined?(::RSpec::Autotest)
+  Autotest.add_discovery { "rspec2" }
+end

--- a/spec/autotest/discover_spec.rb
+++ b/spec/autotest/discover_spec.rb
@@ -1,19 +1,49 @@
 require "spec_helper"
 
 describe "autotest/discover.rb" do
+  before { File.stub(:exist?).and_call_original }
+
   context "with ./.rspec present" do
-    it "adds 'rspec2' to the list of discoveries" do
-      File.stub(:exist?).with("./.rspec") { true }
-      Autotest.should_receive(:add_discovery)
-      load File.expand_path("../../../lib/autotest/discover.rb", __FILE__)
+    before { File.stub(:exist?).with("./.rspec") { true } }
+
+    context "when RSpec::Autotest is defined" do
+      before { stub_const "RSpec::Autotest", Module.new }
+
+      it "does not add 'rspec2' to the list of discoveries" do
+        Autotest.should_not_receive(:add_discovery)
+        load File.expand_path("../../../lib/autotest/discover.rb", __FILE__)
+      end
+    end
+
+    context "when RSpec::Autotest is not defined" do
+      before { hide_const "RSpec::Autotest" }
+
+      it "adds 'rspec2' to the list of discoveries" do
+        Autotest.should_receive(:add_discovery)
+        load File.expand_path("../../../lib/autotest/discover.rb", __FILE__)
+      end
     end
   end
 
   context "with ./.rspec absent" do
-    it "does not add 'rspec2' to the list of discoveries" do
-      File.stub(:exist?) { false }
-      Autotest.should_not_receive(:add_discovery)
-      load File.expand_path("../../../lib/autotest/discover.rb", __FILE__)
+    before { File.stub(:exist?).with("./.rspec") { false } }
+
+    context "when RSpec::Autotest is defined" do
+      before { stub_const "RSpec::Autotest", Module.new }
+
+      it "does not add 'rspec2' to the list of discoveries" do
+        Autotest.should_not_receive(:add_discovery)
+        load File.expand_path("../../../lib/autotest/discover.rb", __FILE__)
+      end
+    end
+
+    context "when RSpec::Autotest is not defined" do
+      before { hide_const "RSpec::Autotest" }
+
+      it "does not add 'rspec2' to the list of discoveries" do
+        Autotest.should_not_receive(:add_discovery)
+        load File.expand_path("../../../lib/autotest/discover.rb", __FILE__)
+      end
     end
   end
 end


### PR DESCRIPTION
Don’t load our autotest plugin when rspec-autotest is available.

It confuses things when rspec-autotest and our auto test plugin are both loaded.
