### PR TITLE
Fix regression in `:parent_example_group` metadata.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ Bug Fixes:
 
 * Fix `BaseTextFormatter` so that it does not re-close a closed output
   stream. (Myron Marston)
+* Fix regression in metadata that caused the metadata hash of a top-level
+  example group to have a `:parent_example_group` key even though it has
+  no parent example group. (Myron Marston)
 
 Enhancements:
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -355,7 +355,7 @@ module RSpec
         args.unshift(description)
 
         @metadata = Metadata::ExampleGroupHash.create(
-          superclass_metadata || {}, user_metadata, *args, &example_group_block
+          superclass_metadata, user_metadata, *args, &example_group_block
         )
 
         hooks.register_globals(self, RSpec.configuration.hooks)

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -75,10 +75,10 @@ module RSpec
       end
 
       def parent_of(metadata)
-        if metadata.has_key?(:parent_example_group)
-          metadata[:parent_example_group]
-        else
+        if metadata.key?(:example_group)
           metadata[:example_group]
+        else
+          metadata[:parent_example_group]
         end
       end
     end

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -435,6 +435,11 @@ module RSpec
         end
       end
 
+      it 'does not have a `:parent_example_group` key for a top level group' do
+        meta = RSpec.describe(Object).metadata
+        expect(meta).not_to include(:parent_example_group)
+      end
+
       describe "backwards compatibility" do
         before { allow_deprecation }
 
@@ -496,9 +501,7 @@ module RSpec
 
             expect(inner_metadata[:description]).to eq("Level 2")
             expect(inner_metadata[:example_group][:description]).to eq("Level 1")
-
-            # On 2.99 this was nil, but I haven't found a way to achieve that behavior, so this is close enough...
-            expect(inner_metadata[:example_group][:example_group].to_h).to eq({})
+            expect(inner_metadata[:example_group][:example_group]).to be_nil
           end
 
           it 'allows integration libraries like VCR to infer a fixture name from the example description by walking up nesting structure' do
@@ -524,8 +527,7 @@ module RSpec
 
             raise ex.execution_result.exception if ex.execution_result.exception
 
-            # On 2.x this returns "Group/ex", no leading slash, but this is close enough...
-            expect(inferred_fixture_name).to eq("/Group/ex")
+            expect(inferred_fixture_name).to eq("Group/ex")
           end
 
           it 'can mutate attributes when accessing them via [:example_group]' do


### PR DESCRIPTION
For a top-level group, it should not be in the metadata,
as it has no parent example group.

As a bonus, this also fixed a couple things I couldn’t get
to work quite right in the backwards compatibility
`:example_group` support.

Fixes #1552.
