### PR TITLE
Setup rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,53 @@
+inherit_from: .rubocop_rspec_base.yml
+
+AllCops:
+  Exclude:
+    # This code was taken from the backports gem. We don't want to mess with it.
+    - lib/rspec/core/backport_random.rb
+
+# This should go down over time.
+ClassLength:
+  Max: 330
+
+# This should go down over time.
+LineLength:
+  Max: 180
+
+Lint/HandleExceptions:
+  Exclude:
+    - lib/rspec/core/example.rb
+    - lib/rspec/core/mocking_adapters/mocha.rb
+    - lib/rspec/core/runner.rb
+    - lib/rspec/core/test_unit_assertions_adapter.rb
+
+Lint/LiteralInInterpolation:
+  Enabled: false
+
+# This should go down over time.
+MethodLength:
+  Max: 152
+
+# Exclude the default spec_helper to make it easier to uncomment out
+# default settings (for both users and the Cucumber suite).
+Style/BlockComments:
+  Exclude:
+    - lib/rspec/core/project_initializer/spec/spec_helper.rb
+
+# Not sure what to do with this rule yet.
+Style/ClassAndModuleChildren:
+  Exclude:
+    - lib/rspec/core/formatters.rb
+    - lib/rspec/core/notifications.rb
+    - lib/rspec/core/option_parser.rb
+    - lib/rspec/core/reporter.rb
+
+# This should go down over time.
+Style/CyclomaticComplexity:
+  Max: 12
+
+Style/RaiseArgs:
+  Exclude:
+    - lib/rspec/core/configuration.rb
+    - lib/rspec/core/hooks.rb
+    - lib/rspec/core/option_parser.rb
+    - lib/rspec/core/pending.rb

--- a/Gemfile
+++ b/Gemfile
@@ -29,5 +29,6 @@ platforms :jruby do
 end
 
 gem 'simplecov', '~> 0.8'
+gem 'rubocop', "~> 0.23.0", :platform => [:ruby_19, :ruby_20, :ruby_21]
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/Rakefile
+++ b/Rakefile
@@ -23,9 +23,16 @@ namespace :spec do
   end
 end
 
+require 'rubocop/rake_task'
+
+desc 'Run RuboCop on the lib directory'
+task :rubocop do
+  sh 'bundle exec rubocop lib'
+end
+
 desc "delete generated files"
 task :clobber do
-  sh %q{find . -name "*.rbc" | xargs rm}
+  sh 'find . -name "*.rbc" | xargs rm'
   sh 'rm -rf pkg'
   sh 'rm -rf tmp'
   sh 'rm -rf coverage'
@@ -39,7 +46,7 @@ task :rdoc do
 end
 
 desc "Push docs/cukes to relishapp using the relish-client-gem"
-task :relish, :version do |t, args|
+task :relish, :version do |_t, args|
   raise "rake relish[VERSION]" unless args[:version]
   sh "cp Changelog.md features/"
   if `relish versions rspec/rspec-core`.split.map(&:strip).include? args[:version]
@@ -51,7 +58,7 @@ task :relish, :version do |t, args|
   sh "rm features/Changelog.md"
 end
 
-task :default => [:spec, :cucumber]
+task :default => [:spec, :cucumber, :rubocop]
 
 task :verify_private_key_present do
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')

--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -1,4 +1,7 @@
+# rubocop:disable Style/GlobalVars
 $_rspec_core_load_started_at = Time.now
+# rubocop:enable Style/GlobalVars
+
 require 'rbconfig'
 
 require "rspec/support"
@@ -64,7 +67,6 @@ module RSpec
                          config.expose_dsl_globally = true
                          config
                        end
-
   end
 
   # Yields the global configuration to a block.

--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -17,9 +17,7 @@ module RSpec
         @inclusion_patterns = [Regexp.new(Dir.getwd)]
       end
 
-      def full_backtrace=(full_backtrace)
-        @full_backtrace = full_backtrace
-      end
+      attr_writer :full_backtrace
 
       def full_backtrace?
         @full_backtrace || @exclusion_patterns.empty?
@@ -27,13 +25,13 @@ module RSpec
 
       def filter_gem(gem_name)
         sep = File::SEPARATOR
