### PR TITLE
returning Rake task command failure message only when in verbose mode

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -93,7 +93,7 @@ module RSpec
 
         return unless fail_on_error && !success
 
-        $stderr.puts "#{command} failed"
+        $stderr.puts "#{command} failed" if verbose
         exit $?.exitstatus
       end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -101,3 +101,5 @@ RSpec::Matchers.define :contain_files do |*expected_files|
 end
 
 RSpec::Matchers.alias_matcher :a_file_collection, :contain_files
+
+RSpec::Matchers.define_negated_matcher :avoid_outputting, :output


### PR DESCRIPTION
Hi,

This fix addresses a particular issue I'm facing whilst trying to parse the RSpec stdout output with JSON formatting when invoked via a Rake task (basically: invalid JSON is being returned).

Given a simple Rake task (with `verbose` set to `true` by default):

``` ruby
RSpec::Core::RakeTask.new(:spec) do |task|
  task.rspec_opts = '-f json'
end
```

produced output (cleaned up for clarity) like:

``` bash
/Users/bensnape/.rvm/rubies/ruby-2.1.0/bin/ruby -I/Users/bensnape/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib:/Users/bensnape/.rvm/gems/ruby-2.1.0/gems/rspec-support-3.1.0/lib /Users/bensnape/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb -f json

{RSpec JSON output}

/Users/bensnape/.rvm/rubies/ruby-2.1.0/bin/ruby -I/Users/bensnape/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/lib:/Users/bensnape/.rvm/gems/ruby-2.1.0/gems/rspec-support-3.1.0/lib /Users/bensnape/.rvm/gems/ruby-2.1.0/gems/rspec-core-3.1.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb -f json failed
```

When I set `verbose` to `false`, the first "debug" line is removed but not the last line. This fixes that.

I fixed a failing test but some undesirable output is produced when running the suite (scroll along a bit...):

``` bash
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................./Users/bensnape/.rvm/rubies/ruby-2.1.0/bin/ruby -e "exit(2);" ;# -I/Users/bensnape/.rvm/gems/ruby-2.1.0/bundler/gems/rspec-support-6fbac97c794b/lib:/Users/bensnape/git/rspec-core/lib /Users/bensnape/git/rspec-core/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*.............................................................................
```

You probably don't want to keep this test (so feel free to modify/delete it) but I just didn't want to submit a PR with _less_ test coverage.

Thanks,
Ben
