### PR TITLE
Fix `subject` for `describe nil` and `describe false`.

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -55,7 +55,7 @@ module RSpec
       def subject
         __memoized.fetch(:subject) do
           __memoized[:subject] = begin
-            described = described_class || self.class.description
+            described = described_class || self.class.metadata.fetch(:description_args).first
             Class === described ? described.new : described
           end
         end

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -49,6 +49,24 @@ module RSpec::Core
         end
       end
 
+      describe "with true" do
+        it "returns `true`" do
+          expect(subject_value_for(true)).to eq(true)
+        end
+      end
+
+      describe "with false" do
+        it "returns `false`" do
+          expect(subject_value_for(false)).to eq(false)
+        end
+      end
+
+      describe "with nil" do
+        it "returns `nil`" do
+          expect(subject_value_for(nil)).to eq(nil)
+        end
+      end
+
       it "can be overriden and super'd to from a nested group" do
         outer_subject_value = inner_subject_value = nil
 


### PR DESCRIPTION
Before, these were returning the string forms.

Fixes rspec/rspec-expectations#653.