-        pattern = %r{#{sep}#{gem_name}(-[^#{sep}]+)?#{sep}}
+        pattern = /#{sep}#{gem_name}(-[^#{sep}]+)?#{sep}/
 
         @exclusion_patterns        << pattern
         @system_exclusion_patterns << pattern
       end
 
-      def format_backtrace(backtrace, options = {})
+      def format_backtrace(backtrace, options={})
         return backtrace if options[:full_backtrace]
 
         backtrace.map { |l| backtrace_line(l) }.compact.

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -4,6 +4,8 @@ RSpec::Support.require_rspec_core "formatters/deprecation_formatter"
 
 module RSpec
   module Core
+    # rubocop:disable Style/ClassLength
+
     # Stores runtime configuration information.
     #
     # Configuration options are loaded from `~/.rspec`, `.rspec`,
@@ -50,7 +52,7 @@ module RSpec
 
       # @private
       def self.define_predicate_for(*names)
-        names.each {|name| alias_method "#{name}?", name}
+        names.each { |name| alias_method "#{name}?", name }
       end
 
       # @private
@@ -58,7 +60,7 @@ module RSpec
       # Invoked by the `add_setting` instance method. Use that method on a
       # `Configuration` instance rather than this class method.
       def self.add_setting(name, opts={})
-        raise "Use the instance add_setting method if you want to set a default" if opts.has_key?(:default)
+        raise "Use the instance add_setting method if you want to set a default" if opts.key?(:default)
         attr_writer name
         add_read_only_setting name
 
@@ -71,7 +73,7 @@ module RSpec
       #
       # As `add_setting` but only add the reader
       def self.add_read_only_setting(name, opts={})
-        raise "Use the instance add_setting method if you want to set a default" if opts.has_key?(:default)
+        raise "Use the instance add_setting method if you want to set a default" if opts.key?(:default)
         define_reader name
         define_predicate_for name
       end
@@ -134,10 +136,10 @@ module RSpec
       # @param value [IO, String] IO to write to or filename to write to
       def deprecation_stream=(value)
         if @reporter && !value.equal?(@deprecation_stream)
-          warn "RSpec's reporter has already been initialized with " +
-            "#{deprecation_stream.inspect} as the deprecation stream, so your change to "+
-            "`deprecation_stream` will be ignored. You should configure it earlier for " +
-            "it to take effect, or use the `--deprecation-out` CLI option. " +
+          warn "RSpec's reporter has already been initialized with " \
+            "#{deprecation_stream.inspect} as the deprecation stream, so your change to "\
+            "`deprecation_stream` will be ignored. You should configure it earlier for " \
+            "it to take effect, or use the `--deprecation-out` CLI option. " \
             "(Called from #{CallerFilter.first_non_rspec_line})"
         else
           @deprecation_stream = value
@@ -174,9 +176,9 @@ module RSpec
       # @attr value [IO] value for output, defaults to $stdout
       def output_stream=(value)
         if @reporter && !value.equal?(@output_stream)
-          warn "RSpec's reporter has already been initialized with " +
-            "#{output_stream.inspect} as the output stream, so your change to "+
-            "`output_stream` will be ignored. You should configure it earlier for " +
+          warn "RSpec's reporter has already been initialized with " \
+            "#{output_stream.inspect} as the output stream, so your change to "\
+            "`output_stream` will be ignored. You should configure it earlier for " \
             "it to take effect. (Called from #{CallerFilter.first_non_rspec_line})"
         else
           @output_stream = value
@@ -257,9 +259,9 @@ module RSpec
       # Deprecated. This config option was added in RSpec 2 to pave the way
       # for this being the default behavior in RSpec 3. Now this option is
       # a no-op.
-      def treat_symbols_as_metadata_keys_with_true_values=(value)
+      def treat_symbols_as_metadata_keys_with_true_values=(_value)
         RSpec.deprecate("RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=",
-                        :message => "RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= " +
+                        :message => "RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= " \
                                     "is deprecated, it is now set to true as default and setting it to false has no effect.")
       end
 
@@ -280,7 +282,9 @@ module RSpec
       attr_reader :backtrace_formatter, :ordering_manager
 
       def initialize
+        # rubocop:disable Style/GlobalVars
         @start_time = $_rspec_core_load_started_at || ::RSpec::Core::Time.now
+        # rubocop:enable Style/GlobalVars
         @expectation_frameworks = []
         @include_or_extend_modules = []
         @mock_framework = nil
@@ -488,18 +492,19 @@ module RSpec
       #       mod_config.custom_setting = true
       #     end
       def mock_with(framework)
-        framework_module = if framework.is_a?(Module)
-           framework
-        else
-          const_name = MOCKING_ADAPTERS.fetch(framework) do
-            raise ArgumentError,
-              "Unknown mocking framework: #{framework.inspect}. " +
-              "Pass a module or one of #{MOCKING_ADAPTERS.keys.inspect}"
-          end
+        framework_module =
+          if framework.is_a?(Module)
+            framework
+          else
+            const_name = MOCKING_ADAPTERS.fetch(framework) do
+              raise ArgumentError,
+                    "Unknown mocking framework: #{framework.inspect}. " \
+                    "Pass a module or one of #{MOCKING_ADAPTERS.keys.inspect}"
+            end
 
-          RSpec::Support.require_rspec_core "mocking_adapters/#{const_name.to_s.downcase}"
-          RSpec::Core::MockingAdapters.const_get(const_name)
-        end
+            RSpec::Support.require_rspec_core "mocking_adapters/#{const_name.to_s.downcase}"
+            RSpec::Core::MockingAdapters.const_get(const_name)
+          end
 
         new_name, old_name = [framework_module, @mock_framework].map do |mod|
           mod.respond_to?(:framework_name) ?  mod.framework_name : :unnamed
@@ -615,20 +620,20 @@ module RSpec
       # @param output [IO] an output stream to use, defaults to the current
       #        `output_stream`
       # @return [Boolean]
-      def color_enabled?(output = output_stream)
+      def color_enabled?(output=output_stream)
         output_to_tty?(output) && color
       end
 
       # Toggle output color
       # @attr true_or_false [Boolean] toggle color enabled
       def color=(true_or_false)
-        if true_or_false
-          if RSpec.world.windows_os? and not ENV['ANSICON']
-            RSpec.warning "You must use ANSICON 1.31 or later (http://adoxa.3eeweb.com/ansicon/) to use colour on Windows"
-            @color = false
-          else
-            @color = true
-          end
+        return unless true_or_false
+
+        if RSpec.world.windows_os? && !ENV['ANSICON']
+          RSpec.warning "You must use ANSICON 1.31 or later (http://adoxa.3eeweb.com/ansicon/) to use colour on Windows"
+          @color = false
+        else
+          @color = true
         end
       end
 
@@ -643,7 +648,7 @@ module RSpec
       # Run examples matching on `description` in all files to run.
       # @param description [String, Regexp] the pattern to filter on
       def full_description=(description)
-        filter_run :full_description => Regexp.union(*Array(description).map {|d| Regexp.new(d) })
+        filter_run :full_description => Regexp.union(*Array(description).map { |d| Regexp.new(d) })
       end
 
       # @return [Array] full description filter
@@ -858,7 +863,7 @@ module RSpec
       #   specs, but does not add any additional documentation.  We use this
       #   in rspec to define `it_should_behave_like` (for backward
       #   compatibility), but we also add docs for that method.
-      def alias_it_behaves_like_to(new_name, report_label = '')
+      def alias_it_behaves_like_to(new_name, report_label='')
         RSpec::Core::ExampleGroup.define_nested_shared_group_method(new_name, report_label)
       end
       alias_method :alias_it_should_behave_like_to, :alias_it_behaves_like_to
@@ -1064,7 +1069,7 @@ module RSpec
       def requires=(paths)
         directories = ['lib', default_path].select { |p| File.directory? p }
         RSpec::Core::RubyProject.add_to_load_path(*directories)
-        paths.each {|path| require path}
+        paths.each { |path| require path }
         @requires += paths
       end
 
@@ -1097,7 +1102,7 @@ module RSpec
 
       # @private
       def load_spec_files
-        files_to_run.uniq.each {|f| load File.expand_path(f) }
+        files_to_run.uniq.each { |f| load File.expand_path(f) }
         @spec_files_loaded = true
       end
 
@@ -1336,10 +1341,14 @@ module RSpec
       end
 
       def extract_location(path)
-        if path =~ /^(.*?)((?:\:\d+)+)$/
-          path, lines = $1, $2[1..-1].split(":").map{|n| n.to_i}
+        match = /^(.*?)((?:\:\d+)+)$/.match(path)
+
+        if match
+          captures = match.captures
+          path, lines = captures[0], captures[1][1..-1].split(":").map { |n| n.to_i }
           filter_manager.add_location path, lines
         end
+
         path
       end
 
@@ -1348,16 +1357,16 @@ module RSpec
       end
 
       def value_for(key, default=nil)
-        @preferred_options.has_key?(key) ? @preferred_options[key] : default
+        @preferred_options.key?(key) ? @preferred_options[key] : default
       end
 
       def assert_no_example_groups_defined(config_option)
-        if RSpec.world.example_groups.any?
-          raise MustBeConfiguredBeforeExampleGroupsError.new(
-            "RSpec's #{config_option} configuration option must be configured before " +
-            "any example groups are defined, but you have already defined a group."
-          )
-        end
+        return unless RSpec.world.example_groups.any?
+
+        raise MustBeConfiguredBeforeExampleGroupsError.new(
+          "RSpec's #{config_option} configuration option must be configured before " \
+          "any example groups are defined, but you have already defined a group."
+        )
       end
 
       def output_to_tty?(output=output_stream)
@@ -1396,5 +1405,6 @@ module RSpec
         @files_to_run = nil
       end
     end
+    # rubocop:enable Style/ClassLength
   end
 end

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -41,14 +41,16 @@ module RSpec
       def organize_options
         @filter_manager_options = []
 
-        @options = (file_options << command_line_options << env_options).each { |opts|
+        @options = (file_options << command_line_options << env_options).each do |opts|
           @filter_manager_options << [:include, opts.delete(:inclusion_filter)] if opts.key?(:inclusion_filter)
           @filter_manager_options << [:exclude, opts.delete(:exclusion_filter)] if opts.key?(:exclusion_filter)
-        }.inject(:libs => [], :requires => []) { |hash, opts|
-          hash.merge(opts) { |key, oldval, newval|
+        end
+
+        @options = @options.inject(:libs => [], :requires => []) do |hash, opts|
+          hash.merge(opts) do |key, oldval, newval|
             [:libs, :requires].include?(key) ? oldval + newval : newval
-          }
-        }
+          end
+        end
       end
 
       UNFORCED_OPTIONS = [
@@ -161,12 +163,10 @@ module RSpec
       end
 
       def global_options_file
-        begin
-          File.join(File.expand_path("~"), ".rspec")
-        rescue ArgumentError
-          RSpec.warning "Unable to find ~/.rspec because the HOME environment variable is not set"
-          nil
-        end
+        File.join(File.expand_path("~"), ".rspec")
+      rescue ArgumentError
+        RSpec.warning "Unable to find ~/.rspec because the HOME environment variable is not set"
+        nil
       end
     end
   end

--- a/lib/rspec/core/drb.rb
+++ b/lib/rspec/core/drb.rb
@@ -60,20 +60,20 @@ module RSpec
       end
 
       def add_failure_exit_code(argv)
-        if @submitted_options[:failure_exit_code]
-          argv << "--failure-exit-code" << @submitted_options[:failure_exit_code].to_s
-        end
+        return unless @submitted_options[:failure_exit_code]
+
+        argv << "--failure-exit-code" << @submitted_options[:failure_exit_code].to_s
       end
 
       def add_full_description(argv)
-        if @submitted_options[:full_description]
-          # The argument to --example is regexp-escaped before being stuffed
-          # into a regexp when received for the first time (see OptionParser).
-          # Hence, merely grabbing the source of this regexp will retain the
-          # backslashes, so we must remove them.
-          @submitted_options[:full_description].each do |description|
-            argv << "--example" << description.source.delete('\\')
-          end
+        return unless @submitted_options[:full_description]
+
+        # The argument to --example is regexp-escaped before being stuffed
+        # into a regexp when received for the first time (see OptionParser).
+        # Hence, merely grabbing the source of this regexp will retain the
+        # backslashes, so we must remove them.
+        @submitted_options[:full_description].each do |description|
+          argv << "--example" << description.source.delete('\\')
         end
       end
 

--- a/lib/rspec/core/dsl.rb
+++ b/lib/rspec/core/dsl.rb
@@ -85,7 +85,6 @@ module RSpec
         (class << top_level; self; end).class_exec(&changes)
         Module.class_exec(&changes)
       end
-
     end
   end
 end

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -73,9 +73,12 @@ module RSpec
       # there is one, otherwise returns a message including the location of the
       # example.
       def description
-        description = metadata[:description].to_s.empty? ?
-          "example at #{location}" :
-          metadata[:description]
+        description = if metadata[:description].to_s.empty?
+                        "example at #{location}"
+                      else
+                        metadata[:description]
+                      end
+
         RSpec.configuration.format_docstrings_block.call(description)
       end
 
@@ -151,8 +154,8 @@ module RSpec
                   Pending.mark_fixed! self
 
                   raise Pending::PendingExampleFixedError,
-                    'Expected example to fail since it is pending, but it passed.',
-                    [location]
+                        'Expected example to fail since it is pending, but it passed.',
+                        [location]
                 end
               rescue Pending::SkipDeclaredInExample
                 # no-op, required metadata has already been set by the `skip`
@@ -201,15 +204,15 @@ module RSpec
         attr_reader :example
 
         Example.public_instance_methods(false).each do |name|
-          unless name.to_sym == :run || name.to_sym == :inspect
-            define_method(name) { |*a, &b| @example.__send__(name, *a, &b) }
-          end
+          next if name.to_sym == :run || name.to_sym == :inspect
+
+          define_method(name) { |*a, &b| @example.__send__(name, *a, &b) }
         end
 
         Proc.public_instance_methods(false).each do |name|
-          unless name.to_sym == :call || name.to_sym == :to_proc || name.to_sym == :inspect
-            define_method(name) { |*a, &b| @proc.__send__(name, *a, &b) }
-          end
+          next if name.to_sym == :call || name.to_sym == :inspect || name.to_sym == :to_proc
+
+          define_method(name) { |*a, &b| @proc.__send__(name, *a, &b) }
         end
 
         # Calls the proc and notes that the example has been executed.
@@ -475,7 +478,7 @@ module RSpec
           end
         end
 
-        def issue_deprecation(method_name, *args)
+        def issue_deprecation(_method_name, *_args)
           RSpec.deprecate("Treating `metadata[:execution_result]` as a hash",
                           :replacement => "the attributes methods to access the data")
         end
@@ -490,7 +493,7 @@ module RSpec
       end
 
       # To ensure we don't silence errors...
-      def set_exception(exception, context=nil)
+      def set_exception(exception, _context=nil)
         raise exception
       end
     end

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -25,12 +25,12 @@ module RSpec
     # There are additional instance methods available to your examples defined in
     # {MemoizedHelpers} and {Pending}.
     class ExampleGroup
-      extend  Hooks
+      extend Hooks
 
       include MemoizedHelpers
-      extend  MemoizedHelpers::ClassMethods
+      extend MemoizedHelpers::ClassMethods
       include Pending
-      extend  SharedExampleGroup
+      extend SharedExampleGroup
 
       unless respond_to?(:define_singleton_method)
         # @private
@@ -50,7 +50,7 @@ module RSpec
       # @private
       # @return [Metadata] belonging to the parent of a nested {ExampleGroup}
       def self.superclass_metadata
-        @superclass_metadata ||= self.superclass.respond_to?(:metadata) ? self.superclass.metadata : nil
+        @superclass_metadata ||= superclass.respond_to?(:metadata) ? superclass.metadata : nil
       end
 
       # @private
@@ -211,8 +211,8 @@ module RSpec
 
           if top_level
             if thread_data[:in_example_group]
-              raise "Creating an isolated context from within a context is " +
-                    "not allowed. Change `RSpec.#{name}` to `#{name}` or " +
+              raise "Creating an isolated context from within a context is " \
+                    "not allowed. Change `RSpec.#{name}` to `#{name}` or " \
                     "move this to a top-level scope."
             end
 
@@ -315,7 +315,9 @@ module RSpec
 
       # @private
       def self.find_and_eval_shared(label, name, *args, &customization_block)
-        unless shared_block = RSpec.world.shared_example_group_registry.find(parent_groups, name)
+        shared_block = RSpec.world.shared_example_group_registry.find(parent_groups, name)
+
+        unless shared_block
           raise ArgumentError, "Could not find shared #{label} #{name.inspect}"
         end
 
@@ -376,7 +378,7 @@ module RSpec
 
       # @private
       def self.descendant_filtered_examples
-        @descendant_filtered_examples ||= filtered_examples + children.inject([]){|l,c| l + c.descendant_filtered_examples}
+        @descendant_filtered_examples ||= filtered_examples + children.inject([]) { |a, e| a + e.descendant_filtered_examples }
       end
 
       # @private
@@ -386,12 +388,12 @@ module RSpec
 
       # @private
       def self.descendants
-        @_descendants ||= [self] + children.inject([]) {|list, c| list + c.descendants}
+        @_descendants ||= [self] + children.inject([]) { |a, e| a + e.descendants }
       end
 
       ## @private
       def self.parent_groups
-        @parent_groups ||= ancestors.select {|a| a < RSpec::Core::ExampleGroup}
+        @parent_groups ||= ancestors.select { |a| a < RSpec::Core::ExampleGroup }
       end
 
       # @private
@@ -404,7 +406,9 @@ module RSpec
         unless defined?(@@example_groups_configured)
           RSpec.configuration.configure_mock_framework
           RSpec.configuration.configure_expectation_framework
+          # rubocop:disable Style/ClassVars
           @@example_groups_configured = true
+          # rubocop:enable Style/ClassVars
         end
       end
 
@@ -417,9 +421,9 @@ module RSpec
       def self.store_before_context_ivars(example_group_instance)
         return if example_group_instance.instance_variables.empty?
 
-        example_group_instance.instance_variables.each { |ivar|
+        example_group_instance.instance_variables.each do |ivar|
           before_context_ivars[ivar] = example_group_instance.instance_variable_get(ivar)
-        }
+        end
       end
 
       # @private
@@ -460,10 +464,10 @@ module RSpec
           results_for_descendants = ordering_strategy.order(children).map { |child| child.run(reporter) }.all?
           result_for_this_group && results_for_descendants
         rescue Pending::SkipDeclaredInExample => ex
-          for_filtered_examples(reporter) {|example| example.skip_with_exception(reporter, ex) }
+          for_filtered_examples(reporter) { |example| example.skip_with_exception(reporter, ex) }
         rescue Exception => ex
           RSpec.world.wants_to_quit = true if fail_fast?
-          for_filtered_examples(reporter) {|example| example.fail_with_exception(reporter, ex) }
+          for_filtered_examples(reporter) { |example| example.fail_with_exception(reporter, ex) }
         ensure
           run_after_context_hooks(new)
           before_context_ivars.clear
@@ -529,8 +533,8 @@ module RSpec
       # @private
       def self.declaration_line_numbers
         @declaration_line_numbers ||= [metadata[:line_number]] +
-          examples.collect {|e| e.metadata[:line_number]} +
-          children.inject([]) {|l,c| l + c.declaration_line_numbers}
+          examples.map { |e| e.metadata[:line_number] } +
+          children.inject([]) { |a, e| a + e.declaration_line_numbers }
       end
 
       # @private
@@ -540,7 +544,7 @@ module RSpec
 
       # @private
       def self.set_ivars(instance, ivars)
-        ivars.each {|name, value| instance.instance_variable_set(name, value)}
+        ivars.each { |name, value| instance.instance_variable_set(name, value) }
       end
 
       # @private
@@ -559,7 +563,10 @@ module RSpec
         # This will fail if no block is provided, which is effectively the
         # same as failing the example so it will be marked correctly as
         # pending.
-        callback = Proc.new { pending(reason); instance_exec(&block) }
+        callback = Proc.new do
+          pending(reason)
+          instance_exec(&block)
+        end
 
         return options, callback
       end
@@ -599,7 +606,7 @@ module RSpec
 
       # convert to CamelCase
       name = ' ' + group.description
-      name.gsub!(/[^0-9a-zA-Z]+([0-9a-zA-Z])/) { $1.upcase }
+      name.gsub!(/[^0-9a-zA-Z]+([0-9a-zA-Z])/) { Regexp.last_match[1].upcase }
 
       name.lstrip!         # Remove leading whitespace
       name.gsub!(/\W/, '') # JRuby, RBX and others don't like non-ascii in const names
@@ -621,4 +628,3 @@ module RSpec
     end
   end
 end
-

--- a/lib/rspec/core/filter_manager.rb
+++ b/lib/rspec/core/filter_manager.rb
@@ -81,7 +81,7 @@ module RSpec
         # locations is a hash of expanded paths to arrays of line
         # numbers to match against. e.g.
         #   { "path/to/file.rb" => [37, 42] }
-        locations = inclusions.delete(:locations) || Hash.new { |h,k| h[k] = [] }
+        locations = inclusions.delete(:locations) || Hash.new { |h, k| h[k] = [] }
         locations[File.expand_path(file_path)].push(*line_numbers)
         inclusions.add_location(locations)
       end
@@ -93,9 +93,9 @@ module RSpec
       def prune(examples)
         if inclusions.standalone?
           base_exclusions = ExclusionRules.new
-          examples.select {|e| !base_exclusions.include_example?(e) && include?(e) }
+          examples.select { |e| !base_exclusions.include_example?(e) && include?(e) }
         else
-          examples.select {|e| !exclude?(e) && include?(e)}
+          examples.select { |e| !exclude?(e) && include?(e) }
         end
       end
 
@@ -156,9 +156,9 @@ module RSpec
         @rules.merge!(updated).each_key { |k| opposite.delete(k) }
       end
 
-      def add_with_low_priority(_updated)
-        updated = _updated.merge(@rules)
-        opposite.each_pair { |k,v| updated.delete(k) if updated[k] == v }
+      def add_with_low_priority(updated)
+        updated = updated.merge(@rules)
+        opposite.each_pair { |k, v| updated.delete(k) if updated[k] == v }
         @rules.replace(updated)
       end
 
@@ -192,7 +192,7 @@ module RSpec
       end
 
       def description
-        rules.inspect.gsub(PROC_HEX_NUMBER, '').gsub(PROJECT_DIR, '.').gsub(' (lambda)','')
+        rules.inspect.gsub(PROC_HEX_NUMBER, '').gsub(PROJECT_DIR, '.').gsub(' (lambda)', '')
       end
     end
 
@@ -201,19 +201,19 @@ module RSpec
       STANDALONE_FILTERS = [:locations, :full_description]
 
       def add_location(locations)
-        replace_filters({ :locations => locations })
+        replace_filters(:locations => locations)
       end
 
       def add(*args)
-        set_standalone_filter(*args) || super
+        apply_standalone_filter(*args) || super
       end
 
       def add_with_low_priority(*args)
-        set_standalone_filter(*args) || super
+        apply_standalone_filter(*args) || super
       end
 
       def use(*args)
-        set_standalone_filter(*args) || super
+        apply_standalone_filter(*args) || super
       end
 
       def include_example?(example)
@@ -226,13 +226,12 @@ module RSpec
 
     private
 
-      def set_standalone_filter(updated)
+      def apply_standalone_filter(updated)
         return true if standalone?
+        return nil unless is_standalone_filter?(updated)
 
-        if is_standalone_filter?(updated)
-          replace_filters(updated)
-          true
-        end
+        replace_filters(updated)
+        true
       end
 
       def replace_filters(new_rules)
@@ -241,7 +240,7 @@ module RSpec
       end
 
       def is_standalone_filter?(rules)
-        STANDALONE_FILTERS.any? { |key| rules.has_key?(key) }
+        STANDALONE_FILTERS.any? { |key| rules.key?(key) }
       end
     end
 

--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -111,15 +111,15 @@ module RSpec::Core::Formatters
 
     # @private
     def setup_default(output_stream, deprecation_stream)
-      if @formatters.empty?
-        add default_formatter, output_stream
-      end
+      add default_formatter, output_stream if @formatters.empty?
+
       unless @formatters.any? { |formatter| DeprecationFormatter === formatter }
         add DeprecationFormatter, deprecation_stream, output_stream
       end
-      if RSpec.configuration.profile_examples? && !existing_formatter_implements?(:dump_profile)
-        add RSpec::Core::Formatters::ProfileFormatter, output_stream
-      end
+
+      return unless RSpec.configuration.profile_examples? && !existing_formatter_implements?(:dump_profile)
+
+      add RSpec::Core::Formatters::ProfileFormatter, output_stream
     end
 
     # @private
@@ -139,11 +139,11 @@ module RSpec::Core::Formatters
         if line
           call_site = "Formatter added at: #{line}"
         else
-          call_site = "The formatter was added via command line flag or your "+
+          call_site = "The formatter was added via command line flag or your "\
                       "`.rspec` file."
         end
 
-        RSpec.warn_deprecation <<-WARNING.gsub(/\s*\|/,' ')
+        RSpec.warn_deprecation <<-WARNING.gsub(/\s*\|/, ' ')
           |The #{formatter_class} formatter uses the deprecated formatter
           |interface not supported directly by RSpec 3.
           |
@@ -202,9 +202,9 @@ module RSpec::Core::Formatters
         formatter_ref
       elsif string_const?(formatter_ref)
         begin
-          formatter_ref.gsub(/^::/,'').split('::').inject(Object) { |const,string| const.const_get string }
+          formatter_ref.gsub(/^::/, '').split('::').inject(Object) { |a, e| a.const_get e }
         rescue NameError
-          require( path_for(formatter_ref) ) ? retry : raise
+          require(path_for(formatter_ref)) ? retry : raise
         end
       end
     end
@@ -225,8 +225,8 @@ module RSpec::Core::Formatters
     def underscore(camel_cased_word)
       word = camel_cased_word.to_s.dup
       word.gsub!(/::/, '/')
-      word.gsub!(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
-      word.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+      word.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+      word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
       word.tr!("-", "_")
       word.downcase!
       word

--- a/lib/rspec/core/formatters/base_formatter.rb
+++ b/lib/rspec/core/formatters/base_formatter.rb
@@ -10,7 +10,6 @@ module RSpec
       # @see RSpec::Core::Reporter
       # @see RSpec::Core::Formatters::Protocol
       class BaseFormatter
-
         # all formatters inheriting from this formatter will receive these notifications
         Formatters.register self, :start, :example_group_started, :close
         attr_accessor :example_group
@@ -45,7 +44,7 @@ module RSpec
         #
         # @param notification [NullNotification]
         # @see RSpec::Core::Formatters::Protocol#close
-        def close(notification)
+        def close(_notification)
           restore_sync_output
         end
 
@@ -56,13 +55,12 @@ module RSpec
         end
 
         def restore_sync_output
-          output.sync = @old_sync if output_supports_sync and !output.closed?
+          output.sync = @old_sync if output_supports_sync && !output.closed?
         end
 
         def output_supports_sync
           output.respond_to?(:sync=)
         end
-
       end
     end
   end

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -4,15 +4,14 @@ RSpec::Support.require_rspec_core "formatters/console_codes"
 module RSpec
   module Core
     module Formatters
-
       # Base for all of RSpec's built-in formatters. See RSpec::Core::Formatters::BaseFormatter
       # to learn more about all of the methods called by the reporter.
       #
       # @see RSpec::Core::Formatters::BaseFormatter
       # @see RSpec::Core::Reporter
       class BaseTextFormatter < BaseFormatter
-        Formatters.register self, :message, :dump_summary, :dump_failures,
-                                  :dump_pending, :seed
+        Formatters.register self,
+                            :message, :dump_summary, :dump_failures, :dump_pending, :seed
 
         # @method message
         # @api public
@@ -65,13 +64,12 @@ module RSpec
         # up resources, e.g. open streams, etc.
         #
         # @param notification [NullNotification]
-        def close(notification)
+        def close(_notification)
           return unless IO === output
           return if output.closed? || output == $stdout
 
           output.close
         end
-
       end
     end
   end

--- a/lib/rspec/core/formatters/console_codes.rb
+++ b/lib/rspec/core/formatters/console_codes.rb
@@ -30,7 +30,7 @@ module RSpec
         def console_code_for(code_or_symbol)
           if RSpec.configuration.respond_to?(:"#{code_or_symbol}_color")
             console_code_for configuration_color(code_or_symbol)
-          elsif VT100_CODE_VALUES.has_key?(code_or_symbol)
+          elsif VT100_CODE_VALUES.key?(code_or_symbol)
             code_or_symbol
           else
             VT100_CODES.fetch(code_or_symbol) do
@@ -58,7 +58,6 @@ module RSpec
         def configuration_color(code)
           RSpec.configuration.__send__(:"#{code}_color")
         end
-
       end
     end
   end

--- a/lib/rspec/core/formatters/deprecation_formatter.rb
+++ b/lib/rspec/core/formatters/deprecation_formatter.rb
@@ -37,7 +37,7 @@ module RSpec
           @seen_deprecations << notification
         end
 
-        def deprecation_summary(notification)
+        def deprecation_summary(_notification)
           printer.deprecation_summary
         end
 
@@ -57,7 +57,7 @@ module RSpec
           |deprecation warnings into errors, giving you the full backtrace.
         EOS
 
-        DEPRECATION_STREAM_NOTICE = "Pass `--deprecation-out` or set " +
+        DEPRECATION_STREAM_NOTICE = "Pass `--deprecation-out` or set " \
           "`config.deprecation_stream` to a file for full output."
 
         SpecifiedDeprecationMessage = Struct.new(:type) do
@@ -213,7 +213,6 @@ module RSpec
             puts RAISE_ERROR_CONFIG_NOTICE
           end
         end
-
       end
     end
 

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -6,7 +6,7 @@ module RSpec
       # @private
       class DocumentationFormatter < BaseTextFormatter
         Formatters.register self, :example_group_started, :example_group_finished,
-                                  :example_passed, :example_pending, :example_failed
+                            :example_passed, :example_pending, :example_failed
 
         def initialize(output)
           super
@@ -20,7 +20,7 @@ module RSpec
           @group_level += 1
         end
 
-        def example_group_finished(notification)
+        def example_group_finished(_notification)
           @group_level -= 1
         end
 
@@ -46,7 +46,7 @@ module RSpec
           ConsoleCodes.wrap("#{current_indentation}#{example.description.strip} (PENDING: #{message})", :pending)
         end
 
-        def failure_output(example, exception)
+        def failure_output(example, _exception)
           ConsoleCodes.wrap("#{current_indentation}#{example.description.strip} (FAILED - #{next_failure_index})", :failure)
         end
 
@@ -62,7 +62,6 @@ module RSpec
         def example_group_chain
           example_group.parent_groups.reverse
         end
-
       end
     end
   end

--- a/lib/rspec/core/formatters/helpers.rb
+++ b/lib/rspec/core/formatters/helpers.rb
@@ -3,7 +3,6 @@ module RSpec
     module Formatters
       # Formatters helpers
       module Helpers
-
         # @private
         SUB_SECOND_PRECISION = 5
 
@@ -22,9 +21,9 @@ module RSpec
         #    format_duration(135.14) #=> "2 minutes 15.14 seconds"
         def self.format_duration(duration)
           precision = case
-                      when duration < 1;    SUB_SECOND_PRECISION
-                      when duration < 120;  DEFAULT_PRECISION
-                      when duration < 300;  1
+                      when duration < 1 then    SUB_SECOND_PRECISION
+                      when duration < 120 then  DEFAULT_PRECISION
+                      when duration < 300 then  1
                       else                  0
                       end
 
@@ -54,9 +53,9 @@ module RSpec
         # The precision used is set in {Helpers::SUB_SECOND_PRECISION} and {Helpers::DEFAULT_PRECISION}.
         #
         # @see #strip_trailing_zeroes
-        def self.format_seconds(float, precision = nil)
+        def self.format_seconds(float, precision=nil)
           precision ||= (float < 1) ? SUB_SECOND_PRECISION : DEFAULT_PRECISION
-          formatted = sprintf("%.#{precision}f", float)
+          formatted = "%.#{precision}f" % float
           strip_trailing_zeroes(formatted)
         end
 

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -7,8 +7,8 @@ module RSpec
       # @private
       class HtmlFormatter < BaseFormatter
         Formatters.register self, :start, :example_group_started, :start_dump,
-                                  :example_started, :example_passed, :example_failed,
-                                  :example_pending, :dump_summary
+                            :example_started, :example_passed, :example_failed,
+                            :example_pending, :dump_summary
 
         def initialize(output)
           super(output)
@@ -30,25 +30,23 @@ module RSpec
           @example_group_red = false
           @example_group_number += 1
 
-          unless example_group_number == 1
-            @printer.print_example_group_end
-          end
-          @printer.print_example_group_start( example_group_number, notification.group.description, notification.group.parent_groups.size )
+          @printer.print_example_group_end unless example_group_number == 1
+          @printer.print_example_group_start(example_group_number, notification.group.description, notification.group.parent_groups.size)
           @printer.flush
         end
 
-        def start_dump(notification)
+        def start_dump(_notification)
           @printer.print_example_group_end
           @printer.flush
         end
 
-        def example_started(notification)
+        def example_started(_notification)
           @example_number += 1
         end
 
         def example_passed(passed)
           @printer.move_progress(percent_done)
-          @printer.print_example_passed( passed.example.description, passed.example.execution_result.run_time )
+          @printer.print_example_passed(passed.example.description, passed.example.execution_result.run_time)
           @printer.flush
         end
 
@@ -70,13 +68,13 @@ module RSpec
 
           exception = failure.exception
           exception_details = if exception
-            {
-              :message => exception.message,
-              :backtrace => failure.formatted_backtrace.join("\n")
-            }
-          else
-            false
-          end
+                                {
+                                  :message => exception.message,
+                                  :backtrace => failure.formatted_backtrace.join("\n")
+                                }
+                              else
+                                false
+                              end
           extra = extra_failure_content(failure)
 
           @printer.print_example_failed(
@@ -97,7 +95,7 @@ module RSpec
           @printer.make_header_yellow unless @header_red
           @printer.make_example_group_header_yellow(example_group_number) unless @example_group_red
           @printer.move_progress(percent_done)
-          @printer.print_example_pending( example.description, example.execution_result.pending_message )
+          @printer.print_example_pending(example.description, example.execution_result.pending_message)
           @printer.flush
         end
 
@@ -113,6 +111,9 @@ module RSpec
 
       private
 
+        # If these methods are declared with attr_reader Ruby will issue a warning because they are private
+        # rubocop:disable Style/TrivialAccessors
+
         # The number of the currently running example_group
         def example_group_number
           @example_group_number
@@ -122,6 +123,7 @@ module RSpec
         def example_number
           @example_number
         end
+        # rubocop:enable Style/TrivialAccessors
 
         def percent_done
           result = 100.0
@@ -136,12 +138,11 @@ module RSpec
         #
         def extra_failure_content(failure)
           RSpec::Support.require_rspec_core "formatters/snippet_extractor"
-          backtrace = failure.exception.backtrace.map {|line| RSpec.configuration.backtrace_formatter.backtrace_line(line)}
+          backtrace = failure.exception.backtrace.map { |line| RSpec.configuration.backtrace_formatter.backtrace_line(line) }
           backtrace.compact!
           @snippet_extractor ||= SnippetExtractor.new
           "    <pre class=\"ruby\"><code>#{@snippet_extractor.snippet(backtrace)}</code></pre>"
         end
-
       end
     end
   end

--- a/lib/rspec/core/formatters/html_printer.rb
+++ b/lib/rspec/core/formatters/html_printer.rb
@@ -27,12 +27,14 @@ module RSpec
         end
 
         def print_example_passed(description, run_time)
-          formatted_run_time = sprintf("%.5f", run_time)
+          formatted_run_time = "%.5f" % run_time
           @output.puts "    <dd class=\"example passed\"><span class=\"passed_spec_name\">#{h(description)}</span><span class='duration'>#{formatted_run_time}s</span></dd>"
         end
 
-        def print_example_failed(pending_fixed, description, run_time, failure_id, exception, extra_content, escape_backtrace = false)
-          formatted_run_time = sprintf("%.5f", run_time)
+        # rubocop:disable Style/ParameterLists
+        def print_example_failed(pending_fixed, description, run_time, failure_id, exception, extra_content, escape_backtrace=false)
+          # rubocop:enable Style/ParameterLists
+          formatted_run_time = "%.5f" % run_time
 
           @output.puts "    <dd class=\"example #{pending_fixed ? 'pending_fixed' : 'failed'}\">"
           @output.puts "      <span class=\"failed_spec_name\">#{h(description)}</span>"
@@ -60,7 +62,7 @@ module RSpec
           totals << "#{failure_count} failure#{'s' unless failure_count == 1}"
           totals << ", #{pending_count} pending" if pending_count > 0
 
-          formatted_duration = sprintf("%.5f", duration)
+          formatted_duration = "%.5f" % duration
 
           @output.puts "<script type=\"text/javascript\">document.getElementById('duration').innerHTML = \"Finished in <strong>#{formatted_duration} seconds</strong>\";</script>"
           @output.puts "<script type=\"text/javascript\">document.getElementById('totals').innerHTML = \"#{totals}\";</script>"
@@ -395,7 +397,6 @@ EOF
 </head>
 <body>
 EOF
-
       end
     end
   end

--- a/lib/rspec/core/formatters/json_formatter.rb
+++ b/lib/rspec/core/formatters/json_formatter.rb
@@ -32,7 +32,8 @@ module RSpec
         def stop(notification)
           @output_hash[:examples] = notification.examples.map do |example|
             format_example(example).tap do |hash|
-              if e=example.exception
+              e = example.exception
+              if e
                 hash[:exception] =  {
                   :class => e.class.name,
                   :message => e.message,
@@ -43,7 +44,7 @@ module RSpec
           end
         end
 
-        def close(notification)
+        def close(_notification)
           output.write @output_hash.to_json
           output.close if IO === output && output != $stdout
         end

--- a/lib/rspec/core/formatters/profile_formatter.rb
+++ b/lib/rspec/core/formatters/profile_formatter.rb
@@ -3,7 +3,6 @@ RSpec::Support.require_rspec_core "formatters/console_codes"
 module RSpec
   module Core
     module Formatters
-
       # @api private
       # Formatter for providing profile output
       class ProfileFormatter
@@ -60,7 +59,6 @@ module RSpec
         def bold(text)
           ConsoleCodes.wrap(text, :bold)
         end
-
       end
     end
   end

--- a/lib/rspec/core/formatters/progress_formatter.rb
+++ b/lib/rspec/core/formatters/progress_formatter.rb
@@ -7,19 +7,19 @@ module RSpec
       class ProgressFormatter < BaseTextFormatter
         Formatters.register self, :example_passed, :example_pending, :example_failed, :start_dump
 
-        def example_passed(notification)
+        def example_passed(_notification)
           output.print ConsoleCodes.wrap('.', :success)
         end
 
-        def example_pending(notification)
+        def example_pending(_notification)
           output.print ConsoleCodes.wrap('*', :pending)
         end
 
-        def example_failed(notification)
+        def example_failed(_notification)
           output.print ConsoleCodes.wrap('F', :failure)
         end
 
-        def start_dump(notification)
+        def start_dump(_notification)
           output.puts
         end
       end

--- a/lib/rspec/core/formatters/protocol.rb
+++ b/lib/rspec/core/formatters/protocol.rb
@@ -17,7 +17,6 @@ module RSpec
       # @see RSpec::Core::Formatters::BaseTextFormatter
       # @see RSpec::Core::Reporter
       class Protocol
-
         # @method initialize
         # @api public
         #
@@ -158,7 +157,6 @@ module RSpec
         # up resources, e.g. open streams, etc.
         #
         # @param notification [NullNotification]
-
       end
     end
   end

--- a/lib/rspec/core/formatters/snippet_extractor.rb
+++ b/lib/rspec/core/formatters/snippet_extractor.rb
@@ -21,10 +21,12 @@ module RSpec
 
         begin
           require 'coderay'
+          # rubocop:disable Style/ClassVars
           @@converter = CoderayConverter.new
         rescue LoadError
           @@converter = NullConverter.new
         end
+        # rubocop:enable Style/ClassVars
 
         # @api private
         #
@@ -50,8 +52,8 @@ module RSpec
         # @see #lines_around
         def snippet_for(error_line)
           if error_line =~ /(.*):(\d+)/
-            file = $1
-            line = $2.to_i
+            file = Regexp.last_match[1]
+            line = Regexp.last_match[2].to_i
             [lines_around(file, line), line]
           else
             ["# Couldn't get snippet for #{error_line}", 1]
@@ -68,8 +70,8 @@ module RSpec
         def lines_around(file, line)
           if File.file?(file)
             lines = File.read(file).split("\n")
-            min = [0, line-3].max
-            max = [line+1, lines.length-1].min
+            min = [0, line - 3].max
+            max = [line + 1, lines.length - 1].min
             selected_lines = []
             selected_lines.join("\n")
             lines[min..max].join("\n")
@@ -90,13 +92,12 @@ module RSpec
         def post_process(highlighted, offending_line)
           new_lines = []
           highlighted.split("\n").each_with_index do |line, i|
-            new_line = "<span class=\"linenum\">#{offending_line+i-2}</span>#{line}"
+            new_line = "<span class=\"linenum\">#{offending_line + i - 2}</span>#{line}"
             new_line = "<span class=\"offending\">#{new_line}</span>" if i == 2
             new_lines << new_line
           end
           new_lines.join("\n")
         end
-
       end
     end
   end

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -320,7 +320,8 @@ module RSpec
       # @private
       # Holds the various registered hooks.
       def hooks
-        @hooks ||= HookCollections.new(self,
+        @hooks ||= HookCollections.new(
+          self,
           :around => { :example => AroundHookCollection.new },
           :before => { :example => HookCollection.new, :context => HookCollection.new, :suite => HookCollection.new },
           :after  => { :example => HookCollection.new, :context => HookCollection.new, :suite => HookCollection.new }
@@ -399,7 +400,7 @@ EOS
         end
 
         attr_reader :hooks
-        protected   :hooks
+        protected :hooks
 
         alias append push
         alias prepend unshift
@@ -413,7 +414,7 @@ EOS
       class HookCollection < BaseHookCollection
         def for(example_or_group)
           self.class.
-            new(hooks.select {|hook| hook.options_apply?(example_or_group)}).
+            new(hooks.select { |hook| hook.options_apply?(example_or_group) }).
             with(example_or_group)
         end
 
@@ -423,14 +424,14 @@ EOS
         end
 
         def run
-          hooks.each {|h| h.run(@example)}
+          hooks.each { |h| h.run(@example) }
         end
       end
 
       # @private
       class AroundHookCollection < BaseHookCollection
         def for(example, initial_procsy=nil)
-          self.class.new(hooks.select {|hook| hook.options_apply?(example)}).
+          self.class.new(hooks.select { |hook| hook.options_apply?(example) }).
             with(example, initial_procsy)
         end
 
@@ -516,7 +517,7 @@ EOS
         def process(host, globals, position, scope)
           globals[position][scope].each do |hook|
             next unless scope == :example || hook.options_apply?(host)
-            next if host.parent_groups.any? {|a| a.hooks[position][scope].include?(hook)}
+            next if host.parent_groups.any? { |a| a.hooks[position][scope].include?(hook) }
             self[position][scope] << hook
           end
         end

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -145,12 +145,12 @@ module RSpec
           end
         end
 
-        def self.fetch(key, &block)
+        def self.fetch(key, &_block)
           description = if key == :subject
-            "subject"
-          else
-            "let declaration `#{key}`"
-          end
+                          "subject"
+                        else
+                          "let declaration `#{key}`"
+                        end
 
           raise <<-EOS
 #{description} accessed in #{article} #{hook_expression} hook at:

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -6,89 +6,89 @@ module RSpec
     # having metadata be a raw hash (not a custom subclass), so externalizing
     # this filtering logic helps us move in that direction.
     module MetadataFilter
-      extend self
+      class << self
+        # @private
+        def any_apply?(filters, metadata)
+          filters.any? { |k, v| filter_applies?(k, v, metadata) }
+        end
 
-      # @private
-      def any_apply?(filters, metadata)
-        filters.any? { |k, v| filter_applies?(k, v, metadata) }
-      end
+        # @private
+        def all_apply?(filters, metadata)
+          filters.all? { |k, v| filter_applies?(k, v, metadata) }
+        end
 
-      # @private
-      def all_apply?(filters, metadata)
-        filters.all? { |k, v| filter_applies?(k, v, metadata) }
-      end
+        # @private
+        def filter_applies?(key, value, metadata)
+          silence_metadata_example_group_deprecations do
+            return filter_applies_to_any_value?(key, value, metadata) if Array === metadata[key] && !(Proc === value)
+            return location_filter_applies?(value, metadata)          if key == :locations
+            return filters_apply?(key, value, metadata)               if Hash === value
 
-      # @private
-      def filter_applies?(key, value, metadata)
-        silence_metadata_example_group_deprecations do
-          return filter_applies_to_any_value?(key, value, metadata) if Array === metadata[key] && !(Proc === value)
-          return location_filter_applies?(value, metadata)          if key == :locations
-          return filters_apply?(key, value, metadata)               if Hash === value
+            return false unless metadata.key?(key)
 
-          return false unless metadata.has_key?(key)
-
-          case value
-          when Regexp
-            metadata[key] =~ value
-          when Proc
-            case value.arity
-            when 0 then value.call
-            when 2 then value.call(metadata[key], metadata)
-            else value.call(metadata[key])
+            case value
+            when Regexp
+              metadata[key] =~ value
+            when Proc
+              case value.arity
+              when 0 then value.call
+              when 2 then value.call(metadata[key], metadata)
+              else value.call(metadata[key])
+              end
+            else
+              metadata[key].to_s == value.to_s
             end
-          else
-            metadata[key].to_s == value.to_s
           end
         end
-      end
 
-    private
+      private
 
-      def filter_applies_to_any_value?(key, value, metadata)
-        metadata[key].any? {|v| filter_applies?(key, v, {key => value})}
-      end
-
-      def location_filter_applies?(locations, metadata)
-        # it ignores location filters for other files
-        line_number = example_group_declaration_line(locations, metadata)
-        line_number ? line_number_filter_applies?(line_number, metadata) : true
-      end
-
-      def line_number_filter_applies?(line_numbers, metadata)
-        preceding_declaration_lines = line_numbers.map {|n| RSpec.world.preceding_declaration_line(n)}
-        !(relevant_line_numbers(metadata) & preceding_declaration_lines).empty?
-      end
-
-      def relevant_line_numbers(metadata)
-        return [] unless metadata
-        [metadata[:line_number]].compact + (relevant_line_numbers(parent_of metadata))
-      end
-
-      def example_group_declaration_line(locations, metadata)
-        parent = parent_of(metadata)
-        return nil unless parent
-        locations[File.expand_path(parent[:file_path])]
-      end
-
-      def filters_apply?(key, value, metadata)
-        subhash = metadata[key]
-        return false unless Hash === subhash || HashImitatable === subhash
-        value.all? { |k, v| filter_applies?(k, v, subhash) }
-      end
-
-      def parent_of(metadata)
-        if metadata.key?(:example_group)
-          metadata[:example_group]
-        else
-          metadata[:parent_example_group]
+        def filter_applies_to_any_value?(key, value, metadata)
+          metadata[key].any? { |v| filter_applies?(key, v,  key => value) }
         end
-      end
 
-      def silence_metadata_example_group_deprecations
-        RSpec.thread_local_metadata[:silence_metadata_example_group_deprecations] = true
-        yield
-      ensure
-        RSpec.thread_local_metadata.delete(:silence_metadata_example_group_deprecations)
+        def location_filter_applies?(locations, metadata)
+          # it ignores location filters for other files
+          line_number = example_group_declaration_line(locations, metadata)
+          line_number ? line_number_filter_applies?(line_number, metadata) : true
+        end
+
+        def line_number_filter_applies?(line_numbers, metadata)
+          preceding_declaration_lines = line_numbers.map { |n| RSpec.world.preceding_declaration_line(n) }
+          !(relevant_line_numbers(metadata) & preceding_declaration_lines).empty?
+        end
+
+        def relevant_line_numbers(metadata)
+          return [] unless metadata
+          [metadata[:line_number]].compact + (relevant_line_numbers(parent_of metadata))
+        end
+
+        def example_group_declaration_line(locations, metadata)
+          parent = parent_of(metadata)
+          return nil unless parent
+          locations[File.expand_path(parent[:file_path])]
+        end
+
+        def filters_apply?(key, value, metadata)
+          subhash = metadata[key]
+          return false unless Hash === subhash || HashImitatable === subhash
+          value.all? { |k, v| filter_applies?(k, v, subhash) }
+        end
+
+        def parent_of(metadata)
+          if metadata.key?(:example_group)
+            metadata[:example_group]
+          else
+            metadata[:parent_example_group]
+          end
+        end
+
+        def silence_metadata_example_group_deprecations
+          RSpec.thread_local_metadata[:silence_metadata_example_group_deprecations] = true
+          yield
+        ensure
+          RSpec.thread_local_metadata.delete(:silence_metadata_example_group_deprecations)
+        end
       end
     end
   end

--- a/lib/rspec/core/mocking_adapters/flexmock.rb
+++ b/lib/rspec/core/mocking_adapters/flexmock.rb
@@ -10,7 +10,9 @@ module RSpec
       module Flexmock
         include ::FlexMock::MockContainer
 
-        def self.framework_name; :flexmock end
+        def self.framework_name
+          :flexmock
+        end
 
         def setup_mocks_for_rspec
           # No setup required

--- a/lib/rspec/core/mocking_adapters/mocha.rb
+++ b/lib/rspec/core/mocking_adapters/mocha.rb
@@ -29,7 +29,9 @@ module RSpec
     module MockingAdapters
       # @private
       module Mocha
-        def self.framework_name; :mocha end
+        def self.framework_name
+          :mocha
+        end
 
         # Mocha::Standalone was deprecated as of Mocha 0.9.7.
         begin

--- a/lib/rspec/core/mocking_adapters/null.rb
+++ b/lib/rspec/core/mocking_adapters/null.rb
@@ -4,7 +4,9 @@ module RSpec
       # @private
       module Null
         def setup_mocks_for_rspec; end
+
         def verify_mocks_for_rspec; end
+
         def teardown_mocks_for_rspec; end
       end
     end

--- a/lib/rspec/core/mocking_adapters/rr.rb
+++ b/lib/rspec/core/mocking_adapters/rr.rb
@@ -8,7 +8,9 @@ module RSpec
     module MockingAdapters
       # @private
       module RR
-        def self.framework_name; :rr end
+        def self.framework_name
+          :rr
+        end
 
         include ::RR::Extensions::InstanceMethods
 

--- a/lib/rspec/core/mocking_adapters/rspec.rb
+++ b/lib/rspec/core/mocking_adapters/rspec.rb
@@ -7,7 +7,9 @@ module RSpec
       module RSpec
         include ::RSpec::Mocks::ExampleMethods
 
-        def self.framework_name; :rspec end
+        def self.framework_name
+          :rspec
+        end
 
         def self.configuration
           ::RSpec::Mocks.configuration

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -5,7 +5,6 @@ module RSpec::Core
   # Notifications are value objects passed to formatters to provide them
   # with information about a particular event of interest.
   module Notifications
-
     # @private
     class NullColorizer
       def wrap(line, _code_or_symbol)
@@ -55,7 +54,6 @@ module RSpec::Core
     #   end
     #
     class ExamplesNotification
-
       def initialize(reporter)
         @reporter = reporter
       end
@@ -78,18 +76,18 @@ module RSpec::Core
       # @return [Array(Rspec::Core::Notifications::ExampleNotification]
       #         returns examples as notifications
       def notifications
-        @notifications ||= format(examples)
+        @notifications ||= format_examples(examples)
       end
 
       # @return [Array(Rspec::Core::Notifications::FailedExampleNotification]
       #         returns failed examples as notifications
       def failure_notifications
-        @failed_notifications ||= format(failed_examples)
+        @failed_notifications ||= format_examples(failed_examples)
       end
 
       # @return [String] The list of failed examples, fully formatted in the way that
       #   RSpec's built-in formatters emit.
-      def fully_formatted_failed_examples(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+      def fully_formatted_failed_examples(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted = "\nFailures:\n"
 
         failure_notifications.each_with_index do |failure, index|
@@ -101,15 +99,15 @@ module RSpec::Core
 
       # @return [String] The list of pending examples, fully formatted in the way that
       #   RSpec's built-in formatters emit.
-      def fully_formatted_pending_examples(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+      def fully_formatted_pending_examples(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted = "\nPending:\n"
 
         pending_examples.each do |example|
           formatted_caller = RSpec.configuration.backtrace_formatter.backtrace_line(example.location)
 
           formatted <<
-            "  #{colorizer.wrap(example.full_description, :pending)}\n" <<
-            "    # #{colorizer.wrap(example.execution_result.pending_message, :detail)}\n" <<
+            "  #{colorizer.wrap(example.full_description, :pending)}\n" \
+            "    # #{colorizer.wrap(example.execution_result.pending_message, :detail)}\n" \
             "    # #{colorizer.wrap(formatted_caller, :detail)}\n"
         end
 
@@ -118,12 +116,11 @@ module RSpec::Core
 
     private
 
-      def format(examples)
+      def format_examples(examples)
         examples.map do |example|
           ExampleNotification.for(example)
         end
       end
-
     end
 
     # The `FailedExampleNotification` extends `ExampleNotification` with
@@ -162,7 +159,7 @@ module RSpec::Core
       #
       # @param colorizer [#wrap] An object to colorize the message_lines by
       # @return [Array(String)] The example failure message colorized
-      def colorized_message_lines(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+      def colorized_message_lines(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         add_shared_group_line(failure_lines, colorizer).map do |line|
           colorizer.wrap line, RSpec.configuration.failure_color
         end
@@ -179,7 +176,7 @@ module RSpec::Core
       #
       # @param colorizer [#wrap] An object to colorize the message_lines by
       # @return [Array(String)] the examples colorized backtrace lines
-      def colorized_formatted_backtrace(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+      def colorized_formatted_backtrace(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted_backtrace.map do |backtrace_info|
           colorizer.wrap "# #{backtrace_info}", RSpec.configuration.detail_color
         end
@@ -187,7 +184,7 @@ module RSpec::Core
 
       # @return [String] The failure information fully formatted in the way that
       #   RSpec's built-in formatters emit.
-      def fully_formatted(failure_number, colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+      def fully_formatted(failure_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted = "\n  #{failure_number}) #{description}\n"
 
         colorized_message_lines(colorizer).each do |line|
@@ -218,7 +215,7 @@ module RSpec::Core
 
       def exception_class_name
         name = exception.class.name.to_s
-        name ="(anonymous error class)" if name == ''
+        name = "(anonymous error class)" if name == ''
         name
       end
 
@@ -248,8 +245,8 @@ module RSpec::Core
       def shared_group_line
         @shared_group_line ||=
           if shared_group
-             "Shared Example Group: \"#{shared_group.metadata[:shared_group_name]}\"" +
-              " called from #{backtrace_formatter.backtrace_line(shared_group.location)}"
+            "Shared Example Group: \"#{shared_group.metadata[:shared_group_name]}\"" \
+             " called from #{backtrace_formatter.backtrace_line(shared_group.location)}"
           else
             ""
           end
@@ -260,7 +257,8 @@ module RSpec::Core
       end
 
       def read_failed_line
-        unless matching_line = find_failed_line
+        matching_line = find_failed_line
+        unless matching_line
           return "Unable to find matching line from backtrace"
         end
 
@@ -278,7 +276,7 @@ module RSpec::Core
 
       def find_failed_line
         path = File.expand_path(example.file_path)
-        exception.backtrace.detect do |line|
+        exception.backtrace.find do |line|
           match = line.match(/(.+?):(\d+)(|:\d+)/)
           match && match[1].downcase == path.downcase
         end
@@ -311,7 +309,7 @@ module RSpec::Core
       #
       # @param colorizer [#wrap] An object to colorize the message_lines by
       # @return [Array(String)] The example failure message colorized
-      def colorized_message_lines(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+      def colorized_message_lines(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         message_lines.map { |line| colorizer.wrap(line, RSpec.configuration.fixed_color) }
       end
     end
@@ -401,7 +399,7 @@ module RSpec::Core
       # @param colorizer [#wrap] An object which supports wrapping text with
       #                          specific colors.
       # @return [String] A colorized results line.
-      def colorized_totals_line(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+      def colorized_totals_line(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         if failure_count > 0
           colorizer.wrap(totals_line, RSpec.configuration.failure_color)
         elsif pending_count > 0
@@ -418,7 +416,7 @@ module RSpec::Core
       # @param colorizer [#wrap] An object which supports wrapping text with
       #                          specific colors.
       # @return [String] A colorized summary line.
-      def colorized_rerun_commands(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+      def colorized_rerun_commands(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         "\nFailed examples:\n\n" +
         failed_examples.map do |example|
           colorizer.wrap("rspec #{example.location}",     RSpec.configuration.failure_color) + " " +
@@ -439,7 +437,7 @@ module RSpec::Core
 
       # @return [String] The summary information fully formatted in the way that
       #   RSpec's built-in formatters emit.
-      def fully_formatted(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+      def fully_formatted(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted = "\nFinished in #{formatted_duration} " \
                     "(files took #{formatted_load_time} to load)\n" \
                     "#{colorized_totals_line(colorizer)}\n"
@@ -502,9 +500,8 @@ module RSpec::Core
           location_hash = example_groups[location] ||= Hash.new(0)
           location_hash[:total_time]  += example.execution_result.run_time
           location_hash[:count]       += 1
-          unless location_hash.has_key?(:description)
-            location_hash[:description] = example.example_group.top_level_description
-          end
+          next if location_hash.key?(:description)
+          location_hash[:description] = example.example_group.top_level_description
         end
 
         # stop if we've only one example group
@@ -540,6 +537,5 @@ module RSpec::Core
     # currently require no information, but we may wish to extend in future.
     class NullNotification
     end
-
   end
 end

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -11,7 +11,7 @@ module RSpec::Core
     def parse(args)
       return {} if args.empty?
 
-      options = args.delete('--tty') ? {:tty => true} : {}
+      options = args.delete('--tty') ? { :tty => true } : {}
       begin
         parser(options).parse!(args)
       rescue OptionParser::InvalidOption => e
@@ -51,11 +51,11 @@ module RSpec::Core
           options[:order] = "rand:#{seed}"
         end
 
-        parser.on('--fail-fast', 'Abort the run on first failure.') do |o|
+        parser.on('--fail-fast', 'Abort the run on first failure.') do |_o|
           options[:fail_fast] = true
         end
 
-        parser.on('--no-fail-fast', 'Do not abort the run on first failure.') do |o|
+        parser.on('--no-fail-fast', 'Do not abort the run on first failure.') do |_o|
           options[:fail_fast] = false
         end
 
@@ -64,7 +64,7 @@ module RSpec::Core
         end
 
         parser.on('--dry-run', 'Print the formatter output of your suite without',
-                  '  running any examples or hooks') do |o|
+                  '  running any examples or hooks') do |_o|
           options[:dry_run] = true
         end
 
@@ -76,7 +76,7 @@ module RSpec::Core
           options[:drb_port] = o.to_i
         end
 
-        parser.on('--init', 'Initialize your project with RSpec.') do |cmd|
+        parser.on('--init', 'Initialize your project with RSpec.') do |_cmd|
           RSpec::Support.require_rspec_core "project_initializer"
           ProjectInitializer.new.run
           exit
@@ -85,11 +85,11 @@ module RSpec::Core
         parser.separator("\n  **** Output ****\n\n")
 
         parser.on('-f', '--format FORMATTER', 'Choose a formatter.',
-                '  [p]rogress (default - dots)',
-                '  [d]ocumentation (group and example names)',
-                '  [h]tml',
-                '  [j]son',
-                '  custom formatter class name') do |o|
+                  '  [p]rogress (default - dots)',
+                  '  [d]ocumentation (group and example names)',
+                  '  [h]tml',
+                  '  [j]son',
+                  '  custom formatter class name') do |o|
           options[:formatters] ||= []
           options[:formatters] << [o]
         end
@@ -107,7 +107,7 @@ module RSpec::Core
           options[:deprecation_stream] = file
         end
 
-        parser.on('-b', '--backtrace', 'Enable full backtrace.') do |o|
+        parser.on('-b', '--backtrace', 'Enable full backtrace.') do |_o|
           options[:full_backtrace] = true
         end
 
@@ -124,10 +124,10 @@ module RSpec::Core
                                          begin
                                            Integer(argument)
                                          rescue ArgumentError
-                                           RSpec.warning "Non integer specified as profile count, seperate " +
-                                                       "your path from options with -- e.g. " +
+                                           RSpec.warning "Non integer specified as profile count, seperate " \
+                                                       "your path from options with -- e.g. " \
                                                        "`rspec --profile -- #{argument}`",
-                                                       :call_site => nil
+                                                         :call_site => nil
                                            true
                                          end
                                        end
@@ -158,7 +158,7 @@ FILTERING
         end
 
         parser.on('-e', '--example STRING', "Run examples whose full nested names include STRING (may be",
-                                            "  used more than once)") do |o|
+                  "  used more than once)") do |o|
           (options[:full_description] ||= []) << Regexp.compile(Regexp.escape(o))
         end
 
@@ -169,25 +169,25 @@ FILTERING
                   '  - TAG is always converted to a symbol') do |tag|
           filter_type = tag =~ /^~/ ? :exclusion_filter : :inclusion_filter
 
-          name,value = tag.gsub(/^(~@|~|@)/, '').split(':',2)
+          name, value = tag.gsub(/^(~@|~|@)/, '').split(':', 2)
           name = name.to_sym
 
           options[filter_type] ||= {}
           options[filter_type][name] = case value
-                                         when  nil        then true # The default value for tags is true
-                                         when 'true'      then true
-                                         when 'false'     then false
-                                         when 'nil'       then nil
-                                         when /^:/        then value[1..-1].to_sym
-                                         when /^\d+$/     then Integer(value)
-                                         when /^\d+.\d+$/ then Float(value)
+                                       when  nil        then true # The default value for tags is true
+                                       when 'true'      then true
+                                       when 'false'     then false
+                                       when 'nil'       then nil
+                                       when /^:/        then value[1..-1].to_sym
+                                       when /^\d+$/     then Integer(value)
+                                       when /^\d+.\d+$/ then Float(value)
                                        else
                                          value
                                        end
         end
 
         parser.on('--default-path PATH', 'Set the default path where RSpec looks for examples (can',
-                                         '  be a path to a file or a directory).') do |path|
+                  '  be a path to a file or a directory).') do |path|
           options[:default_path] = path
         end
 
@@ -205,7 +205,7 @@ FILTERING
 
         parser.on_tail('-h', '--help', "You're looking at it.") do
           # removing the blank invalid options from the output
-          puts parser.to_s.gsub(/^\s+(#{invalid_options.join('|')})\s*$\n/,'')
+          puts parser.to_s.gsub(/^\s+(#{invalid_options.join('|')})\s*$\n/, '')
           exit
         end
 

--- a/lib/rspec/core/ordering.rb
+++ b/lib/rspec/core/ordering.rb
@@ -123,29 +123,29 @@ module RSpec
 
         def order=(type)
           order, seed = type.to_s.split(':')
-          @seed = seed = seed.to_i if seed
+          @seed = seed.to_i if seed
 
           ordering_name = if order.include?('rand')
-            :random
-          elsif order == 'defined'
-            :defined
-          end
+                            :random
+                          elsif order == 'defined'
+                            :defined
+                          end
 
           register_ordering(:global, ordering_registry.fetch(ordering_name)) if ordering_name
         end
 
         def force(hash)
-          if hash.has_key?(:seed)
+          if hash.key?(:seed)
             self.seed = hash[:seed]
             @seed_forced  = true
             @order_forced = true
-          elsif hash.has_key?(:order)
+          elsif hash.key?(:order)
             self.order = hash[:order]
             @order_forced = true
           end
         end
 
-        def register_ordering(name, strategy = Custom.new(Proc.new { |l| yield l }))
+        def register_ordering(name, strategy=Custom.new(Proc.new { |l| yield l }))
           return if @order_forced && name == :global
           ordering_registry.register(name, strategy)
         end
@@ -153,4 +153,3 @@ module RSpec
     end
   end
 end
-

--- a/lib/rspec/core/pending.rb
+++ b/lib/rspec/core/pending.rb
@@ -89,7 +89,7 @@ module RSpec
         elsif current_example
           Pending.mark_pending! current_example, message
         else
-          raise "`pending` may not be used outside of examples, such as in " +
+          raise "`pending` may not be used outside of examples, such as in " \
                 "before(:context). Maybe you want `skip`?"
         end
       end
@@ -116,9 +116,7 @@ module RSpec
       def skip(message=nil)
         current_example = RSpec.current_example
 
-        if current_example
-          Pending.mark_skipped! current_example, message
-        end
+        Pending.mark_skipped!(current_example, message) if current_example
 
         raise SkipDeclaredInExample.new(message)
       end
@@ -142,10 +140,10 @@ module RSpec
       # @param message_or_bool [Boolean, String] the message to use, or true
       def self.mark_pending!(example, message_or_bool)
         message = if !message_or_bool || !(String === message_or_bool)
-          NO_REASON_GIVEN
-        else
-          message_or_bool
-        end
+                    NO_REASON_GIVEN
+                  else
+                    message_or_bool
+                  end
 
         example.metadata[:pending] = true
         example.execution_result.pending_message = message

--- a/lib/rspec/core/project_initializer.rb
+++ b/lib/rspec/core/project_initializer.rb
@@ -10,7 +10,7 @@ module RSpec
       DOT_RSPEC_FILE = '.rspec'
       SPEC_HELPER_FILE =  'spec/spec_helper.rb'
 
-      def initialize(opts = {})
+      def initialize(opts={})
         @destination = opts.fetch(:destination, Dir.getwd)
         @stream = opts.fetch(:report_stream, $stdout)
         @template_path = opts.fetch(:template_path) do

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -90,10 +90,11 @@ module RSpec
         rescue
           puts failure_message if failure_message
         end
-        if fail_on_error && !success
-          $stderr.puts "#{command} failed"
-          exit $?.exitstatus
-        end
+
+        return unless fail_on_error && !success
+
+        $stderr.puts "#{command} failed"
+        exit $?.exitstatus
       end
 
     private
@@ -112,7 +113,7 @@ module RSpec
 
       def file_inclusion_specification
         if ENV['SPEC']
-          FileList[ ENV['SPEC'] ].sort
+          FileList[ ENV['SPEC']].sort
         else
           "--pattern '#{pattern}'"
         end
@@ -135,13 +136,14 @@ module RSpec
       end
 
       def blank
-        lambda {|s| s.nil? || s == ""}
+        lambda { |s| s.nil? || s == "" }
       end
 
       def rspec_load_path
         @rspec_load_path ||= begin
-          core_and_support = $LOAD_PATH.grep \
-            %r{#{File::SEPARATOR}rspec-(core|support)[^#{File::SEPARATOR}]*#{File::SEPARATOR}lib}
+          core_and_support = $LOAD_PATH.grep(
+            /#{File::SEPARATOR}rspec-(core|support)[^#{File::SEPARATOR}]*#{File::SEPARATOR}lib/
+          )
 
           "-I#{core_and_support.map(&:shellescape).join(File::PATH_SEPARATOR)}"
         end

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -2,10 +2,9 @@ module RSpec::Core
   # A reporter will send notifications to listeners, usually formatters for the
   # spec suite run.
   class Reporter
-
     def initialize(configuration)
       @configuration = configuration
-      @listeners = Hash.new { |h,k| h[k] = Set.new }
+      @listeners = Hash.new { |h, k| h[k] = Set.new }
       @examples = []
       @failed_examples = []
       @pending_examples = []
@@ -58,7 +57,7 @@ module RSpec::Core
     end
 
     # @private
-    def start(expected_example_count, time = RSpec::Core::Time.now)
+    def start(expected_example_count, time=RSpec::Core::Time.now)
       @start = time
       @load_time = (@start - @configuration.start_time).to_f
       notify :start, Notifications::StartNotification.new(expected_example_count, @load_time)
@@ -109,20 +108,18 @@ module RSpec::Core
 
     # @private
     def finish
-      begin
-        stop
-        notify :start_dump,    Notifications::NullNotification
-        notify :dump_pending,  Notifications::ExamplesNotification.new(self)
-        notify :dump_failures, Notifications::ExamplesNotification.new(self)
-        notify :deprecation_summary, Notifications::NullNotification
-        notify :dump_summary, Notifications::SummaryNotification.new(@duration, @examples, @failed_examples, @pending_examples, @load_time)
-        unless mute_profile_output?
-          notify :dump_profile, Notifications::ProfileNotification.new(@duration, @examples, @configuration.profile_examples)
-        end
-        notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
-      ensure
-        notify :close, Notifications::NullNotification
+      stop
+      notify :start_dump,    Notifications::NullNotification
+      notify :dump_pending,  Notifications::ExamplesNotification.new(self)
+      notify :dump_failures, Notifications::ExamplesNotification.new(self)
+      notify :deprecation_summary, Notifications::NullNotification
+      notify :dump_summary, Notifications::SummaryNotification.new(@duration, @examples, @failed_examples, @pending_examples, @load_time)
+      unless mute_profile_output?
+        notify :dump_profile, Notifications::ProfileNotification.new(@duration, @examples, @configuration.profile_examples)
       end
+      notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
+    ensure
+      notify :close, Notifications::NullNotification
     end
 
     # @private

--- a/lib/rspec/core/ruby_project.rb
+++ b/lib/rspec/core/ruby_project.rb
@@ -9,7 +9,7 @@ module RSpec
     # @private
     module RubyProject
       def add_to_load_path(*dirs)
-        dirs.map {|dir| add_dir_to_load_path(File.join(root, dir))}
+        dirs.map { |dir| add_dir_to_load_path(File.join(root, dir)) }
       end
 
       def add_dir_to_load_path(dir)
@@ -25,7 +25,7 @@ module RSpec
       end
 
       def find_first_parent_containing(dir)
-        ascend_until {|path| File.exist?(File.join(path, dir))}
+        ascend_until { |path| File.exist?(File.join(path, dir)) }
       end
 
       def ascend_until

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -2,7 +2,6 @@ module RSpec
   module Core
     # Provides the main entry point to run a suite of RSpec examples.
     class Runner
-
       # Register an `at_exit` hook that runs the suite when the process exits.
       #
       # @note This is not generally needed. The `rspec` command takes care
@@ -22,7 +21,7 @@ module RSpec
           # Don't bother running any specs and just let the program terminate
           # if we got here due to an unrescued exception (anything other than
           # SystemExit, which is raised when somebody calls Kernel#exit).
-          next unless $!.nil? || $!.kind_of?(SystemExit)
+          next unless $!.nil? || $!.is_a?(SystemExit)
 
           # We got here because either the end of the program was reached or
           # somebody called Kernel#exit.  Run the specs and then override any
@@ -132,21 +131,19 @@ module RSpec
       end
 
       # @private
+      # rubocop:disable Lint/EnsureReturn
       def self.running_in_drb?
-        begin
-          if defined?(DRb) && DRb.current_server
-            require 'socket'
-            require 'uri'
-
-            local_ipv4 = IPSocket.getaddress(Socket.gethostname)
-
-            local_drb = ["127.0.0.1", "localhost", local_ipv4].any? { |addr| addr == URI(DRb.current_server.uri).host }
-          end
-        rescue DRb::DRbServerNotFound
-        ensure
-          return local_drb || false
+        if defined?(DRb) && DRb.current_server
+          require 'socket'
+          require 'uri'
+          local_ipv4 = IPSocket.getaddress(Socket.gethostname)
+          local_drb = ["127.0.0.1", "localhost", local_ipv4].any? { |addr| addr == URI(DRb.current_server.uri).host }
         end
+      rescue DRb::DRbServerNotFound
+      ensure
+        return local_drb || false
       end
+      # rubocop:enable Lint/EnsureReturn
 
       # @private
       def self.trap_interrupt

--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -50,8 +50,8 @@ module RSpec
       def shared_examples(name, *args, &block)
         top_level = self == ExampleGroup
         if top_level && RSpec.thread_local_metadata[:in_example_group]
-          raise "Creating isolated shared examples from within a context is " +
-                "not allowed. Remove `RSpec.` prefix or move this to a " +
+          raise "Creating isolated shared examples from within a context is " \
+                "not allowed. Remove `RSpec.` prefix or move this to a " \
                 "top-level scope."
         end
 
@@ -103,7 +103,6 @@ module RSpec
 
           @exposed_globally = false
         end
-
       end
 
       # @private
@@ -118,13 +117,13 @@ module RSpec
             metadata_args.unshift name
           end
 
-          unless metadata_args.empty?
-            mod = Module.new
-            (class << mod; self; end).__send__(:define_method, :included) do |host|
-              host.class_exec(&block)
-            end
-            RSpec.configuration.include mod, *metadata_args
+          return if metadata_args.empty?
+
+          mod = Module.new
+          (class << mod; self; end).__send__(:define_method, :included) do |host|
+            host.class_exec(&block)
           end
+          RSpec.configuration.include mod, *metadata_args
         end
 
         def find(lookup_contexts, name)
@@ -144,13 +143,15 @@ module RSpec
 
         def valid_name?(candidate)
           case candidate
-            when String, Symbol, Module then true
-            else false
+          when String, Symbol, Module then true
+          else false
           end
         end
 
         def warn_if_key_taken(context, key, new_block)
-          return unless existing_block = shared_example_groups[context][key]
+          existing_block = shared_example_groups[context][key]
+
+          return unless existing_block
 
           RSpec.warn_with <<-WARNING.gsub(/^ +\|/, ''), :call_site => nil
             |WARNING: Shared example group '#{key}' has been previously defined at:
@@ -166,7 +167,7 @@ module RSpec
         end
 
         if Proc.method_defined?(:source_location)
-          def ensure_block_has_source_location(block); end
+          def ensure_block_has_source_location(_block); end
         else # for 1.8.7
           def ensure_block_has_source_location(block)
             source_location = yield.split(':')

--- a/lib/rspec/core/warnings.rb
+++ b/lib/rspec/core/warnings.rb
@@ -7,7 +7,7 @@ module RSpec
       # @private
       #
       # Used internally to print deprecation warnings
-      def deprecate(deprecated, data = {})
+      def deprecate(deprecated, data={})
         RSpec.configuration.reporter.deprecation(
           {
             :deprecated => deprecated,
@@ -19,12 +19,12 @@ module RSpec
       # @private
       #
       # Used internally to print deprecation warnings
-      def warn_deprecation(message, opts = {})
-        RSpec.configuration.reporter.deprecation opts.merge( :message => message )
+      def warn_deprecation(message, opts={})
+        RSpec.configuration.reporter.deprecation opts.merge(:message => message)
       end
 
       # @private
-      def warn_with(message, options = {})
+      def warn_with(message, options={})
         if options[:use_spec_location_as_call_site]
           message += "." unless message.end_with?(".")
 

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -4,7 +4,6 @@ module RSpec
     #
     # Internal container for global non-configuration data
     class World
-
       include RSpec::Core::Hooks
 
       # @private
@@ -16,14 +15,14 @@ module RSpec
       def initialize(configuration=RSpec.configuration)
         @configuration = configuration
         @example_groups = []
-        @filtered_examples = Hash.new { |hash,group|
+        @filtered_examples = Hash.new do |hash, group|
           hash[group] = begin
             examples = group.examples.dup
             examples = filter_manager.prune(examples)
             examples.uniq!
             examples
           end
-        }
+        end
       end
 
       # @private
@@ -90,8 +89,8 @@ module RSpec
       #
       # Get count of examples to be run
       def example_count(groups=example_groups)
-        FlatMap.flat_map(groups) {|g| g.descendants}.
-          inject(0) {|sum, g| sum + g.filtered_examples.size}
+        FlatMap.flat_map(groups) { |g| g.descendants }.
+          inject(0) { |a, e| a + e.filtered_examples.size }
       end
 
       # @api private
@@ -131,19 +130,19 @@ module RSpec
           inclusion_filter.clear
         end
 
-        if example_count.zero?
-          example_groups.clear
-          if filter_manager.empty?
-            reporter.message("No examples found.")
-          elsif exclusion_filter.empty?
-            message = everything_filtered_message
-            if @configuration.run_all_when_everything_filtered?
-              message << "; ignoring #{inclusion_filter.description}"
-            end
-            reporter.message(message)
-          elsif inclusion_filter.empty?
-            reporter.message(everything_filtered_message)
+        return unless example_count.zero?
+
+        example_groups.clear
+        if filter_manager.empty?
+          reporter.message("No examples found.")
+        elsif exclusion_filter.empty?
+          message = everything_filtered_message
+          if @configuration.run_all_when_everything_filtered?
+            message << "; ignoring #{inclusion_filter.description}"
           end
+          reporter.message(message)
+        elsif inclusion_filter.empty?
+          reporter.message(everything_filtered_message)
         end
       end
 
@@ -156,18 +155,18 @@ module RSpec
       #
       # Add inclusion filters to announcement message
       def announce_inclusion_filter(announcements)
-        unless inclusion_filter.empty?
-          announcements << "include #{inclusion_filter.description}"
-        end
+        return if inclusion_filter.empty?
+
+        announcements << "include #{inclusion_filter.description}"
       end
 
       # @api private
       #
       # Add exclusion filters to announcement message
       def announce_exclusion_filter(announcements)
-        unless exclusion_filter.empty?
-          announcements << "exclude #{exclusion_filter.description}"
-        end
+        return if exclusion_filter.empty?
+
+        announcements << "exclude #{exclusion_filter.description}"
       end
 
     private
@@ -177,7 +176,6 @@ module RSpec
           lines + g.declaration_line_numbers
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
This setup of rubocop is very lenient to begin with. Some leniencies are
established in .rubocop.yml and other times rules are disabled
inline in the files. Over time, more rules should be enabled.

(Based on #1663).
