### PR TITLE
Tidy up windows support.

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -629,7 +629,7 @@ module RSpec
       def color=(true_or_false)
         return unless true_or_false
 
-        if RSpec.world.windows_os? && !ENV['ANSICON']
+        if RSpec::Support::OS.windows? && !ENV['ANSICON']
           RSpec.warning "You must use ANSICON 1.31 or later (http://adoxa.3eeweb.com/ansicon/) to use colour on Windows"
           @color = false
         else

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -31,11 +31,6 @@ module RSpec
         example_groups.clear
       end
 
-      # @private
-      def windows_os?
-        RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/
-      end
-
       # @api private
       #
       # Apply ordering strategy from configuration to example groups

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -103,7 +103,7 @@ module RSpec::Core
     end
 
     describe "#format_backtrace" do
-      it "excludes lines from rspec libs by default", :unless => RSpec.world.windows_os? do
+      it "excludes lines from rspec libs by default", :unless => RSpec::Support::OS.windows? do
         backtrace = [
           "/path/to/rspec-expectations/lib/rspec/expectations/foo.rb:37",
           "/path/to/rspec-expectations/lib/rspec/matchers/foo.rb:37",
@@ -115,7 +115,7 @@ module RSpec::Core
         expect(BacktraceFormatter.new.format_backtrace(backtrace)).to eq(["./my_spec.rb:5"])
       end
 
-      it "excludes lines from rspec libs by default", :if => RSpec.world.windows_os? do
+      it "excludes lines from rspec libs by default", :if => RSpec::Support::OS.windows? do
         backtrace = [
           "\\path\\to\\rspec-expectations\\lib\\rspec\\expectations\\foo.rb:37",
           "\\path\\to\\rspec-expectations\\lib\\rspec\\matchers\\foo.rb:37",
@@ -147,7 +147,7 @@ module RSpec::Core
       end
 
       context "when rspec is installed in the current working directory" do
-        it "excludes lines from rspec libs by default", :unless => RSpec.world.windows_os? do
+        it "excludes lines from rspec libs by default", :unless => RSpec::Support::OS.windows? do
           backtrace = [
             "#{Dir.getwd}/.bundle/path/to/rspec-expectations/lib/rspec/expectations/foo.rb:37",
             "#{Dir.getwd}/.bundle/path/to/rspec-expectations/lib/rspec/matchers/foo.rb:37",

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -495,12 +495,12 @@ module RSpec::Core
           expect(config.files_to_run).to contain_files("spec/rspec/core/resources/a_spec.rb", "spec/rspec/core/resources/acceptance/foo_spec.rb")
         end
 
-        it "loads files in Windows", :if => RSpec.world.windows_os? do
+        it "loads files in Windows", :if => RSpec::Support::OS.windows? do
           assign_files_or_directories_to_run "C:\\path\\to\\project\\spec\\sub\\foo_spec.rb"
           expect(config.files_to_run).to contain_files(["C:/path/to/project/spec/sub/foo_spec.rb"])
         end
 
-        it "loads files in Windows when directory is specified", :if => RSpec.world.windows_os? do
+        it "loads files in Windows when directory is specified", :if => RSpec::Support::OS.windows? do
           assign_files_or_directories_to_run "spec\\rspec\\core\\resources"
           expect(config.files_to_run).to contain_files(["spec/rspec/core/resources/a_spec.rb"])
         end


### PR DESCRIPTION
Switches from our private `windows_os?` method to `RSpec::Support::OS.windows?`
