### PR TITLE
Formalize config.libs= as a public API

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -163,8 +163,8 @@ module RSpec
       # Indicates files configured to be required
       define_reader :requires
 
-      # @macro define_reader
-      # Returns dirs that have been prepended to the load path by the `-I` command line option
+      # @!method libs
+      # Returns dirs that have been prepended to the load path by the `-I` command line option.
       define_reader :libs
 
       # @macro add_setting
@@ -637,8 +637,9 @@ module RSpec
         end
       end
 
-      # @private
-      def libs=(libs)
+      # Define additional load paths for requiring test dependencies.
+      # @attr string_paths [Array] string load paths
+      def libs=(lib)
         libs.map do |lib|
           @libs.unshift lib
           $LOAD_PATH.unshift lib


### PR DESCRIPTION
Making `libs=` a public API allows for safely setting additional load paths in application spec configuration (e.g. `spec_helper.rb`). By allowing the setting of `libs` in an application-level spec configuration file, this allows us to move this particular piece of application configuration out of the `.rspec` file. That way, we can reserve `.rspec` for user- or environment-specific configuration.

A specific use case for this would be to make it easier to keep `.rspec` out of version control while still being able to add additional load paths to the test suite configuration.
