### PR TITLE
Add --exclude_pattern option to configuration

### DIFF
--- a/features/configuration/exclude_pattern.feature
+++ b/features/configuration/exclude_pattern.feature
@@ -1,0 +1,43 @@
+Feature: exclude_pattern
+
+  Use the `--exclude-pattern` option to tell RSpec to skip looking for specs in files
+  that match the pattern specified.
+
+  Background:
+    Given a file named "spec/models/model_spec.rb" with:
+      """ruby
+      RSpec.describe "two specs here" do
+        it "passes" do
+        end
+
+        it "passes too" do
+        end
+      end
+      """
+    And a file named "spec/features/feature_spec.rb" with:
+      """ruby
+      RSpec.describe "only one spec" do
+        it "passes" do
+        end
+      end
+      """
+
+  Scenario: By default, RSpec runs files that match `"**/*_spec.rb"`
+   When I run `rspec`
+   Then the output should contain "3 examples, 0 failures"
+
+  Scenario: The `--exclude-pattern` flag makes RSpec first match the default pattern, then skip files matching the specified exclude pattern
+   When I run `rspec --exclude-pattern "**/models/*_spec.rb"`
+   Then the output should contain "1 example, 0 failures"
+
+  Scenario: The `--exclude-pattern` flag can be used to pass in multiple patterns, separated by comma
+   When I run `rspec --exclude-pattern "**/models/*_spec.rb, **/features/*_spec.rb"`
+   Then the output should contain "0 examples, 0 failures"
+
+  Scenario: The `--exclude-pattern` flag accepts shell style glob unions
+   When I run `rspec --exclude-pattern "**/{models,features}/*_spec.rb"`
+   Then the output should contain "0 examples, 0 failures"
+
+  Scenario: The `--exclude-pattern` flag can be used with the `--pattern` flag
+   When I run `rspec --pattern "spec/**/*_spec.rb" --exclude-pattern "spec/models/*_spec.rb"`
+   Then the output should contain "1 example, 0 failures"

--- a/features/configuration/pattern.feature
+++ b/features/configuration/pattern.feature
@@ -1,7 +1,7 @@
 Feature: pattern
 
   Use the `--pattern` option to tell RSpec to look for specs in files that match
-  a pattern other than `"**/*_spec.rb"`.
+  a pattern instead of the default `"**/*_spec.rb"`.
 
   Background:
     Given a file named "spec/example_spec.rb" with:

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -193,6 +193,19 @@ module RSpec
         @pattern = value
       end
 
+      # @macro define_reader
+      # Exclude files matching this pattern
+      define_reader :exclude_pattern
+
+      # Set pattern to match files to exclude
+      # @attr value [String] the filename pattern to exclude spec files by
+      def exclude_pattern=(value)
+        if @spec_files_loaded
+          RSpec.warning "Configuring `exclude_pattern` to #{value} has no effect since RSpec has already loaded the spec files."
+        end
+        @exclude_pattern = value
+      end
+
       # @macro add_setting
       # Report the times for the slowest examples (default: `false`).
       # Use this to specify the number of examples to include in the profile.
@@ -277,6 +290,7 @@ module RSpec
         @files_or_directories_to_run = []
         @color = false
         @pattern = '**/*_spec.rb'
+        @exclude_pattern = ''
         @failure_exit_code = 1
         @spec_files_loaded = false
 
@@ -1280,9 +1294,14 @@ module RSpec
       end
 
       def gather_directories(path)
+        include_files = get_matching_files(path, pattern)
+        exclude_files = get_matching_files(path, exclude_pattern)
+        (include_files - exclude_files).sort
+      end
+
+      def get_matching_files(path, pattern)
         stripped = "{#{pattern.gsub(/\s*,\s*/, ',')}}"
-        files    = pattern =~ /^#{Regexp.escape path}/ ? Dir[stripped] : Dir["#{path}/#{stripped}"]
-        files.sort
+        pattern =~ /^#{Regexp.escape path}/ ? Dir[stripped] : Dir["#{path}/#{stripped}"]
       end
 
       def extract_location(path)

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -153,6 +153,10 @@ FILTERING
           options[:pattern] = o
         end
 
+        parser.on('--exclude-pattern PATTERN', 'Load files except those matching pattern. Opposite effect of --pattern.') do |o|
+          options[:exclude_pattern] = o
+        end
+
         parser.on('-e', '--example STRING', "Run examples whose full nested names include STRING (may be",
                                             "  used more than once)") do |o|
           (options[:full_description] ||= []) << Regexp.compile(Regexp.escape(o))


### PR DESCRIPTION
Resolves #1626. It allows passing `--exclude_pattern` to `rspec` on the command line.

Afaik we still can't use the power of rake tasks. This is because the rake task still uses `FileList` to include files. And once files are included, they can't be changed by passing `--pattern` or `--exclude-pattern` (there is a warning about this when you try). Fortunately, once #1589 is merged, it will be possible to pass  `--exclude-pattern` within `rspec_opts` in the rake task config.  This is because the rake task's `pattern` option will use `--pattern` which can be combined with `--exclude-pattern` for a one-two punch.

@myronmarston Let me know how this looks! Sorry it took so long.
