### PR TITLE
Test for same tag, different values

### DIFF
--- a/features/command_line/tag.feature
+++ b/features/command_line/tag.feature
@@ -21,6 +21,7 @@ Feature: `--tag` option
         it "example I'm working now", :focus => true do; end
         it "special example with string", :type => 'special' do; end
         it "special example with symbol", :type => :special do; end
+        it "custom example with symbol", :type => :custom do; end
         it "slow example", :skip => true do; end
         it "ordinary example", :speed => 'slow' do; end
         it "untagged example" do; end
@@ -95,4 +96,12 @@ Feature: `--tag` option
     Then the output should contain one of the following:
       | exclude {:skip=>true, :speed=>"slow"} |
       | exclude {:speed=>"slow", :skip=>true} |
+    Then the examples should all pass
+
+  @wip
+  Scenario: Exclude two two values for thes same tag
+    When I run `rspec . --tag ~type:special --tag ~type:custom`
+    Then the output should contain one of the following:
+      | exclude {:type=>"special", :type=>"custom"} |
+      | exclude {:type=>"custom", :type=>"special"} |
     Then the examples should all pass


### PR DESCRIPTION
I thought I might be able to hack around the lack of a logical OR operator for tags [like cucumber](https://github.com/cucumber/cucumber/wiki/Tags#logically-anding-and-oring-tags) by using DeMorgan's law, but I found that doesn't work for different values of the same tag.

In the test I added, I was hoping to get something like:
`exclude {:type=>"special", :type=>"custom"}`
but the tags overwrite each other, so I just get
`exclude {:type=>"custom"}`

Tests fails for both rspec2 and rspec3.
