### PR TITLE
Fix another regression in rake task pattern handling.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+### 3.1.3 Development
+[Full Changelog](http://github.com/rspec/rspec-core/compare/v3.1.2...3-1-maintenance)
+
+Bug Fixes:
+
+* Fix yet another regression in rake task pattern handling, to allow
+  `task.pattern = FileList["..."]` to work. That was never intended
+  to be supported but accidentally worked in 3.0 and earlier.
+  (Myron Marston, #1701)
+
 ### 3.1.2 / 2014-09-08
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.1.1...v3.1.2)
 

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -114,7 +114,9 @@ module RSpec
       def file_inclusion_specification
         if ENV['SPEC']
           FileList[ ENV['SPEC']].sort
-        elsif Array === pattern || File.exist?(pattern)
+        elsif String === pattern && !File.exist?(pattern)
+          "--pattern #{pattern.shellescape}"
+        else
           # Before RSpec 3.1, we used `FileList` to get the list of matched files, and
           # then pass that along to the `rspec` command. Starting with 3.1, we prefer to
           # pass along the pattern as-is to the `rspec` command, for 3 reasons:
@@ -126,15 +128,14 @@ module RSpec
           #     which causes all files to get run.
           #
           # However, `FileList` is *far* more flexible than the `--pattern` option. Specifically, it
-          # supports individual files and directories, as well as arrays of files, directories and globs.
+          # supports individual files and directories, as well as arrays of files, directories and globs,
+          # as well as other `FileList` objects.
           #
           # For backwards compatibility, we have to fall back to using FileList if the user has passed
           # a `pattern` option that will not work with `--pattern`.
           #
           # TODO: consider deprecating support for this and removing it in RSpec 4.
           FileList[pattern].sort.map(&:shellescape)
-        else
-          "--pattern #{pattern.shellescape}"
         end
       end
 

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -231,6 +231,17 @@ module RSpec::Core
           )
         end
       end
+
+      context "that is a FileList" do
+        it "loads the files from the FileList" do
+          task.pattern = FileList["spec/rspec/core/resources/**/*_spec.rb"]
+
+          expect(loaded_files).to contain_exactly(
+            "spec/rspec/core/resources/a_spec.rb",
+            "spec/rspec/core/resources/acceptance/foo_spec.rb"
+          )
+        end
+      end
     end
 
     context "without an exclude_pattern" do


### PR DESCRIPTION
Apparently `FileList[file_list_object]` works, and some
users used `task.pattern = FileList[…]`.

See https://github.com/rspec/rspec-core/commit/667a4ca00f50fddb3fca7cdfcaf97633ba267b1f#commitcomment-7725799
