### PR TITLE
Prefer CLI filter options to those in files

### DIFF
--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -373,6 +373,15 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
       expect(parse_options("--format", "cli")[:formatters]).to eq([['cli']])
     end
 
+    it "prefers CLI over file options for filter inclusion" do
+      File.open("./.rspec", "w") {|f| f << "--tag ~slow"}
+      opts = config_options_object("--tag", "slow")
+      config = RSpec::Core::Configuration.new
+      opts.configure(config)
+      expect(config.inclusion_filter.rules).to have_key(:slow)
+      expect(config.exclusion_filter.rules).not_to have_key(:slow)
+    end
+
     it "prefers project file options over global file options" do
       File.open("./.rspec", "w") {|f| f << "--format project"}
       File.open(File.expand_path("~/.rspec"), "w") {|f| f << "--format global"}


### PR DESCRIPTION
With the changes in 381b068f, it looks like we lost ordering information about how the exclusions and inclusions interleave. Internally, each group is consistent. Currently on master, I think all inclusions will be overridden by exclusions for the same value, regardless of the file/CLI/env ordering.

So concretely, overriding a project's `.rspec` file with CLI arguments doesn't currently appear to work.

This PR preserves the single Configuration reference from 381b068f, but keeps all the options ordered (`file_options << command_line_options << env_options`) for the filter manager. Seems to work well locally.

This affects releases starting with 3.0.0-rc1. 
