### PR TITLE
fixing Metadata.relative_path for /foo/bar , /foo/bar_baz becoming ._baz

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -30,7 +30,18 @@ module RSpec
       # @param line [String] current code line
       # @return [String] relative path to line
       def self.relative_path(line)
-        line = line.sub(File.expand_path("."), ".")
+        # Matches strings either at the beginning of the input or prefixed with a whitespace,
+        # containing the current path, either postfixed with the separator, or at the end of the string.
+        # Match groups are the character before and the character after the string if any.
+        #
+        # http://rubular.com/r/fT0gmX6VJX
+        # http://rubular.com/r/duOrD4i3wb
+        # http://rubular.com/r/sbAMHFrOx1
+        #
+
+        regex = /(\A|\s)#{File.expand_path('.')}(#{File::SEPARATOR}|\s|\Z)/
+
+        line = line.sub(regex, "\\1.\\2")
         line = line.sub(/\A([^:]+:\d+)$/, '\\1')
         return nil if line == '-e:1'
         line

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -24,6 +24,13 @@ module RSpec
           end
         end
 
+        it 'should not transform directories beginning with the same prefix' do
+          #E.g. /foo/bar_baz is not relative to /foo/bar !!
+
+          similar_directory = "#{File.expand_path(".")}_similar"
+          expect(Metadata.relative_path(similar_directory)).to eq similar_directory
+        end
+
       end
 
       context "when created" do


### PR DESCRIPTION
The behaviour of relative path in Metadata was causing me problems when invoking rspec in a directory named
/foo/bar, while the tests were in /foo/bar_baz.

Metadata.relative_path solved them to ._baz, instead of seeing that the tests are not in the directory of invocation, and using the absolute path instead.

Not sure why this is done with regexes though. The pathname object supports finding the relative path from one to the other.
