### PR TITLE
Remove deprecated backtrace cleaner 2 99

### DIFF
--- a/lib/rspec/core/mocking/with_rr.rb
+++ b/lib/rspec/core/mocking/with_rr.rb
@@ -1,6 +1,6 @@
 require 'rr'
 
-RSpec.configuration.backtrace_clean_patterns.push(RR::Errors::BACKTRACE_IDENTIFIER)
+RSpec.configuration.backtrace_exclusion_patterns.push(RR::Errors::BACKTRACE_IDENTIFIER)
 
 module RSpec
   module Core


### PR DESCRIPTION
Duplicating #1548 against rspec:2-99-maintenance at @JonRowe's request
