### PR TITLE
Create class doubles in our example so they have a full lifecycle.

### DIFF
--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -152,10 +152,12 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
 
     context "with multiple example groups", :slow do
       before do
+        example_clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+
         group1 = RSpec::Core::ExampleGroup.describe("slow group") do
           example("example") do |example|
             # make it look slow without actually taking up precious time
-            example.clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+            example.clock = example_clock
           end
         end
         group2 = RSpec::Core::ExampleGroup.describe("fast group") do

--- a/spec/rspec/core/formatters/profile_formatter_spec.rb
+++ b/spec/rspec/core/formatters/profile_formatter_spec.rb
@@ -39,10 +39,12 @@ RSpec.describe RSpec::Core::Formatters::ProfileFormatter do
 
     context "with one example group" do
       before do
+        example_clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+
         profile(RSpec::Core::ExampleGroup.describe("group") do
           example("example") do |example|
             # make it look slow without actually taking up precious time
-            example.clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+            example.clock = example_clock
           end
           example_line_number = __LINE__ - 4
         end)
@@ -53,10 +55,12 @@ RSpec.describe RSpec::Core::Formatters::ProfileFormatter do
 
     context "with multiple example groups" do
       before do
+        example_clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+
         group1 = RSpec::Core::ExampleGroup.describe("slow group") do
           example("example") do |example|
             # make it look slow without actually taking up precious time
-            example.clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+            example.clock = example_clock
           end
             example_line_number = __LINE__ - 4
         end


### PR DESCRIPTION
...rather than creating them in a nested example, which resets
them before they get used.

This is necessary for rspec/rspec-mocks#718.
