### PR TITLE
Use rspec -P pattern option in rake tasks

### DIFF
--- a/features/command_line/rake_task.feature
+++ b/features/command_line/rake_task.feature
@@ -93,7 +93,7 @@ Feature: rake task
     Then the exit status should be 0
     Then the output should match:
       """
-      (ruby|rbx) -I\S+ -S [\/\S]+\/exe\/rspec ./spec/thing_spec.rb --tag fast
+      (ruby|rbx) -I\S+ -S [\/\S]+\/exe\/rspec --pattern 'spec{,\/\*\/\*\*}\/\*_spec.rb' --tag fast
       """
 
   Scenario: Passing rake task arguments to the `rspec` command via `rspec_opts`
@@ -121,5 +121,5 @@ Feature: rake task
     Then the exit status should be 0
     Then the output should match:
       """
-      (ruby|rbx) -I\S+ -S [\/\S]+\/exe\/rspec ./spec/thing_spec.rb --tag fast
+      (ruby|rbx) -I\S+ -S [\/\S]+\/exe\/rspec --pattern 'spec{,\/\*\/\*\*}\/\*_spec.rb' --tag fast
       """

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -18,7 +18,7 @@ module RSpec
       DEFAULT_RSPEC_PATH = File.expand_path('../../../../exe/rspec', __FILE__)
 
       # Default pattern for spec files.
-      DEFAULT_PATTERN = './spec{,/*/**}/*_spec.rb'
+      DEFAULT_PATTERN = 'spec{,/*/**}/*_spec.rb'
 
       # Name of task.
       #
@@ -112,7 +112,7 @@ module RSpec
         if ENV['SPEC']
           FileList[ ENV['SPEC'] ].sort
         else
-          FileList[ pattern ].sort.map(&:shellescape)
+          "--pattern '#{pattern}'"
         end
       end
 


### PR DESCRIPTION
rspec has an internal option (-P) to receive pattern of files to run via the command line, use this option in rake_tasks instead of passing through a huge list of files one by one on the command line.
