### PR TITLE
Add placeholder for code_or_symbol to NullColorizer

### DIFF
--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -7,7 +7,7 @@ module RSpec::Core
 
     # @private
     class NullColorizer
-      def wrap(line)
+      def wrap(line, _code_or_symbol)
         line
       end
     end

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -189,16 +189,25 @@ module FormatterSupport
   end
 
   def example
-    result = { :exception => Exception.new }
-    allow(result).to receive(:pending_fixed?) { false }
-    allow(result).to receive(:status) { :passed }
-    instance_double(RSpec::Core::Example,
-                    :description       => "Example",
-                    :full_description  => "Example",
-                    :execution_result  => result,
-                    :location          => "",
-                    :metadata          => {}
-                   )
+    @example ||=
+      begin
+        result = instance_double(RSpec::Core::Example::ExecutionResult,
+                                 :pending_fixed? => false,
+                                 :status         => :passed
+                                )
+        allow(result).to receive(:exception) { exception }
+        instance_double(RSpec::Core::Example,
+                        :description       => "Example",
+                        :full_description  => "Example",
+                        :execution_result  => result,
+                        :location          => "",
+                        :metadata          => {}
+                       )
+      end
+  end
+
+  def exception
+    Exception.new
   end
 
   def examples(n)


### PR DESCRIPTION
The signature of `NullColorizer#wrap` was different from `ConsoleCodes#wrap`, therefore `#message_lines` raised error.
