### PR TITLE
Leverage our caller filter to filter rspec lines.

### DIFF
--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -7,13 +7,15 @@ module RSpec
 
       def initialize
         @full_backtrace = false
-        @system_exclusion_patterns = [] << Regexp.union(
-          *["/lib\d*/ruby/",
-            "org/jruby/",
-            "bin/",
-            "/gems/",
-            "lib/rspec/(core|expectations|matchers|mocks)"].
-          map {|s| Regexp.new(s.gsub("/", File::SEPARATOR))})
+
+        patterns = [
+          "/lib\d*/ruby/",
+          "org/jruby/",
+          "bin/",
+          "/gems/",
+        ].map { |s| Regexp.new(s.gsub("/", File::SEPARATOR)) }
+
+        @system_exclusion_patterns = [Regexp.union(RSpec::CallerFilter::IGNORE_REGEX, *patterns)]
         @exclusion_patterns = [] + @system_exclusion_patterns
         @inclusion_patterns = [Regexp.new(Dir.getwd)]
       end

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -11,11 +11,12 @@ module RSpec::Core
 
     describe "defaults" do
       it "excludes rspec files" do
-        expect(make_backtrace_formatter.exclude?("lib/rspec/core.rb")).to be true
-        expect(make_backtrace_formatter.exclude?("lib/rspec/core/foo.rb")).to be true
-        expect(make_backtrace_formatter.exclude?("lib/rspec/expectations/foo.rb")).to be true
-        expect(make_backtrace_formatter.exclude?("lib/rspec/matchers/foo.rb")).to be true
-        expect(make_backtrace_formatter.exclude?("lib/rspec/mocks/foo.rb")).to be true
+        expect(make_backtrace_formatter.exclude?("/lib/rspec/core.rb")).to be true
+        expect(make_backtrace_formatter.exclude?("/lib/rspec/core/foo.rb")).to be true
+        expect(make_backtrace_formatter.exclude?("/lib/rspec/expectations/foo.rb")).to be true
+        expect(make_backtrace_formatter.exclude?("/lib/rspec/matchers/foo.rb")).to be true
+        expect(make_backtrace_formatter.exclude?("/lib/rspec/mocks/foo.rb")).to be true
+        expect(make_backtrace_formatter.exclude?("/lib/rspec/support/foo.rb")).to be true
       end
 
       it "excludes java files (for JRuby)" do


### PR DESCRIPTION
This part of the filter was largely duplicated, but
not exactly the same — `CallerFilter` would filter
out rspec-support lines but not the backtrace formatter.
