### PR TITLE
Add an additional spec for the first from #1580.

### DIFF
--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -81,6 +81,13 @@ module RSpec::Core
         expect { ExampleGroup.describe("Config") }.not_to output.to_stderr
       end
 
+      it 'ignores top level constants that have the same name' do
+        parent = RSpec.describe("Some Parent Group")
+        child  = parent.describe("Hash")
+        # This would be `SomeParentGroup::Hash_2` if we didn't ignore the top level `Hash`
+        expect(child).to have_class_const("SomeParentGroup::Hash")
+      end
+
       it 'disambiguates name collisions by appending a number' do
         groups = 10.times.map { ExampleGroup.describe("Collision") }
         expect(groups[0]).to have_class_const("Collision")


### PR DESCRIPTION
The spec added in #1580 is a bit implicit in that
it depends upon RbConfig issuing a warning, which
may not always be the case in all versions of ruby.
The basic problem is that we were not ignoring top
level constants, so this added spec makes that
more explicit, and we can count on `Hash` always
being a top level constant even if RbConfig doesn’t
always issue the warning.
