### PR TITLE
Update rake task docs with note about LoadError

### DIFF
--- a/features/command_line/rake_task.feature
+++ b/features/command_line/rake_task.feature
@@ -1,15 +1,32 @@
 Feature: rake task
 
-  RSpec ships with a rake task with a number of useful options
+  RSpec ships with a rake task with a number of useful options.
+
+  We recommend you wrap this in a `rescue` clause so that you can
+  use your `Rakefile` in an environment where RSpec is unavailable
+  (for example on a production server). e.g:
+
+  ```ruby
+  begin
+    require 'rspec/core/rake_task'
+    RSpec::Core::RakeTask.new(:spec)
+  rescue LoadError
+  end
+  ```
 
   Scenario: Default options with passing spec (prints command and exit status is 0)
     Given a file named "Rakefile" with:
       """ruby
-      require 'rspec/core/rake_task'
 
-      RSpec::Core::RakeTask.new(:spec)
+      begin
+        require 'rspec/core/rake_task'
 
-      task :default => :spec
+        RSpec::Core::RakeTask.new(:spec)
+
+        task :default => :spec
+      rescue LoadError
+        # no rspec available
+      end
       """
     And a file named "spec/thing_spec.rb" with:
       """ruby
@@ -29,11 +46,15 @@ Feature: rake task
   Scenario: Default options with failing spec (exit status is 1)
     Given a file named "Rakefile" with:
       """ruby
-      require 'rspec/core/rake_task'
+      begin
+        require 'rspec/core/rake_task'
 
-      RSpec::Core::RakeTask.new(:spec)
+        RSpec::Core::RakeTask.new(:spec)
 
-      task :default => :spec
+        task :default => :spec
+      rescue LoadError
+        # no rspec available
+      end
       """
     And a file named "spec/thing_spec.rb" with:
       """ruby
@@ -49,13 +70,17 @@ Feature: rake task
   Scenario: Setting `fail_on_error = false` with failing spec (exit status is 0)
     Given a file named "Rakefile" with:
       """ruby
-      require 'rspec/core/rake_task'
+      begin
+        require 'rspec/core/rake_task'
 
-      RSpec::Core::RakeTask.new(:spec) do |t|
-        t.fail_on_error = false
+        RSpec::Core::RakeTask.new(:spec) do |t|
+          t.fail_on_error = false
+        end
+
+        task :default => :spec
+      rescue LoadError
+        # no rspec available
       end
-
-      task :default => :spec
       """
     And a file named "spec/thing_spec.rb" with:
       """ruby
@@ -71,10 +96,14 @@ Feature: rake task
   Scenario: Passing arguments to the `rspec` command using `rspec_opts`
     Given a file named "Rakefile" with:
       """ruby
-      require 'rspec/core/rake_task'
+      begin
+        require 'rspec/core/rake_task'
 
-      RSpec::Core::RakeTask.new(:spec) do |t|
-        t.rspec_opts = "--tag fast"
+        RSpec::Core::RakeTask.new(:spec) do |t|
+          t.rspec_opts = "--tag fast"
+        end
+      rescue LoadError
+        # no rspec available
       end
       """
     And a file named "spec/thing_spec.rb" with:
@@ -99,10 +128,14 @@ Feature: rake task
   Scenario: Passing rake task arguments to the `rspec` command via `rspec_opts`
     Given a file named "Rakefile" with:
       """ruby
-      require 'rspec/core/rake_task'
+      begin
+        require 'rspec/core/rake_task'
 
-      RSpec::Core::RakeTask.new(:spec, :tag) do |t, task_args|
-        t.rspec_opts = "--tag #{task_args[:tag]}"
+        RSpec::Core::RakeTask.new(:spec, :tag) do |t, task_args|
+          t.rspec_opts = "--tag #{task_args[:tag]}"
+        end
+      rescue LoadError
+        # no rspec available
       end
       """
     And a file named "spec/thing_spec.rb" with:


### PR DESCRIPTION
Update rake task docs with note(s) about using `rescue LoadError` to allow usage in production.

Fixes #1638
