### PR TITLE
Fix `:pending` metadata to always work.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,10 @@ Bug Fixes:
 * Prevent constant lookup mistakenly finding `RSpec::ExampleGroups` generated
   constants on 1.9.2 by appending a trailing `_` to the generated names.
   (Jon Rowe, #1737)
+* Fix bug in `:pending` metadata. If it got set in any way besides passing
+  it as part of the metadata literal passed to `it` (such as by using
+  `define_derived_metadata`), it did not have the desired effect,
+  instead marking the example as `:passed`. (Myron Marston, #1739)
 
 ### 3.1.6 / 2014-10-08
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.1.5...v3.1.6)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -149,6 +149,7 @@ module RSpec
         RSpec.current_example = self
 
         start(reporter)
+        Pending.mark_pending!(self, pending) if pending?
 
         begin
           if skipped?

--- a/spec/rspec/core/pending_example_spec.rb
+++ b/spec/rspec/core/pending_example_spec.rb
@@ -50,6 +50,40 @@ RSpec.describe "an example" do
     end
   end
 
+  context "made pending with `define_derived_metadata`" do
+    before do
+      RSpec.configure do |config|
+        config.define_derived_metadata(:not_ready) do |meta|
+          meta[:pending] ||= "Not ready"
+        end
+      end
+    end
+
+    it 'has a pending result if there is an error' do
+      group = RSpec.describe "group" do
+        example "something", :not_ready do
+          boom
+        end
+      end
+
+      group.run
+      example = group.examples.first
+      expect(example).to be_pending_with("Not ready")
+    end
+
+    it 'fails if there is no error' do
+      group = RSpec.describe "group" do
+        example "something", :not_ready do
+        end
+      end
+
+      group.run
+      example = group.examples.first
+      expect(example.execution_result.status).to be(:failed)
+      expect(example.execution_result.exception.message).to include("Expected example to fail")
+    end
+  end
+
   context "with no block" do
     it "is listed as pending with 'Not yet implemented'" do
       group = RSpec::Core::ExampleGroup.describe('group') do


### PR DESCRIPTION
It got processed immediately by `it`, which means that
if it got set later (e.g. via `define_derived_metadata`)
it would not take effect.

@xaviershay -- do you want to review this since you refactored `pending` for RSpec 3?
