### PR TITLE
Add option to render backtrace elements as URLs that open editors

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -268,6 +268,7 @@ module RSpec
       attr_accessor :filter_manager
       # @private
       attr_reader :backtrace_formatter, :ordering_manager
+      add_setting :editor_url_template
 
       def initialize
         @start_time = $_rspec_core_load_started_at || ::RSpec::Core::Time.now
@@ -281,6 +282,7 @@ module RSpec
         @spec_files_loaded = false
 
         @backtrace_formatter = BacktraceFormatter.new
+        @editor_url_template = false
 
         @default_path = 'spec'
         @deprecation_stream = $stderr

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -137,6 +137,16 @@ module RSpec::Core
           $VERBOSE = true
         end
 
+        parser.on('--editor_url_template TEMPLATE', 'HTMLoutput only: make backtraces link to editor',
+                  '  [txmt]    TextMate txmt:// style',
+                  '  [subl]    Sublime subl:// style',
+                  '  [macvim]  MacVim macvim:// style',
+                  '  [emacs]   EMACS emacs:// style',
+                  '  or a custom url template using \%{file} and \%{line_num} placeholders',
+                  '  (defaults to no links)') do |template|
+          options[:editor_url_template] = template
+        end
+
         parser.separator <<-FILTERING
 
   **** Filtering/tags ****


### PR DESCRIPTION
adds the --url_editor_template command line option, which allows the user to specify a url template for rendering backtrace links in the html output. The option has settings for TextMate, Sublime, EMACs and Macvim, but also allows arbitrary URLS to be constructed from the file name and line number of the backtrace element.
