### PR TITLE
Removing code duplication in feature test

### DIFF
--- a/features/mock_framework_integration/use_any_framework.feature
+++ b/features/mock_framework_integration/use_any_framework.feature
@@ -69,7 +69,7 @@ Feature: mock with an alternative framework
           end
 
           def verify_mocks_for_rspec
-            Expector.verify_expectors.each {|d| d.verify}
+            Expector.verify_expectors
           end
 
           def teardown_mocks_for_rspec


### PR DESCRIPTION
The verification on the expectors was run twice in the feature test for the
integration of mocking frameworks. Tests still pass, maybe a millisecond faster.
