### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rspec-core [![Build Status](https://secure.travis-ci.org/rspec/rspec-core.png?branch=master)](http://travis-ci.org/rspec/rspec-core) [![Code Climate](https://codeclimate.com/github/rspec/rspec-core.png)](https://codeclimate.com/github/rspec/rspec-core) [![Inline docs](http://inch-pages.github.io/github/rspec/rspec-core.png)](http://inch-pages.github.io/github/rspec/rspec-core)
+# rspec-core [![Build Status](https://secure.travis-ci.org/rspec/rspec-core.png?branch=master)](http://travis-ci.org/rspec/rspec-core) [![Code Climate](https://codeclimate.com/github/rspec/rspec-core.png)](https://codeclimate.com/github/rspec/rspec-core) [![Inline docs](http://inch-ci.org/github/rspec/rspec-core.png)](http://inch-ci.org/github/rspec/rspec-core)
 
 rspec-core provides the structure for writing executable examples of how your
 code should behave, and an `rspec` command with tools to constrain which


### PR DESCRIPTION
Update the URL of the docs badge to include it from inch-ci.org instead of inch-pages.github.io (the former being the successor of the Inch Pages project).

This is basically the same as https://github.com/rspec/rspec-rails/pull/1063 (where I write more about this change)
