### PR TITLE
Change "Interrupt again" message

### DIFF
--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -150,7 +150,7 @@ module RSpec
         trap('INT') do
           exit!(1) if RSpec.world.wants_to_quit
           RSpec.world.wants_to_quit = true
-          STDERR.puts "\nExiting... Interrupt again to exit immediately."
+          STDERR.puts "\nExiting... Wait for report, or interrupt again to exit immediately."
         end
       end
     end


### PR DESCRIPTION
When you hit ^C Rspec says "Interrupt again to exit immediately". This seems to indicate that you _should_ interrupt again, so everyone I've ever paired with just keeps mashing ^C at this point. But if you just wait a _second_ longer, RSpec will kindly show you the report of specs run up til now. This is a great feature and more people should use it!

This patch updates the message to indicate what great rewards await if you _don't_ interrupt.
