### PR TITLE
Remove unneeded requires in rake task.

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -1,7 +1,3 @@
-require 'rspec/support'
-require 'rspec/core/version'
-RSpec::Support.require_rspec_support "warnings"
-
 require 'rake'
 require 'rake/tasklib'
 require 'shellwords'


### PR DESCRIPTION
- rspec/core/version require was added in
  390392e7e76429bbeddedd615565e858c70194f9 but
  looks like it was never actually used.
- We used to have some warnings emitted by the rake
  task (and thus needed to load that support) but
  don’t have any more warnings.

@postmodern, do you remember why you added `require 'rspec/core/version'` in that commit?
