### PR TITLE
Don’t re-close a closed output stream.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### 3.0.0 Development
+[Full Changelog](http://github.com/rspec/rspec-core/compare/v3.0.0.rc1...master)
+
+Bug Fixes:
+
+* Fix `BaseTextFormatter` so that it does not re-close a closed output
+  stream. (Myron Marston)
+
 ### 3.0.0.rc1 / 2014-05-18
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.0.0.beta2...v3.0.0.rc1)
 

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -66,7 +66,10 @@ module RSpec
         #
         # @param notification [NullNotification]
         def close(notification)
-          output.close if IO === output && output != $stdout
+          return unless IO === output
+          return if output.closed? || output == $stdout
+
+          output.close
         end
 
       end

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -4,6 +4,16 @@ require 'rspec/core/formatters/base_text_formatter'
 RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
   include FormatterSupport
 
+  context "when closing the formatter", :isolated_directory => true do
+    it 'does not close an already closed output stream' do
+      output = File.new("./output_to_close", "w")
+      formatter = described_class.new(output)
+      output.close
+
+      expect { formatter.close(RSpec::Core::Notifications::NullNotification) }.not_to raise_error
+    end
+  end
+
   describe "#dump_summary" do
     it "with 0s outputs pluralized (excluding pending)" do
       send_notification :dump_summary, summary_notification(0, [], [], [], 0)


### PR DESCRIPTION
Fixes #1541 for 3.0.  Follow up to #1544.  Will merge when green.
