### PR TITLE
Add better `inspect` output for ExampleGroup

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -82,6 +82,15 @@ module RSpec
         RSpec.configuration.format_docstrings_block.call(description)
       end
 
+      # Returns a description of the example that always includes the location.
+      def inspect_output
+        inspect_output = "\"#{description}\""
+        unless metadata[:description].to_s.empty?
+          inspect_output << " (#{location})"
+        end
+        inspect_output
+      end
+
       # @attr_reader
       #
       # Returns the first exception raised in the context of running this
@@ -170,7 +179,7 @@ module RSpec
         rescue Exception => e
           set_exception(e)
         ensure
-          @example_group_instance.instance_variables.each do |ivar|
+          ExampleGroup.instance_variables_for_example(@example_group_instance).each do |ivar|
             @example_group_instance.instance_variable_set(ivar, nil)
           end
           @example_group_instance = nil


### PR DESCRIPTION
Pull Request for #1590 

The only problem I ran into was that the syntax error in the after hook test produces error output while running the spec (the test still passes).

> An error occurred in an `after(:context)` hook.
>   NoMethodError: undefined method `expcts' for #<RSpec::ExampleGroups::SomeClass_3 after(:context) hook>

This is definitely not ideal because it could distract from problems with "real" after hooks. The only two options I could up with were: 1) remove the test, or 2) add a way to suppress that error. I'm interested in your thoughts on the best way to handle this.
