### PR TITLE
Fix regression in rake task pattern handling.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,8 +9,14 @@ Enhancements:
 * Add `RSpec.clear_examples` as a clear way to reset examples in between
   spec runs, whilst retaining user configuration.  (Alexey Fedorov, #1706)
 
+### 3.1.6 Development
+[Full Changelog](http://github.com/rspec/rspec-core/compare/v3.1.5...3-1-maintenance)
+
 Bug Fixes:
 
+* Fix regression in rake task pattern handling, that prevented patterns
+  that were relative from the current directory rather than from `spec`
+  from working properly. (Myron Marston, #1734)
 * Prevent rake task from generating duplicate load path entries.
   (Myron Marston, #1735)
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1339,10 +1339,19 @@ module RSpec
     private
 
       def get_files_to_run(paths)
-        FlatMap.flat_map(paths) do |path|
+        FlatMap.flat_map(paths_to_check(paths)) do |path|
           path = path.gsub(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
           File.directory?(path) ? gather_directories(path) : extract_location(path)
-        end.sort
+        end.sort.uniq
+      end
+
+      def paths_to_check(paths)
+        return paths if pattern_might_load_specs_from_vendored_dirs?
+        paths + ['.']
+      end
+
+      def pattern_might_load_specs_from_vendored_dirs?
+        pattern.split(File::SEPARATOR).first.include?('**')
       end
 
       def gather_directories(path)
@@ -1385,6 +1394,7 @@ module RSpec
           filter_manager.add_location path, lines
         end
 
+        return [] if path == default_path
         path
       end
 

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -244,6 +244,19 @@ module RSpec::Core
         end
       end
 
+      context "that is a relative file glob, for a path not under the default spec dir (`spec`)" do
+        it "loads the matching spec files" do
+          Dir.chdir("./spec/rspec/core") do
+            task.pattern = "resources/**/*_spec.rb"
+
+            expect(loaded_files).to contain_files(
+              "resources/acceptance/foo_spec.rb",
+              "resources/a_spec.rb"
+            )
+          end
+        end
+      end
+
       context "that is an array of existing files or directories, not a file glob" do
         it "loads the specified spec files, and spec files from the specified directories" do
           task.pattern = ["./spec/rspec/core/resources/acceptance",


### PR DESCRIPTION
Since our change to forward `task.pattern` to `rspec`
in #1653, it has not handled patterns that are relative
to the current directory for a side directory (e.g.
not under `spec`) of specs. This restores that behavior.

Fixes #1728.
