### PR TITLE
exclude_pattern with 1 glob starting with ./ doesn't match any files

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1337,7 +1337,8 @@ module RSpec
 
       def get_matching_files(path, pattern)
         stripped = "{#{pattern.gsub(/\s*,\s*/, ',')}}"
-        pattern =~ /^(\.\/)?#{Regexp.escape path}/ ? Dir[stripped] : Dir["#{path}/#{stripped}"]
+        files = (pattern =~ /^(\.\/)?#{Regexp.escape path}/) ? Dir[stripped] : Dir["#{path}/#{stripped}"]
+        files.map { |file| File.expand_path(file) }
       end
 
       def extract_location(path)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -426,25 +426,25 @@ module RSpec::Core
     describe "#files_to_run" do
       it "loads files not following pattern if named explicitly" do
         assign_files_or_directories_to_run "spec/rspec/core/resources/a_bar.rb"
-        expect(config.files_to_run).to eq(["spec/rspec/core/resources/a_bar.rb"])
+        expect(config.files_to_run).to contain_files(["spec/rspec/core/resources/a_bar.rb"])
       end
 
       it "prevents repetition of dir when start of the pattern" do
         config.pattern = "spec/**/a_spec.rb"
         assign_files_or_directories_to_run "spec"
-        expect(config.files_to_run).to eq(["spec/rspec/core/resources/a_spec.rb"])
+        expect(config.files_to_run).to contain_files(["spec/rspec/core/resources/a_spec.rb"])
       end
 
       it "does not prevent repetition of dir when later of the pattern" do
         config.pattern = "rspec/**/a_spec.rb"
         assign_files_or_directories_to_run "spec"
-        expect(config.files_to_run).to eq(["spec/rspec/core/resources/a_spec.rb"])
+        expect(config.files_to_run).to contain_files(["spec/rspec/core/resources/a_spec.rb"])
       end
 
       it "supports patterns starting with ./" do
         config.pattern = "./spec/**/a_spec.rb"
         assign_files_or_directories_to_run "spec"
-        expect(config.files_to_run).to eq(["./spec/rspec/core/resources/a_spec.rb"])
+        expect(config.files_to_run).to contain_files(["./spec/rspec/core/resources/a_spec.rb"])
       end
 
       it 'reloads when `files_or_directories_to_run` is reassigned' do
@@ -454,7 +454,7 @@ module RSpec::Core
         expect {
           config.files_or_directories_to_run = "spec"
         }.to change { config.files_to_run }.
-          to(["spec/rspec/core/resources/a_spec.rb"])
+          to(a_file_collection("spec/rspec/core/resources/a_spec.rb"))
       end
 
       context "with <path>:<line_number>" do
@@ -492,17 +492,17 @@ module RSpec::Core
       context "with default pattern" do
         it "loads files named _spec.rb" do
           assign_files_or_directories_to_run "spec/rspec/core/resources"
-          expect(config.files_to_run).to contain_exactly("spec/rspec/core/resources/a_spec.rb", "spec/rspec/core/resources/acceptance/foo_spec.rb")
+          expect(config.files_to_run).to contain_files("spec/rspec/core/resources/a_spec.rb", "spec/rspec/core/resources/acceptance/foo_spec.rb")
         end
 
         it "loads files in Windows", :if => RSpec.world.windows_os? do
           assign_files_or_directories_to_run "C:\\path\\to\\project\\spec\\sub\\foo_spec.rb"
-          expect(config.files_to_run).to eq(["C:/path/to/project/spec/sub/foo_spec.rb"])
+          expect(config.files_to_run).to contain_files(["C:/path/to/project/spec/sub/foo_spec.rb"])
         end
 
         it "loads files in Windows when directory is specified", :if => RSpec.world.windows_os? do
           assign_files_or_directories_to_run "spec\\rspec\\core\\resources"
-          expect(config.files_to_run).to eq(["spec/rspec/core/resources/a_spec.rb"])
+          expect(config.files_to_run).to contain_files(["spec/rspec/core/resources/a_spec.rb"])
         end
 
         it_behaves_like "handling symlinked directories when loading spec files" do

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -177,14 +177,14 @@ module RSpec::Core
       context "that is an existing directory, not a file glob" do
         it "loads the spec files in that directory" do
           task.pattern = "./spec/rspec/core/resources/acceptance"
-          expect(loaded_files).to eq(["./spec/rspec/core/resources/acceptance/foo_spec.rb"])
+          expect(loaded_files).to contain_files(["./spec/rspec/core/resources/acceptance/foo_spec.rb"])
         end
       end
 
       context "that is an existing file, not a file glob" do
         it "loads the spec file" do
           task.pattern = "./spec/rspec/core/resources/acceptance/foo_spec.rb"
-          expect(loaded_files).to eq(["./spec/rspec/core/resources/acceptance/foo_spec.rb"])
+          expect(loaded_files).to contain_files(["./spec/rspec/core/resources/acceptance/foo_spec.rb"])
         end
       end
 
@@ -193,7 +193,7 @@ module RSpec::Core
           task.pattern = ["./spec/rspec/core/resources/acceptance",
                           "./spec/rspec/core/resources/a_bar.rb"]
 
-          expect(loaded_files).to contain_exactly(
+          expect(loaded_files).to contain_files(
             "./spec/rspec/core/resources/acceptance/foo_spec.rb",
             "./spec/rspec/core/resources/a_bar.rb"
           )
@@ -204,7 +204,7 @@ module RSpec::Core
       context "that is a single glob that starts with ./" do
         it "loads the spec files that match the glob" do
           task.pattern = "./spec/rspec/core/resources/acceptance/**/*_spec.rb"
-          expect(loaded_files).to eq(["./spec/rspec/core/resources/acceptance/foo_spec.rb"])
+          expect(loaded_files).to contain_files(["./spec/rspec/core/resources/acceptance/foo_spec.rb"])
         end
       end
 
@@ -213,7 +213,7 @@ module RSpec::Core
           task.pattern = ["./spec/rspec/core/resources/acceptance/*_spec.rb",
                           "./spec/rspec/core/resources/*_bar.rb"]
 
-          expect(loaded_files).to contain_exactly(
+          expect(loaded_files).to contain_files(
             "./spec/rspec/core/resources/acceptance/foo_spec.rb",
             "./spec/rspec/core/resources/a_bar.rb"
           )
@@ -225,7 +225,7 @@ module RSpec::Core
           task.pattern = ["./spec/rspec/core/resources/acceptance/*_spec.rb",
                           "./spec/rspec/core/resources/a_bar.rb"]
 
-          expect(loaded_files).to contain_exactly(
+          expect(loaded_files).to contain_files(
             "./spec/rspec/core/resources/acceptance/foo_spec.rb",
             "./spec/rspec/core/resources/a_bar.rb"
           )
@@ -271,7 +271,15 @@ module RSpec::Core
         task.pattern = "spec/**/*_spec.rb"
         unit_files = make_files_in_dir "unit"
 
-        expect(loaded_files).to match_array(unit_files)
+        expect(loaded_files).to contain_files(unit_files)
+      end
+
+      it "excludes files when pattern and exclusion_pattern don't consistently start with ./" do
+        task.exclude_pattern = "./spec/acceptance/*_spec.rb"
+        task.pattern = "spec/**/*_spec.rb"
+        unit_files = make_files_in_dir "unit"
+
+        expect(loaded_files).to contain_files(unit_files)
       end
     end
 
@@ -287,7 +295,7 @@ module RSpec::Core
           File.join("spec", file_name).tap { |f| FileUtils.touch(f) }
         end
 
-        expect(loaded_files).to match_array(files)
+        expect(loaded_files).to contain_files(files)
       end
     end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -87,3 +87,17 @@ RSpec::Matchers.define :be_skipped_with do |message|
     "expected: example skipped with #{message.inspect}\n     got: #{example.execution_result.pending_message.inspect}"
   end
 end
+
+RSpec::Matchers.define :contain_files do |*expected_files|
+  contain_exactly_matcher = RSpec::Matchers::BuiltIn::ContainExactly.new(expected_files.flatten.map { |f| File.expand_path(f) })
+
+  match do |actual_files|
+    files = actual_files.map { |f| File.expand_path(f) }
+    contain_exactly_matcher.matches?(files)
+  end
+
+  failure_message { contain_exactly_matcher.failure_message }
+  failure_message_when_negated { contain_exactly_matcher.failure_message_when_negated }
+end
+
+RSpec::Matchers.alias_matcher :a_file_collection, :contain_files

--- a/spec/support/shared_example_groups.rb
+++ b/spec/support/shared_example_groups.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples_for "handling symlinked directories when loading spec file
 
     FileUtils.ln_s bars_dir, File.join(project_dir, "spec/bars")
 
-    expect(loaded_files).to contain_exactly(
+    expect(loaded_files).to contain_files(
       "spec/bars/bar_spec.rb",
       "spec/foos/foo_spec.rb"
     )
@@ -38,6 +38,6 @@ RSpec.shared_examples_for "handling symlinked directories when loading spec file
     FileUtils.touch("subtrees/DD/spec/dd_foo_spec.rb")
     FileUtils.ln_s(File.join(project_dir, "subtrees/DD/spec"), "spec/lib/DD")
 
-    expect(loaded_files).to contain_exactly("spec/lib/DD/dd_foo_spec.rb")
+    expect(loaded_files).to contain_files("spec/lib/DD/dd_foo_spec.rb")
   end
 end


### PR DESCRIPTION
The exclusion filter doesn't find any files when given a single glob starting with ./ (related to #1695). Since no files are found, it returns an empty array and does not remove the files from the set to be run. As a result, files that we would expect to be excluded are not excluded.

**Pattern starts with spec/**

```
rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb  --exclude-pattern spec/features/\*\*/\*_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
 1/1 |========================= 100 ==========================>| Time: 00:00:00

1 example, 0 failures
```

**Pattern starts with ./spec/**

```
rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb  --exclude-pattern ./spec/features/\*\*/\*_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
 3/3 |========================= 100 ==========================>| Time: 00:00:01

3 examples, 0 failures
```

I should have noticed this when I fixed the inclusion case. :(  I'll take a shot at this soon; it should be easy having just fixed the other case.
