### PR TITLE
Undefine methods before redefining them

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -182,9 +182,9 @@ module RSpec
         end
       end
 
-      # @macro add_setting
+      # @macro define_reader
       # Load files matching this pattern (default: `'**/*_spec.rb'`)
-      add_setting :pattern
+      define_reader :pattern
 
       # Set pattern to match files to load
       # @attr value [String] the filename pattern to filter spec files by

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -201,7 +201,9 @@ module RSpec
         attr_reader :example
 
         Example.public_instance_methods(false).each do |name|
-          define_method(name) { |*a, &b| @example.__send__(name, *a, &b) }
+          unless name.to_sym == :run
+            define_method(name) { |*a, &b| @example.__send__(name, *a, &b) }
+          end
         end
 
         Proc.public_instance_methods(false).each do |name|

--- a/script/rspec_with_simplecov
+++ b/script/rspec_with_simplecov
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
 
+# Turn on verbose to make sure we not generating any ruby warning
+$VERBOSE = true
+
 # This is necessary for when `--standalone` is being used.
 $:.unshift File.expand_path '../../bundle', __FILE__
 


### PR DESCRIPTION
If you run RSpec test suite and turn on Ruby warnings (`ruby -w`), there are several warnings about method redefined:
- /lib/rspec/core/configuration.rb:191: warning: method redefined; discarding old pattern=
- /lib/rspec/core/example.rb:210: warning: method redefined; discarding old run
- /lib/rspec/core/example.rb:204: warning: previous definition of run was here

By `undef` these method first we can silence those warnings from Ruby.
