### PR TITLE
Remove /gems/ from default backtrace exclusion patterns.

### DIFF
--- a/features/configuration/backtrace_exclusion_patterns.feature
+++ b/features/configuration/backtrace_exclusion_patterns.feature
@@ -7,8 +7,6 @@ Feature: Excluding lines from the backtrace
   /\/lib\d*\/ruby\//,
   /org\/jruby\//,
   /bin\//,
-  /gems/,
-  /spec\/spec_helper\.rb/,
   /lib\/rspec\/(core|expectations|matchers|mocks)/
   ```
 

--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -12,7 +12,6 @@ module RSpec
           "/lib\d*/ruby/",
           "org/jruby/",
           "bin/",
-          "/gems/",
         ].map { |s| Regexp.new(s.gsub("/", File::SEPARATOR)) }
 
         @system_exclusion_patterns = [Regexp.union(RSpec::CallerFilter::IGNORE_REGEX, *patterns)]

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -23,10 +23,6 @@ module RSpec::Core
         expect(make_backtrace_formatter.exclude?("org/jruby/RubyArray.java:2336")).to be true
       end
 
-      it "excludes files within installed gems" do
-        expect(make_backtrace_formatter.exclude?('ruby-1.8.7-p334/gems/mygem-2.3.0/lib/mygem.rb')).to be true
-      end
-
       it "includes files in projects containing 'gems' in the name" do
         expect(make_backtrace_formatter.exclude?('code/my-gems-plugin/lib/plugin.rb')).to be false
       end


### PR DESCRIPTION
As discussed in #1536 and #1554, the failure can often be in a gem.

We may add an additional gem filtering API later on but for
now I just want to try this on a few projects and see how the
experience is.
