### PR TITLE
Fix misleading `:example_group` metadata deprecation warning.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,10 @@ Bug Fixes:
 * Fix regression in CLI option handling that prevented `--tag slow`
   passed at the command line from overriding `--tag ~slow` in `.rspec`.
   (Colin Jones, #1602)
+* Fix metadata `:example_group` deprecation warning so that it gets
+  issued at the call site of the configuration that specified it as
+  a filter rather than later when an example group is defined.
+  (Myron Marston, #1562)
 
 ### 3.0.1 / 2014-06-12
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.0.0...v3.0.1)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -848,7 +848,8 @@ module RSpec
       #
       #     filter_run_including :foo # same as filter_run_including :foo => true
       def filter_run_including(*args)
-        filter_manager.include_with_low_priority Metadata.build_hash_from(args)
+        meta = Metadata.build_hash_from(args, :warn_about_example_group_filtering)
+        filter_manager.include_with_low_priority meta
       end
 
       alias_method :filter_run, :filter_run_including
@@ -861,7 +862,8 @@ module RSpec
       # This overrides any inclusion filters/tags set on the command line or in
       # configuration files.
       def inclusion_filter=(filter)
-        filter_manager.include_only Metadata.build_hash_from([filter])
+        meta = Metadata.build_hash_from([filter], :warn_about_example_group_filtering)
+        filter_manager.include_only meta
       end
 
       alias_method :filter=, :inclusion_filter=
@@ -904,7 +906,8 @@ module RSpec
       #
       #     filter_run_excluding :foo # same as filter_run_excluding :foo => true
       def filter_run_excluding(*args)
-        filter_manager.exclude_with_low_priority Metadata.build_hash_from(args)
+        meta = Metadata.build_hash_from(args, :warn_about_example_group_filtering)
+        filter_manager.exclude_with_low_priority meta
       end
 
       # Clears and reassigns the `exclusion_filter`. Set to `nil` if you don't
@@ -915,7 +918,8 @@ module RSpec
       # This overrides any exclusion filters/tags set on the command line or in
       # configuration files.
       def exclusion_filter=(filter)
-        filter_manager.exclude_only Metadata.build_hash_from([filter])
+        meta = Metadata.build_hash_from([filter], :warn_about_example_group_filtering)
+        filter_manager.exclude_only meta
       end
 
       # Returns the `exclusion_filter`. If none has been set, returns an empty
@@ -957,7 +961,8 @@ module RSpec
       #
       # @see #extend
       def include(mod, *filters)
-        include_or_extend_modules << [:include, mod, Metadata.build_hash_from(filters)]
+        meta = Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
+        include_or_extend_modules << [:include, mod, meta]
       end
 
       # Tells RSpec to extend example groups with `mod`.  Methods defined in
@@ -990,7 +995,8 @@ module RSpec
       #
       # @see #include
       def extend(mod, *filters)
-        include_or_extend_modules << [:extend, mod, Metadata.build_hash_from(filters)]
+        meta = Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
+        include_or_extend_modules << [:extend, mod, meta]
       end
 
       # @private
@@ -1253,7 +1259,8 @@ module RSpec
       #     end
       #   end
       def define_derived_metadata(*filters, &block)
-        @derived_metadata_blocks << [Metadata.build_hash_from(filters), block]
+        meta = Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
+        @derived_metadata_blocks << [meta, block]
       end
 
       # @private

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -508,7 +508,9 @@ EOS
         end
 
         def scope_and_options_from(*args)
-          return extract_scope_from(args), Metadata.build_hash_from(args)
+          scope = extract_scope_from(args)
+          meta  = Metadata.build_hash_from(args, :warn_about_example_group_filtering)
+          return scope, meta
         end
 
         def extract_scope_from(args)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -11,6 +11,14 @@ module RSpec::Core
     let(:exclusion_filter) { config.exclusion_filter.rules }
     let(:inclusion_filter) { config.inclusion_filter.rules }
 
+    shared_examples_for "warning of deprecated `:example_group` during filtering configuration" do |method, *args|
+      it "issues a deprecation warning when filtering by `:example_group`" do
+        args << { :example_group => { :file_location => /spec\/unit/ } }
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /:example_group/)
+        config.__send__(method, *args)
+      end
+    end
+
     describe '#deprecation_stream' do
       it 'defaults to standard error' do
         expect($rspec_core_without_stderr_monkey_patch.deprecation_stream).to eq STDERR
@@ -684,6 +692,7 @@ module RSpec::Core
     end
 
     describe "#include" do
+      include_examples "warning of deprecated `:example_group` during filtering configuration", :include, Enumerable
 
       module InstanceLevelMethods
         def you_call_this_a_blt?
@@ -725,6 +734,7 @@ module RSpec::Core
     end
 
     describe "#extend" do
+      include_examples "warning of deprecated `:example_group` during filtering configuration", :extend, Enumerable
 
       module ThatThingISentYou
         def that_thing
@@ -950,6 +960,8 @@ module RSpec::Core
         end
       end
 
+      include_examples "warning of deprecated `:example_group` during filtering configuration", :filter_run_including
+
       it "sets the filter with a hash" do
         config.filter_run_including :foo => true
         expect(inclusion_filter).to eq( {:foo => true} )
@@ -974,6 +986,8 @@ module RSpec::Core
           config.exclusion_filter.rules
         end
       end
+
+      include_examples "warning of deprecated `:example_group` during filtering configuration", :filter_run_excluding
 
       it "sets the filter" do
         config.filter_run_excluding :foo => true
@@ -1011,6 +1025,8 @@ module RSpec::Core
           config.send("#{type}=", {:want => :this})
           expect(send(type)).to eq( {:want => :this} )
         end
+
+        include_examples "warning of deprecated `:example_group` during filtering configuration", :"#{type}="
       end
     end
     it_behaves_like "a spec filter", :inclusion_filter
@@ -1080,6 +1096,8 @@ module RSpec::Core
     end
 
     describe "#define_derived_metadata" do
+      include_examples "warning of deprecated `:example_group` during filtering configuration", :define_derived_metadata
+
       it 'allows the provided block to mutate example group metadata' do
         RSpec.configuration.define_derived_metadata do |metadata|
           metadata[:reverse_description] = metadata[:description].reverse
@@ -1740,6 +1758,10 @@ module RSpec::Core
         config.start_time = 42
         expect(config.start_time).to eq 42
       end
+    end
+
+    describe "hooks" do
+      include_examples "warning of deprecated `:example_group` during filtering configuration", :before, :each
     end
 
     # assigns files_or_directories_to_run and triggers post-processing

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -451,6 +451,12 @@ module RSpec
             end
           end
 
+          it 'does not issue a deprecation warning when :example_group is accessed while applying configured filterings' do
+            RSpec.configuration.include Module.new, :example_group => { :file_path => /.*/ }
+            expect_no_deprecation
+            RSpec.describe(Object, "group")
+          end
+
           it 'can still access the example group attributes via [:example_group]' do
             meta = nil
             RSpec.describe(Object, "group") { meta = metadata }


### PR DESCRIPTION
Fixes #1562.
