### PR TITLE
Don't re-close a closed IO (for 2.99)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### 2.99.0 Development
+[Full Changelog](http://github.com/rspec/rspec-core/compare/v2.99.0.rc1...2-99-maintenance)
+
+Bug Fixes:
+
+* Fix `BaseTextFormatter` so that it does not re-close a closed output
+  stream. (Myron Marston)
+
 ### 2.99.0.rc1 / 2014-05-18
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v2.99.0.beta2...v2.99.0.rc1)
 

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -162,7 +162,10 @@ module RSpec
         end
 
         def close
-          output.close if IO === output && output != $stdout
+          return unless IO === output
+          return if output.closed? || output == $stdout
+
+          output.close
         end
 
         def self.const_missing(name)

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -5,6 +5,16 @@ describe RSpec::Core::Formatters::BaseTextFormatter do
   let(:output) { StringIO.new }
   let(:formatter) { RSpec::Core::Formatters::BaseTextFormatter.new(output) }
 
+  context "when closing the formatter", :isolated_directory => true do
+    it 'does not close an already closed output stream' do
+      output = File.new("./output_to_close", "w")
+      formatter = described_class.new(output)
+      output.close
+
+      expect { formatter.close }.not_to raise_error
+    end
+  end
+
   describe "#summary_line" do
     it "with 0s outputs pluralized (excluding pending)" do
       expect(formatter.summary_line(0,0,0)).to eq("0 examples, 0 failures")


### PR DESCRIPTION
This should fix #1541.  I'll forward port to 3.0 when we get confirmation this fixes the error for the user.
