### PR TITLE
Apply module/shared context inclusion to individual examples

### DIFF
--- a/benchmarks/module_inclusion_filtering.rb
+++ b/benchmarks/module_inclusion_filtering.rb
@@ -21,7 +21,7 @@ module RSpecConfigurationOverrides
 
   def old_configure_group(group)
     @include_extend_or_prepend_modules.each do |include_extend_or_prepend, mod, filters|
-      next unless filters.empty? || group.apply?(:any?, filters)
+      next unless filters.empty? || RSpec::Core::MetadataFilter.apply?(:any?, filters, group.metadata)
       __send__("safe_#{include_extend_or_prepend}", mod, group)
     end
   end

--- a/benchmarks/singleton_example_groups/helper.rb
+++ b/benchmarks/singleton_example_groups/helper.rb
@@ -1,0 +1,93 @@
+require_relative "../../bundle/bundler/setup" # configures load paths
+require 'rspec/core'
+
+class << RSpec
+  attr_writer :world
+end
+
+RSpec::Core::Example.class_eval do
+  alias_method :new_with_around_and_singleton_context_hooks, :with_around_and_singleton_context_hooks
+  alias_method :old_with_around_and_singleton_context_hooks, :with_around_example_hooks
+end
+
+RSpec::Core::Hooks::HookCollections.class_eval do
+  def old_register_global_singleton_context_hooks(*)
+    # no-op: this method didn't exist before
+  end
+  alias_method :new_register_global_singleton_context_hooks, :register_global_singleton_context_hooks
+end
+
+RSpec::Core::Configuration.class_eval do
+  def old_configure_example(*)
+    # no-op: this method didn't exist before
+  end
+  alias_method :new_configure_example, :configure_example
+end
+
+RSpec.configure do |c|
+  c.output_stream = StringIO.new
+end
+
+require 'benchmark/ips'
+
+class BenchmarkHelpers
+  def self.prepare_implementation(prefix)
+    RSpec.world = RSpec::Core::World.new # clear our state
+    RSpec::Core::Example.__send__ :alias_method, :with_around_and_singleton_context_hooks, :"#{prefix}_with_around_and_singleton_context_hooks"
+    RSpec::Core::Hooks::HookCollections.__send__ :alias_method, :register_global_singleton_context_hooks, :"#{prefix}_register_global_singleton_context_hooks"
+    RSpec::Core::Configuration.__send__ :alias_method, :configure_example, :"#{prefix}_configure_example"
+  end
+
+  @@runner = RSpec::Core::Runner.new(RSpec::Core::ConfigurationOptions.new([]))
+  def self.define_and_run_examples(desc, count, group_meta: {}, example_meta: {})
+    groups = count.times.map do |i|
+      RSpec.describe "Group #{desc} #{i}", group_meta do
+        10.times { |j| example("ex #{j}", example_meta) { } }
+      end
+    end
+
+    @@runner.run_specs(groups)
+  end
+
+  def self.run_benchmarks
+    Benchmark.ips do |x|
+      implementations = { :old => "without", :new => "with" }
+      # Historically, many of our benchmarks have initially been order-sensitive,
+      # where whichever implementation went first got favored because defining
+      # more groups (or whatever) would cause things to slow down. To easily
+      # check if we're having those problems, you can pass REVERSE=1 to try
+      # it out in the opposite order.
+      implementations = implementations.to_a.reverse.to_h if ENV['REVERSE']
+
+      implementations.each do |prefix, description|
+        x.report("No match -- #{description} singleton group support") do |times|
+          prepare_implementation(prefix)
+          define_and_run_examples("No match/#{description}", times)
+        end
+      end
+
+      implementations.each do |prefix, description|
+        x.report("Example match -- #{description} singleton group support") do |times|
+          prepare_implementation(prefix)
+          define_and_run_examples("Example match/#{description}", times, example_meta: { apply_it: true })
+        end
+      end
+
+      implementations.each do |prefix, description|
+        x.report("Group match -- #{description} singleton group support") do |times|
+          prepare_implementation(prefix)
+          define_and_run_examples("Group match/#{description}", times, group_meta: { apply_it: true })
+        end
+      end
+
+      implementations.each do |prefix, description|
+        x.report("Both match -- #{description} singleton group support") do |times|
+          prepare_implementation(prefix)
+          define_and_run_examples("Both match/#{description}", times,
+                                  example_meta: { apply_it: true },
+                                  group_meta: { apply_it: true })
+        end
+      end
+    end
+  end
+end

--- a/benchmarks/singleton_example_groups/with_config_hooks.rb
+++ b/benchmarks/singleton_example_groups/with_config_hooks.rb
@@ -1,0 +1,29 @@
+require_relative "helper"
+
+RSpec.configure do |c|
+  10.times do
+    c.before(:context, :apply_it) { }
+    c.after(:context,  :apply_it) { }
+  end
+end
+
+BenchmarkHelpers.run_benchmarks
+
+__END__
+
+No match -- without singleton group support
+                        489.165  (±33.3%) i/s -      2.080k
+No match -- with singleton group support
+                        451.019  (±29.3%) i/s -      1.890k
+Example match -- without singleton group support
+                        465.178  (±35.3%) i/s -      1.820k
+Example match -- with singleton group support
+                        244.273  (±23.3%) i/s -      1.064k
+Group match -- without singleton group support
+                        406.979  (±27.0%) i/s -      1.700k
+Group match -- with singleton group support
+                        327.455  (±22.6%) i/s -      1.421k
+Both match -- without singleton group support
+                        423.859  (±32.1%) i/s -      1.763k
+Both match -- with singleton group support
+                        293.873  (±23.5%) i/s -      1.333k

--- a/benchmarks/singleton_example_groups/with_config_hooks.rb
+++ b/benchmarks/singleton_example_groups/with_config_hooks.rb
@@ -10,20 +10,19 @@ end
 BenchmarkHelpers.run_benchmarks
 
 __END__
-
 No match -- without singleton group support
-                        614.535  (±33.8%) i/s -      2.520k
+                        575.250  (±29.0%) i/s -      2.484k
 No match -- with singleton group support
-                        555.190  (±21.1%) i/s -      2.496k
+                        503.671  (±21.8%) i/s -      2.250k
 Example match -- without singleton group support
-                        574.821  (±31.5%) i/s -      2.491k
+                        544.191  (±25.7%) i/s -      2.160k
 Example match -- with singleton group support
-                        436.391  (±25.2%) i/s -      1.872k
+                        413.538  (±22.2%) i/s -      1.715k
 Group match -- without singleton group support
-                        544.063  (±31.4%) i/s -      2.112k
+                        517.998  (±28.2%) i/s -      2.058k
 Group match -- with singleton group support
-                        457.098  (±18.8%) i/s -      1.961k
+                        431.554  (±15.3%) i/s -      1.960k
 Both match -- without singleton group support
-                        554.004  (±30.1%) i/s -      2.255k
+                        525.306  (±25.1%) i/s -      2.107k in   5.556760s
 Both match -- with singleton group support
-                        452.834  (±19.7%) i/s -      1.935k
+                        440.288  (±16.6%) i/s -      1.848k

--- a/benchmarks/singleton_example_groups/with_config_hooks.rb
+++ b/benchmarks/singleton_example_groups/with_config_hooks.rb
@@ -12,18 +12,18 @@ BenchmarkHelpers.run_benchmarks
 __END__
 
 No match -- without singleton group support
-                        489.165  (±33.3%) i/s -      2.080k
+                        614.535  (±33.8%) i/s -      2.520k
 No match -- with singleton group support
-                        451.019  (±29.3%) i/s -      1.890k
+                        555.190  (±21.1%) i/s -      2.496k
 Example match -- without singleton group support
-                        465.178  (±35.3%) i/s -      1.820k
+                        574.821  (±31.5%) i/s -      2.491k
 Example match -- with singleton group support
-                        244.273  (±23.3%) i/s -      1.064k
+                        436.391  (±25.2%) i/s -      1.872k
 Group match -- without singleton group support
-                        406.979  (±27.0%) i/s -      1.700k
+                        544.063  (±31.4%) i/s -      2.112k
 Group match -- with singleton group support
-                        327.455  (±22.6%) i/s -      1.421k
+                        457.098  (±18.8%) i/s -      1.961k
 Both match -- without singleton group support
-                        423.859  (±32.1%) i/s -      1.763k
+                        554.004  (±30.1%) i/s -      2.255k
 Both match -- with singleton group support
-                        293.873  (±23.5%) i/s -      1.333k
+                        452.834  (±19.7%) i/s -      1.935k

--- a/benchmarks/singleton_example_groups/with_config_hooks_module_inclusions_and_shared_context_inclusions.rb
+++ b/benchmarks/singleton_example_groups/with_config_hooks_module_inclusions_and_shared_context_inclusions.rb
@@ -1,0 +1,35 @@
+require_relative "helper"
+
+RSpec.configure do |c|
+  10.times do
+    c.before(:context, :apply_it) { }
+    c.after(:context,  :apply_it) { }
+    c.include Module.new, :apply_it
+  end
+end
+
+1.upto(10) do |i|
+  RSpec.shared_context "context #{i}", :apply_it do
+  end
+end
+
+BenchmarkHelpers.run_benchmarks
+
+__END__
+
+No match -- without singleton group support
+                        452.015  (±33.8%) i/s -      1.900k
+No match -- with singleton group support
+                        464.520  (±31.0%) i/s -      1.887k
+Example match -- without singleton group support
+                        476.961  (±34.6%) i/s -      1.978k in   5.340615s
+Example match -- with singleton group support
+                         76.177  (±34.1%) i/s -    266.000
+Group match -- without singleton group support
+                        364.554  (±28.3%) i/s -      1.372k
+Group match -- with singleton group support
+                        281.761  (±24.1%) i/s -      1.200k
+Both match -- without singleton group support
+                        281.521  (±27.4%) i/s -      1.188k
+Both match -- with singleton group support
+                        297.886  (±18.1%) i/s -      1.288k

--- a/benchmarks/singleton_example_groups/with_config_hooks_module_inclusions_and_shared_context_inclusions.rb
+++ b/benchmarks/singleton_example_groups/with_config_hooks_module_inclusions_and_shared_context_inclusions.rb
@@ -18,18 +18,18 @@ BenchmarkHelpers.run_benchmarks
 __END__
 
 No match -- without singleton group support
-                        452.015  (±33.8%) i/s -      1.900k
+                        544.396  (±34.0%) i/s -      2.340k
 No match -- with singleton group support
-                        464.520  (±31.0%) i/s -      1.887k
+                        451.635  (±31.0%) i/s -      1.935k
 Example match -- without singleton group support
-                        476.961  (±34.6%) i/s -      1.978k in   5.340615s
+                        538.788  (±23.8%) i/s -      2.450k
 Example match -- with singleton group support
-                         76.177  (±34.1%) i/s -    266.000
+                        342.990  (±22.4%) i/s -      1.440k
 Group match -- without singleton group support
-                        364.554  (±28.3%) i/s -      1.372k
+                        509.969  (±26.7%) i/s -      2.070k
 Group match -- with singleton group support
-                        281.761  (±24.1%) i/s -      1.200k
+                        405.284  (±20.5%) i/s -      1.518k
 Both match -- without singleton group support
-                        281.521  (±27.4%) i/s -      1.188k
+                        513.344  (±24.0%) i/s -      1.927k
 Both match -- with singleton group support
-                        297.886  (±18.1%) i/s -      1.288k
+                        406.111  (±18.5%) i/s -      1.760k

--- a/benchmarks/singleton_example_groups/with_module_inclusions.rb
+++ b/benchmarks/singleton_example_groups/with_module_inclusions.rb
@@ -1,0 +1,28 @@
+require_relative "helper"
+
+RSpec.configure do |c|
+  1.upto(10) do
+    c.include Module.new, :apply_it
+  end
+end
+
+BenchmarkHelpers.run_benchmarks
+
+__END__
+
+No match -- without singleton group support
+                        519.880  (±33.9%) i/s -      2.162k
+No match -- with singleton group support
+                        481.334  (±28.5%) i/s -      2.028k
+Example match -- without singleton group support
+                        491.348  (±29.9%) i/s -      2.068k
+Example match -- with singleton group support
+                        407.257  (±22.3%) i/s -      1.782k
+Group match -- without singleton group support
+                        483.403  (±36.4%) i/s -      1.815k
+Group match -- with singleton group support
+                        424.932  (±29.4%) i/s -      1.804k
+Both match -- without singleton group support
+                        397.831  (±31.9%) i/s -      1.720k
+Both match -- with singleton group support
+                        424.233  (±25.5%) i/s -      1.720k

--- a/benchmarks/singleton_example_groups/with_module_inclusions.rb
+++ b/benchmarks/singleton_example_groups/with_module_inclusions.rb
@@ -11,18 +11,18 @@ BenchmarkHelpers.run_benchmarks
 __END__
 
 No match -- without singleton group support
-                        519.880  (±33.9%) i/s -      2.162k
+                        555.498  (±27.0%) i/s -      2.496k
 No match -- with singleton group support
-                        481.334  (±28.5%) i/s -      2.028k
+                        529.826  (±23.0%) i/s -      2.397k in   5.402305s
 Example match -- without singleton group support
-                        491.348  (±29.9%) i/s -      2.068k
+                        541.845  (±29.0%) i/s -      2.208k
 Example match -- with singleton group support
-                        407.257  (±22.3%) i/s -      1.782k
+                        465.440  (±20.4%) i/s -      2.091k
 Group match -- without singleton group support
-                        483.403  (±36.4%) i/s -      1.815k
+                        530.976  (±24.1%) i/s -      2.303k
 Group match -- with singleton group support
-                        424.932  (±29.4%) i/s -      1.804k
+                        505.291  (±18.8%) i/s -      2.226k
 Both match -- without singleton group support
-                        397.831  (±31.9%) i/s -      1.720k
+                        542.168  (±28.4%) i/s -      2.067k in   5.414905s
 Both match -- with singleton group support
-                        424.233  (±25.5%) i/s -      1.720k
+                        503.226  (±27.2%) i/s -      1.880k in   5.621210s

--- a/benchmarks/singleton_example_groups/with_no_config_hooks_or_inclusions.rb
+++ b/benchmarks/singleton_example_groups/with_no_config_hooks_or_inclusions.rb
@@ -1,0 +1,22 @@
+require_relative "helper"
+
+BenchmarkHelpers.run_benchmarks
+
+__END__
+
+No match -- without singleton group support
+                        504.865  (±31.9%) i/s -      2.128k
+No match -- with singleton group support
+                        463.115  (±26.6%) i/s -      1.998k
+Example match -- without singleton group support
+                        472.825  (±31.9%) i/s -      1.938k
+Example match -- with singleton group support
+                        436.539  (±33.9%) i/s -      1.840k
+Group match -- without singleton group support
+                        460.643  (±33.4%) i/s -      1.892k
+Group match -- with singleton group support
+                        430.339  (±23.2%) i/s -      1.911k
+Both match -- without singleton group support
+                        406.712  (±26.6%) i/s -      1.848k
+Both match -- with singleton group support
+                        470.299  (±26.4%) i/s -      1.890k

--- a/benchmarks/singleton_example_groups/with_no_config_hooks_or_inclusions.rb
+++ b/benchmarks/singleton_example_groups/with_no_config_hooks_or_inclusions.rb
@@ -5,18 +5,18 @@ BenchmarkHelpers.run_benchmarks
 __END__
 
 No match -- without singleton group support
-                        504.865  (±31.9%) i/s -      2.128k
+                        565.198  (±28.8%) i/s -      2.438k
 No match -- with singleton group support
-                        463.115  (±26.6%) i/s -      1.998k
+                        539.781  (±18.9%) i/s -      2.496k
 Example match -- without singleton group support
-                        472.825  (±31.9%) i/s -      1.938k
+                        539.287  (±28.2%) i/s -      2.450k in   5.555471s
 Example match -- with singleton group support
-                        436.539  (±33.9%) i/s -      1.840k
+                        511.576  (±28.1%) i/s -      2.058k
 Group match -- without singleton group support
-                        460.643  (±33.4%) i/s -      1.892k
+                        535.298  (±23.2%) i/s -      2.352k
 Group match -- with singleton group support
-                        430.339  (±23.2%) i/s -      1.911k
+                        539.454  (±19.1%) i/s -      2.350k
 Both match -- without singleton group support
-                        406.712  (±26.6%) i/s -      1.848k
+                        550.932  (±32.1%) i/s -      2.145k in   5.930432s
 Both match -- with singleton group support
-                        470.299  (±26.4%) i/s -      1.890k
+                        540.183  (±19.6%) i/s -      2.300k

--- a/benchmarks/singleton_example_groups/with_shared_context_inclusions.rb
+++ b/benchmarks/singleton_example_groups/with_shared_context_inclusions.rb
@@ -6,6 +6,7 @@ require_relative "helper"
 end
 
 BenchmarkHelpers.run_benchmarks
+# BenchmarkHelpers.profile(1000)
 
 __END__
 

--- a/benchmarks/singleton_example_groups/with_shared_context_inclusions.rb
+++ b/benchmarks/singleton_example_groups/with_shared_context_inclusions.rb
@@ -1,0 +1,27 @@
+require_relative "helper"
+
+1.upto(10) do |i|
+  RSpec.shared_context "context #{i}", :apply_it do
+  end
+end
+
+BenchmarkHelpers.run_benchmarks
+
+__END__
+
+No match -- without singleton group support
+                        503.700  (±33.2%) i/s -      2.184k
+No match -- with singleton group support
+                        471.018  (±26.8%) i/s -      2.009k
+Example match -- without singleton group support
+                        467.859  (±34.8%) i/s -      2.021k in   5.600106s
+Example match -- with singleton group support
+                         84.138  (±34.5%) i/s -    296.000  in   5.515586s
+Group match -- without singleton group support
+                        384.144  (±27.9%) i/s -      1.560k
+Group match -- with singleton group support
+                        349.301  (±27.5%) i/s -      1.288k
+Both match -- without singleton group support
+                        388.100  (±25.8%) i/s -      1.702k
+Both match -- with singleton group support
+                        339.310  (±20.3%) i/s -      1.504k

--- a/benchmarks/singleton_example_groups/with_shared_context_inclusions.rb
+++ b/benchmarks/singleton_example_groups/with_shared_context_inclusions.rb
@@ -11,18 +11,18 @@ BenchmarkHelpers.run_benchmarks
 __END__
 
 No match -- without singleton group support
-                        503.700  (±33.2%) i/s -      2.184k
+                        563.304  (±29.6%) i/s -      2.385k
 No match -- with singleton group support
-                        471.018  (±26.8%) i/s -      2.009k
+                        538.738  (±22.3%) i/s -      2.209k
 Example match -- without singleton group support
-                        467.859  (±34.8%) i/s -      2.021k in   5.600106s
+                        546.605  (±25.6%) i/s -      2.450k
 Example match -- with singleton group support
-                         84.138  (±34.5%) i/s -    296.000  in   5.515586s
+                        421.111  (±23.5%) i/s -      1.845k
 Group match -- without singleton group support
-                        384.144  (±27.9%) i/s -      1.560k
+                        536.267  (±27.4%) i/s -      2.050k
 Group match -- with singleton group support
-                        349.301  (±27.5%) i/s -      1.288k
+                        508.644  (±17.7%) i/s -      2.268k
 Both match -- without singleton group support
-                        388.100  (±25.8%) i/s -      1.702k
+                        538.047  (±27.7%) i/s -      2.067k in   5.431649s
 Both match -- with singleton group support
-                        339.310  (±20.3%) i/s -      1.504k
+                        505.388  (±26.7%) i/s -      1.880k in   5.578614s

--- a/features/example_groups/shared_context.feature
+++ b/features/example_groups/shared_context.feature
@@ -4,6 +4,8 @@ Feature: shared context
   of example groups either explicitly, using `include_context`, or implicitly by
   matching metadata.
 
+  When implicitly including shared contexts via matching metadata, the normal way is to define matching metadata on an example group (in which case the ontext is included in the entire group), but you can also include it in an individual example. RSpec treats every example as having a singleton example group (analogous to Ruby's singleton classes) containing just the one example.
+
   Background:
     Given a file named "shared_stuff.rb" with:
       """ruby
@@ -85,6 +87,24 @@ Feature: shared context
 
         it "accesses the subject defined in the shared context" do
           expect(subject).to eq('this is the subject')
+        end
+      end
+      """
+    When I run `rspec shared_context_example.rb`
+    Then the examples should all pass
+
+  Scenario: Declare a shared context and include it with metadata of an individual example
+    Given a file named "shared_context_example.rb" with:
+      """ruby
+      require "./shared_stuff.rb"
+
+      RSpec.describe "group that does not include the shared context" do
+        it "does not have access to shared methods normally" do
+          expect(self).not_to respond_to(:shared_method)
+        end
+
+        it "has access to shared methods from examples with matching metadata", :a => :b do
+          expect(shared_method).to eq("it works")
         end
       end
       """

--- a/features/helper_methods/modules.feature
+++ b/features/helper_methods/modules.feature
@@ -11,6 +11,8 @@ Feature: Define helper methods in a module
   given metadata will `include` or `extend` the module. You can also specify
   metadata using only symbols.
 
+  Note that examples that match a `config.include` module's metadata will also have the module included. RSpec treats every example as having a singleton example group (analogous to Ruby's singleton classes) containing just the one example.
+
   Background:
     Given a file named "helpers.rb" with:
       """ruby
@@ -78,6 +80,10 @@ Feature: Define helper methods in a module
       RSpec.describe "an example group without matching metadata" do
         it "does not have access to the helper methods defined in the module" do
           expect { help }.to raise_error(NameError)
+        end
+
+        it "does have access when the example has matching metadata", :foo => :bar do
+          expect(help).to be(:available)
         end
       end
       """

--- a/features/hooks/filtering.feature
+++ b/features/hooks/filtering.feature
@@ -14,6 +14,8 @@ Feature: filters
   end
   ```
 
+  Note that filtered `:context` hooks will still be applied to individual examples with matching metadata -- in effect, every example has a singleton example group containing just the one example (analogous to Ruby's singleton classes).
+
   You can also specify metadata using only symbols.
 
   Scenario: Filter `before(:example)` hooks using arbitrary metadata
@@ -127,6 +129,10 @@ Feature: filters
             expect(@hook).to be_nil
           end
 
+          it "runs the hook for a single example with matching metadata", :foo => :bar do
+            expect(@hook).to eq(:before_context_foo_bar)
+          end
+
           describe "a nested subgroup with matching metadata", :foo => :bar do
             it "runs the hook" do
               expect(@hook).to eq(:before_context_foo_bar)
@@ -166,31 +172,37 @@ Feature: filters
           it "does not run the hook" do
             puts "unfiltered"
           end
+
+          it "runs the hook for a single example with matching metadata", :foo => :bar do
+            puts "filtered 1"
+          end
         end
 
         describe "a group with matching metadata", :foo => :bar do
           it "runs the hook" do
-            puts "filtered 1"
+            puts "filtered 2"
           end
         end
 
         describe "another group without matching metadata" do
           describe "a nested subgroup with matching metadata", :foo => :bar do
             it "runs the hook" do
-              puts "filtered 2"
+              puts "filtered 3"
             end
           end
         end
       end
       """
-    When I run `rspec --format progress filter_after_context_hooks_spec.rb`
+    When I run `rspec --format progress filter_after_context_hooks_spec.rb --order defined`
     Then the examples should all pass
     And the output should contain:
       """
       unfiltered
       .filtered 1
+      after :context
+      .filtered 2
       .after :context
-      filtered 2
+      filtered 3
       .after :context
       """
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1525,6 +1525,14 @@ module RSpec
         end
       end
 
+      # @private
+      # Holds the various registered hooks. Here we use a FilterableItemRepository
+      # implementation that is specifically optimized for the read/write patterns
+      # of the config object.
+      def hooks
+        @hooks ||= HookCollections.new(self, FilterableItemRepository::QueryOptimized)
+      end
+
     private
 
       def handle_suite_hook(args, collection, append_or_prepend, hook_type, block)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1019,7 +1019,7 @@ module RSpec
 
       # Tells RSpec to include `mod` in example groups. Methods defined in
       # `mod` are exposed to examples (not example groups). Use `filters` to
-      # constrain the groups in which to include the module.
+      # constrain the groups or examples in which to include the module.
       #
       # @example
       #
@@ -1047,6 +1047,13 @@ module RSpec
       #         assert_select ".username", :text => 'jdoe'
       #       end
       #     end
+      #
+      # @note Filtered module inclusions can also be applied to
+      #   individual examples that have matching metadata. Just like
+      #   Ruby's object model is that every object has a singleton class
+      #   which has only a single instance, RSpec's model is that every
+      #   example has a singleton example group containing just the one
+      #   example.
       #
       # @see #extend
       # @see #prepend

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1158,8 +1158,12 @@ module RSpec
       # Used internally to extend the singleton class of a single example's
       # example group instance with modules using `include` and/or `extend`.
       def configure_example(example)
-        @include_modules.items_for(example.metadata).each do |mod|
-          safe_include(mod, example.example_group_instance.singleton_class)
+        # We replace the metadata so that SharedExampleGroupModule#included
+        # has access to the example's metadata[:location].
+        example.example_group_instance.singleton_class.with_replaced_metadata(example.metadata) do
+          @include_modules.items_for(example.metadata).each do |mod|
+            safe_include(mod, example.example_group_instance.singleton_class)
+          end
         end
       end
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1156,11 +1156,6 @@ module RSpec
         end
       end
 
-      # @private
-      def safe_include(mod, host)
-        host.__send__(:include, mod) unless host < mod
-      end
-
       if RSpec::Support::RubyFeatures.module_prepends_supported?
         # @private
         def safe_prepend(mod, host)
@@ -1179,10 +1174,20 @@ module RSpec
       # @private
       if RUBY_VERSION.to_f >= 1.9
         # @private
+        def safe_include(mod, host)
+          host.__send__(:include, mod) unless host < mod
+        end
+
+        # @private
         def safe_extend(mod, host)
           host.extend(mod) unless host.singleton_class < mod
         end
       else
+        # @private
+        def safe_include(mod, host)
+          host.__send__(:include, mod) unless host.included_modules.include?(mod)
+        end
+
         # @private
         def safe_extend(mod, host)
           host.extend(mod) unless (class << host; self; end).included_modules.include?(mod)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1147,6 +1147,16 @@ module RSpec
       end
 
       # @private
+      #
+      # Used internally to extend the singleton class of a single example's
+      # example group instance with modules using `include` and/or `extend`.
+      def configure_example(example)
+        @include_modules.items_for(example.metadata).each do |mod|
+          safe_include(mod, example.example_group_instance.singleton_class)
+        end
+      end
+
+      # @private
       def safe_include(mod, host)
         host.__send__(:include, mod) unless host < mod
       end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -297,9 +297,9 @@ module RSpec
         @start_time = $_rspec_core_load_started_at || ::RSpec::Core::Time.now
         # rubocop:enable Style/GlobalVars
         @expectation_frameworks = []
-        @include_modules = FilterableItemRepository.new(:any?)
-        @extend_modules  = FilterableItemRepository.new(:any?)
-        @prepend_modules = FilterableItemRepository.new(:any?)
+        @include_modules = FilterableItemRepository::QueryOptimized.new(:any?)
+        @extend_modules  = FilterableItemRepository::QueryOptimized.new(:any?)
+        @prepend_modules = FilterableItemRepository::QueryOptimized.new(:any?)
 
         @before_suite_hooks = []
         @after_suite_hooks  = []
@@ -333,7 +333,7 @@ module RSpec
         @profile_examples = false
         @requires = []
         @libs = []
-        @derived_metadata_blocks = FilterableItemRepository.new(:any?)
+        @derived_metadata_blocks = FilterableItemRepository::QueryOptimized.new(:any?)
       end
 
       # @private

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -160,6 +160,7 @@ module RSpec
       # @param example_group_instance the instance of an ExampleGroup subclass
       def run(example_group_instance, reporter)
         @example_group_instance = example_group_instance
+        RSpec.configuration.configure_example(self)
         RSpec.current_example = self
 
         start(reporter)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -170,7 +170,7 @@ module RSpec
           if skipped?
             Pending.mark_pending! self, skip
           elsif !RSpec.configuration.dry_run?
-            with_around_example_hooks do
+            with_around_and_singleton_context_hooks do
               begin
                 run_before_example
                 @example_group_instance.instance_exec(self, &@example_block)
@@ -376,6 +376,14 @@ module RSpec
       def run_before_example
         @example_group_instance.setup_mocks_for_rspec
         hooks.run(:before, :example, self)
+      end
+
+      def with_around_and_singleton_context_hooks
+        singleton_context_hooks_host = example_group_instance.singleton_class
+        singleton_context_hooks_host.run_before_context_hooks(example_group_instance)
+        with_around_example_hooks { yield }
+      ensure
+        singleton_context_hooks_host.run_after_context_hooks(example_group_instance)
       end
 
       def run_after_example

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -160,6 +160,7 @@ module RSpec
       # @param example_group_instance the instance of an ExampleGroup subclass
       def run(example_group_instance, reporter)
         @example_group_instance = example_group_instance
+        hooks.register_global_singleton_context_hooks(self, RSpec.configuration.hooks)
         RSpec.configuration.configure_example(self)
         RSpec.current_example = self
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -334,8 +334,12 @@ module RSpec
 
     private
 
+      def hooks
+        example_group_instance.singleton_class.hooks
+      end
+
       def with_around_example_hooks
-        @example_group_class.hooks.run(:around, :example, self) { yield }
+        hooks.run(:around, :example, self) { yield }
       rescue Exception => e
         set_exception(e, "in an `around(:example)` hook")
       end
@@ -371,12 +375,12 @@ module RSpec
 
       def run_before_example
         @example_group_instance.setup_mocks_for_rspec
-        @example_group_class.hooks.run(:before, :example, self)
+        hooks.run(:before, :example, self)
       end
 
       def run_after_example
         assign_generated_description if defined?(::RSpec::Matchers)
-        @example_group_class.hooks.run(:after, :example, self)
+        hooks.run(:after, :example, self)
         verify_mocks
       ensure
         @example_group_instance.teardown_mocks_for_rspec

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -573,6 +573,13 @@ module RSpec
         "#<#{self.class} #{@__inspect_output}>"
       end
 
+      unless method_defined?(:singleton_class) # for 1.8.7
+        # @private
+        def singleton_class
+          class << self; self; end
+        end
+      end
+
       # Raised when an RSpec API is called in the wrong scope, such as `before`
       # being called from within an example rather than from within an example
       # group block.

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -45,7 +45,21 @@ module RSpec
       # The [Metadata](Metadata) object associated with this group.
       # @see Metadata
       def self.metadata
-        @metadata if defined?(@metadata)
+        @metadata ||= nil
+      end
+
+      # Temporarily replace the provided metadata.
+      # Intended primarily to allow an example group's singleton class
+      # to return the metadata of the example that it exists for. This
+      # is necessary for shared example group inclusion to work properly
+      # with singleton example groups.
+      # @private
+      def self.with_replaced_metadata(meta)
+        orig_metadata = metadata
+        @metadata = meta
+        yield
+      ensure
+        @metadata = orig_metadata
       end
 
       # @private
@@ -333,7 +347,7 @@ module RSpec
           raise ArgumentError, "Could not find shared #{label} #{name.inspect}"
         end
 
-        SharedExampleGroupInclusionStackFrame.with_frame(name, inclusion_location) do
+        SharedExampleGroupInclusionStackFrame.with_frame(name, Metadata.relative_path(inclusion_location)) do
           module_exec(*args, &shared_block)
           module_exec(&customization_block) if customization_block
         end

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -582,13 +582,13 @@ EOS
         end
 
         def run_example_hooks_for(example, position, each_method)
-          @owner.parent_groups.__send__(each_method) do |group|
+          owner_parent_groups.__send__(each_method) do |group|
             group.hooks.run_owned_hooks_for(position, :example, example)
           end
         end
 
         def run_around_example_hooks_for(example)
-          hooks = FlatMap.flat_map(@owner.parent_groups) do |group|
+          hooks = FlatMap.flat_map(owner_parent_groups) do |group|
             group.hooks.matching_hooks_for(:around, :example, example)
           end
 
@@ -598,6 +598,16 @@ EOS
           hooks.inject(initial_procsy) do |procsy, around_hook|
             procsy.wrap { around_hook.execute_with(example, procsy) }
           end.call
+        end
+
+        if respond_to?(:singleton_class) && singleton_class.ancestors.include?(singleton_class)
+          def owner_parent_groups
+            @owner.parent_groups
+          end
+        else # Ruby < 2.1 (see https://bugs.ruby-lang.org/issues/8035)
+          def owner_parent_groups
+            @owner_parent_groups ||= [@owner] + @owner.parent_groups
+          end
         end
       end
     end

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -88,6 +88,13 @@ module RSpec
       #       end
       #     end
       #
+      # Note that filtered config `:context` hooks can still be applied
+      # to individual examples that have matching metadata. Just like
+      # Ruby's object model is that every object has a singleton class
+      # which has only a single instance, RSpec's model is that every
+      # example has a singleton example group containing just the one
+      # example.
+      #
       # ### Warning: `before(:suite, :with => :conditions)`
       #
       # The conditions hash is used to match against specific examples. Since

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -540,18 +540,18 @@ EOS
         def ensure_hooks_initialized_for(position, scope)
           if position == :before
             if scope == :example
-              @before_example_hooks ||= FilterableItemRepository.new(:all?)
+              @before_example_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
             else
-              @before_context_hooks ||= FilterableItemRepository.new(:all?)
+              @before_context_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
             end
           elsif position == :after
             if scope == :example
-              @after_example_hooks ||= FilterableItemRepository.new(:all?)
+              @after_example_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
             else
-              @after_context_hooks ||= FilterableItemRepository.new(:all?)
+              @after_context_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
             end
           else # around
-            @around_example_hooks ||= FilterableItemRepository.new(:all?)
+            @around_example_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
           end
         end
 

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -336,7 +336,7 @@ module RSpec
       # @private
       # Holds the various registered hooks.
       def hooks
-        @hooks ||= HookCollections.new(self)
+        @hooks ||= HookCollections.new(self, FilterableItemRepository::UpdateOptimized)
       end
 
     private
@@ -413,13 +413,14 @@ EOS
       # API, so that callers _tell_ this class what to do with the hooks, rather than
       # asking this class for a list of hooks, and then doing something with them.
       class HookCollections
-        def initialize(owner)
-          @owner = owner
-          @before_example_hooks = nil
-          @after_example_hooks  = nil
-          @before_context_hooks = nil
-          @after_context_hooks  = nil
-          @around_example_hooks = nil
+        def initialize(owner, filterable_item_repo_class)
+          @owner                      = owner
+          @filterable_item_repo_class = filterable_item_repo_class
+          @before_example_hooks       = nil
+          @after_example_hooks        = nil
+          @before_context_hooks       = nil
+          @after_context_hooks        = nil
+          @around_example_hooks       = nil
         end
 
         def register_globals(host, globals)
@@ -540,18 +541,18 @@ EOS
         def ensure_hooks_initialized_for(position, scope)
           if position == :before
             if scope == :example
-              @before_example_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
+              @before_example_hooks ||= @filterable_item_repo_class.new(:all?)
             else
-              @before_context_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
+              @before_context_hooks ||= @filterable_item_repo_class.new(:all?)
             end
           elsif position == :after
             if scope == :example
-              @after_example_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
+              @after_example_hooks ||= @filterable_item_repo_class.new(:all?)
             else
-              @after_context_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
+              @after_context_hooks ||= @filterable_item_repo_class.new(:all?)
             end
           else # around
-            @around_example_hooks ||= FilterableItemRepository::QueryOptimized.new(:all?)
+            @around_example_hooks ||= @filterable_item_repo_class.new(:all?)
           end
         end
 

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -80,95 +80,140 @@ module RSpec
     # Tracks a collection of filterable items (e.g. modules, hooks, etc)
     # and provides an optimized API to get the applicable items for the
     # metadata of an example or example group.
+    #
+    # There are two implementations, optimized for different uses.
     # @private
-    class FilterableItemRepository
-      attr_reader :items_and_filters
+    module FilterableItemRepository
+      # This implementation is simple, and is optimized for frequent
+      # updates but rare queries. `append` and `prepend` do no extra
+      # processing, and no internal memoization is done, since this
+      # is not optimized for queries.
+      #
+      # This is ideal for use by a example or example group, which may
+      # be updated multiple times with globally configured hooks, etc,
+      # but will not be queried frequently by other examples or examle
+      # groups.
+      # @private
+      class UpdateOptimized
+        attr_reader :items_and_filters
 
-      def initialize(applies_predicate)
-        @applies_predicate = applies_predicate
-        @items_and_filters = []
-        @applicable_keys   = Set.new
-        @proc_keys         = Set.new
-        @memoized_lookups  = Hash.new do |hash, applicable_metadata|
-          hash[applicable_metadata] = find_items_for(applicable_metadata)
+        def initialize(applies_predicate)
+          @applies_predicate = applies_predicate
+          @items_and_filters = []
         end
-      end
 
-      def append(item, metadata)
-        @items_and_filters << [item, metadata]
-        handle_mutation(metadata)
-      end
-
-      def prepend(item, metadata)
-        @items_and_filters.unshift [item, metadata]
-        handle_mutation(metadata)
-      end
-
-      def items_for(metadata)
-        # The filtering of `metadata` to `applicable_metadata` is the key thing
-        # that makes the memoization actually useful in practice, since each
-        # example and example group have different metadata (e.g. location and
-        # description). By filtering to the metadata keys our items care about,
-        # we can ignore extra metadata keys that differ for each example/group.
-        # For example, given `config.include DBHelpers, :db`, example groups
-        # can be split into these two sets: those that are tagged with `:db` and those
-        # that are not. For each set, this method for the first group in the set is
-        # still an `O(N)` calculation, but all subsequent groups in the set will be
-        # constant time lookups when they call this method.
-        applicable_metadata = applicable_metadata_from(metadata)
-
-        if applicable_metadata.any? { |k, _| @proc_keys.include?(k) }
-          # It's unsafe to memoize lookups involving procs (since they can
-          # be non-deterministic), so we skip the memoization in this case.
-          find_items_for(applicable_metadata)
-        else
-          @memoized_lookups[applicable_metadata]
+        def append(item, metadata)
+          @items_and_filters << [item, metadata]
         end
-      end
 
-    private
-
-      def handle_mutation(metadata)
-        @applicable_keys.merge(metadata.keys)
-        @proc_keys.merge(proc_keys_from metadata)
-        @memoized_lookups.clear
-      end
-
-      def applicable_metadata_from(metadata)
-        @applicable_keys.inject({}) do |hash, key|
-          hash[key] = metadata[key] if metadata.key?(key)
-          hash
+        def prepend(item, metadata)
+          @items_and_filters.unshift [item, metadata]
         end
-      end
 
-      def find_items_for(request_meta)
-        @items_and_filters.each_with_object([]) do |(item, item_meta), to_return|
-          to_return << item if item_meta.empty? ||
-                               MetadataFilter.apply?(@applies_predicate, item_meta, request_meta)
-        end
-      end
-
-      def proc_keys_from(metadata)
-        metadata.each_with_object([]) do |(key, value), to_return|
-          to_return << key if Proc === value
-        end
-      end
-
-      unless [].respond_to?(:each_with_object) # For 1.8.7
-        undef find_items_for
-        def find_items_for(request_meta)
-          @items_and_filters.inject([]) do |to_return, (item, item_meta)|
+        def items_for(request_meta)
+          @items_and_filters.each_with_object([]) do |(item, item_meta), to_return|
             to_return << item if item_meta.empty? ||
                                  MetadataFilter.apply?(@applies_predicate, item_meta, request_meta)
-            to_return
           end
         end
 
-        undef proc_keys_from
+        unless [].respond_to?(:each_with_object) # For 1.8.7
+          undef items_for
+          def items_for(request_meta)
+            @items_and_filters.inject([]) do |to_return, (item, item_meta)|
+              to_return << item if item_meta.empty? ||
+                                   MetadataFilter.apply?(@applies_predicate, item_meta, request_meta)
+              to_return
+            end
+          end
+        end
+      end
+
+      # This implementation is much more complex, and is optimized for
+      # rare (or hopefully no) updates once the queries start. Updates
+      # incur a cost as it has to clear the memoization and keep track
+      # of applicable keys. Queries will be O(N) the first time an item
+      # is provided with a given set of applicable metadata; subsequent
+      # queries with items with the same set of applicable metadata will
+      # be O(1) due to internal memoization.
+      #
+      # This is ideal for use by config, where filterable items (e.g. hooks)
+      # are typically added at the start of the process (e.g. in `spec_helper`)
+      # and then repeatedly queried as example groups and examples are defined.
+      # @private
+      class QueryOptimized < UpdateOptimized
+        alias find_items_for items_for
+        private :find_items_for
+
+        def initialize(applies_predicate)
+          super
+          @applicable_keys   = Set.new
+          @proc_keys         = Set.new
+          @memoized_lookups  = Hash.new do |hash, applicable_metadata|
+            hash[applicable_metadata] = find_items_for(applicable_metadata)
+          end
+        end
+
+        def append(item, metadata)
+          super
+          handle_mutation(metadata)
+        end
+
+        def prepend(item, metadata)
+          super
+          handle_mutation(metadata)
+        end
+
+        def items_for(metadata)
+          # The filtering of `metadata` to `applicable_metadata` is the key thing
+          # that makes the memoization actually useful in practice, since each
+          # example and example group have different metadata (e.g. location and
+          # description). By filtering to the metadata keys our items care about,
+          # we can ignore extra metadata keys that differ for each example/group.
+          # For example, given `config.include DBHelpers, :db`, example groups
+          # can be split into these two sets: those that are tagged with `:db` and those
+          # that are not. For each set, this method for the first group in the set is
+          # still an `O(N)` calculation, but all subsequent groups in the set will be
+          # constant time lookups when they call this method.
+          applicable_metadata = applicable_metadata_from(metadata)
+
+          if applicable_metadata.any? { |k, _| @proc_keys.include?(k) }
+            # It's unsafe to memoize lookups involving procs (since they can
+            # be non-deterministic), so we skip the memoization in this case.
+            find_items_for(applicable_metadata)
+          else
+            @memoized_lookups[applicable_metadata]
+          end
+        end
+
+      private
+
+        def handle_mutation(metadata)
+          @applicable_keys.merge(metadata.keys)
+          @proc_keys.merge(proc_keys_from metadata)
+          @memoized_lookups.clear
+        end
+
+        def applicable_metadata_from(metadata)
+          @applicable_keys.inject({}) do |hash, key|
+            hash[key] = metadata[key] if metadata.key?(key)
+            hash
+          end
+        end
+
         def proc_keys_from(metadata)
-          metadata.inject([]) do |to_return, (key, value)|
+          metadata.each_with_object([]) do |(key, value), to_return|
             to_return << key if Proc === value
-            to_return
+          end
+        end
+
+        unless [].respond_to?(:each_with_object) # For 1.8.7
+          undef proc_keys_from
+          def proc_keys_from(metadata)
+            metadata.inject([]) do |to_return, (key, value)|
+              to_return << key if Proc === value
+              to_return
+            end
           end
         end
       end

--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -48,13 +48,13 @@ module RSpec
       #   @param name [String, Symbol, Module] identifer to use when looking up
       #     this shared group
       #   @param metadata [Array<Symbol>, Hash] metadata to attach to this
-      #     group; any example group with matching metadata will automatically
-      #     include this shared example group.
+      #     group; any example group or example with matching metadata will
+      #     automatically include this shared example group.
       #   @param block The block to be eval'd
       # @overload shared_examples(metadata, &block)
       #   @param metadata [Array<Symbol>, Hash] metadata to attach to this
-      #     group; any example group with matching metadata will automatically
-      #     include this shared example group.
+      #     group; any example group or example with matching metadata will
+      #     automatically include this shared example group.
       #   @param block The block to be eval'd
       #
       # Stores the block for later use. The block will be evaluated

--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -20,7 +20,8 @@ module RSpec
       # Our definition evaluates the shared group block in the context of the
       # including example group.
       def included(klass)
-        SharedExampleGroupInclusionStackFrame.with_frame(@description, RSpec::CallerFilter.first_non_rspec_line) do
+        inclusion_line = klass.metadata[:location]
+        SharedExampleGroupInclusionStackFrame.with_frame(@description, inclusion_line) do
           klass.class_exec(&@definition)
         end
       end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -4,8 +4,6 @@ module RSpec
     #
     # Internal container for global non-configuration data.
     class World
-      include RSpec::Core::Hooks
-
       # @private
       attr_reader :example_groups, :filtered_examples
 

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1662,7 +1662,8 @@ module RSpec::Core
       rspec_core_methods = ExampleGroup.instance_methods -
         RSpec::Matchers.instance_methods -
         RSpec::Mocks::ExampleMethods.instance_methods -
-        Object.instance_methods
+        Object.instance_methods -
+        ["singleton_class"]
 
       # Feel free to expand this list if you intend to add another public API
       # for users. RSpec internals should not add methods here, though.

--- a/spec/rspec/core/filterable_item_repository_spec.rb
+++ b/spec/rspec/core/filterable_item_repository_spec.rb
@@ -3,187 +3,199 @@ module RSpec
     RSpec.describe FilterableItemRepository, "#items_for" do
       FilterableItem = Struct.new(:name)
 
-      let(:repo)   { FilterableItemRepository.new(:any?) }
-      let(:item_1) { FilterableItem.new("Item 1") }
-      let(:item_2) { FilterableItem.new("Item 2") }
-      let(:item_3) { FilterableItem.new("Item 3") }
-      let(:item_4) { FilterableItem.new("Item 4") }
+      def self.it_behaves_like_a_filterable_item_repo(&when_the_repo_has_items_with_metadata)
+        let(:repo)   { described_class.new(:any?) }
+        let(:item_1) { FilterableItem.new("Item 1") }
+        let(:item_2) { FilterableItem.new("Item 2") }
+        let(:item_3) { FilterableItem.new("Item 3") }
+        let(:item_4) { FilterableItem.new("Item 4") }
 
-      context "when the repository is empty" do
-        it 'returns an empty list' do
-          expect(repo.items_for(:foo => "bar")).to eq([])
+        context "when the repository is empty" do
+          it 'returns an empty list' do
+            expect(repo.items_for(:foo => "bar")).to eq([])
+          end
         end
-      end
 
-      shared_examples_for "adding items to the repository" do |add_method|
-        describe "adding items using `#{add_method}`" do
-          define_method :add_item do |*args|
-            repo.__send__ add_method, *args
-          end
-
-          context "when the repository has items that have no metadata" do
-            before do
-              add_item item_1, {}
-              add_item item_2, {}
+        shared_examples_for "adding items to the repository" do |add_method|
+          describe "adding items using `#{add_method}`" do
+            define_method :add_item do |*args|
+              repo.__send__ add_method, *args
             end
 
-            it "returns those items, regardless of the provided argument" do
-              expect(repo.items_for({})).to contain_exactly(item_1, item_2)
-              expect(repo.items_for(:foo => "bar")).to contain_exactly(item_1, item_2)
-            end
-          end
-
-          context "when the repository has items that have metadata" do
-            before do
-              add_item item_1, :foo => "bar"
-              add_item item_2, :slow => true
-              add_item item_3, :foo => "bar"
-            end
-
-            it 'return an empty list when given empty metadata' do
-              expect(repo.items_for({})).to eq([])
-            end
-
-            it 'return an empty list when given metadata that matches no items' do
-              expect(repo.items_for(:slow => false, :foo => "bazz")).to eq([])
-            end
-
-            it 'returns matching items for the provided metadata' do
-              expect(repo.items_for(:slow => true)).to contain_exactly(item_2)
-              expect(repo.items_for(:foo => "bar")).to contain_exactly(item_1, item_3)
-              expect(repo.items_for(:slow => true, :foo => "bar")).to contain_exactly(item_1, item_2, item_3)
-            end
-
-            it 'returns the matching items in the correct order' do
-              expect(repo.items_for(:slow => true, :foo => "bar")).to eq items_in_expected_order
-            end
-
-            it 'ignores other metadata keys that are not related to the appended items' do
-              expect(repo.items_for(:slow => true, :other => "foo")).to contain_exactly(item_2)
-            end
-
-            it 'differentiates between an applicable key being missing and having an explicit `nil` value' do
-              add_item item_4, :bar => nil
-
-              expect(repo.items_for({})).to eq([])
-              expect(repo.items_for(:bar => nil)).to contain_exactly(item_4)
-            end
-
-            it 'returns the correct items when they are appended after a memoized lookup' do
-              expect {
-                add_item item_4, :slow => true
-              }.to change { repo.items_for(:slow => true) }.
-                from(a_collection_containing_exactly(item_2)).
-                to(a_collection_containing_exactly(item_2, item_4))
-            end
-
-            let(:flip_proc) do
-              return_val = true
-              Proc.new { return_val.tap { |v| return_val = !v } }
-            end
-
-            context "with proc values" do
+            context "when the repository has items that have no metadata" do
               before do
-                add_item item_4, { :include_it => flip_proc }
+                add_item item_1, {}
+                add_item item_2, {}
               end
 
-              it 'evaluates the proc each time since the logic can return a different value each time' do
-                expect(repo.items_for(:include_it => nil)).to contain_exactly(item_4)
-                expect(repo.items_for(:include_it => nil)).to eq([])
-                expect(repo.items_for(:include_it => nil)).to contain_exactly(item_4)
-                expect(repo.items_for(:include_it => nil)).to eq([])
-              end
-            end
-
-            context "when initialized with the `:any?` predicate" do
-              let(:repo) { FilterableItemRepository.new(:any?) }
-
-              it 'matches against multi-entry items when any of the metadata entries match' do
-                add_item item_4, :key_1 => "val_1", :key_2 => "val_2"
-
-                expect(repo.items_for(:key_1 => "val_1")).to contain_exactly(item_4)
-                expect(repo.items_for(:key_2 => "val_2")).to contain_exactly(item_4)
-                expect(repo.items_for(:key_1 => "val_1", :key_2 => "val_2")).to contain_exactly(item_4)
+              it "returns those items, regardless of the provided argument" do
+                expect(repo.items_for({})).to contain_exactly(item_1, item_2)
+                expect(repo.items_for(:foo => "bar")).to contain_exactly(item_1, item_2)
               end
             end
 
-            context "when initialized with the `:all?` predicate" do
-              let(:repo) { FilterableItemRepository.new(:all?) }
-
-              it 'matches against multi-entry items when all of the metadata entries match' do
-                add_item item_4, :key_1 => "val_1", :key_2 => "val_2"
-
-                expect(repo.items_for(:key_1 => "val_1")).to eq([])
-                expect(repo.items_for(:key_2 => "val_2")).to eq([])
-                expect(repo.items_for(:key_1 => "val_1", :key_2 => "val_2")).to contain_exactly(item_4)
-              end
-            end
-
-            describe "performance optimization" do
-              # NOTE: the specs in this context are potentially brittle because they are
-              # coupled to the implementation's usage of `MetadataFilter.apply?`. However,
-              # they demonstrate the perf optimization that was the reason we created
-              # this class, and thus have value in demonstrating the memoization is working
-              # properly and in documenting the reason the class exists in the first place.
-              # Still, if these prove to be brittle in the future, feel free to delete them since
-              # they are not concerned with externally visible behaviors.
-
-              it 'is optimized to check metadata filter application for a given pair of metadata hashes only once' do
-                # TODO: use mock expectations for this once https://github.com/rspec/rspec-mocks/pull/841 is fixed.
-                call_counts = track_metadata_filter_apply_calls
-
-                3.times do
-                  expect(repo.items_for(:slow => true, :other => "foo")).to contain_exactly(item_2)
-                end
-
-                expect(call_counts[:slow => true]).to eq(1)
+            context "when the repository has items that have metadata" do
+              before do
+                add_item item_1, :foo => "bar"
+                add_item item_2, :slow => true
+                add_item item_3, :foo => "bar"
               end
 
-              it 'ignores extraneous metadata keys when doing memoized lookups' do
-                # TODO: use mock expectations for this once https://github.com/rspec/rspec-mocks/pull/841 is fixed.
-                call_counts = track_metadata_filter_apply_calls
+              it 'return an empty list when given empty metadata' do
+                expect(repo.items_for({})).to eq([])
+              end
 
+              it 'return an empty list when given metadata that matches no items' do
+                expect(repo.items_for(:slow => false, :foo => "bazz")).to eq([])
+              end
+
+              it 'returns matching items for the provided metadata' do
+                expect(repo.items_for(:slow => true)).to contain_exactly(item_2)
+                expect(repo.items_for(:foo => "bar")).to contain_exactly(item_1, item_3)
+                expect(repo.items_for(:slow => true, :foo => "bar")).to contain_exactly(item_1, item_2, item_3)
+              end
+
+              it 'returns the matching items in the correct order' do
+                expect(repo.items_for(:slow => true, :foo => "bar")).to eq items_in_expected_order
+              end
+
+              it 'ignores other metadata keys that are not related to the appended items' do
                 expect(repo.items_for(:slow => true, :other => "foo")).to contain_exactly(item_2)
-                expect(repo.items_for(:slow => true, :other => "bar")).to contain_exactly(item_2)
-                expect(repo.items_for(:slow => true, :goo => "bazz")).to contain_exactly(item_2)
-
-                expect(call_counts[:slow => true]).to eq(1)
               end
 
-              context "when there are some proc keys" do
+              it 'differentiates between an applicable key being missing and having an explicit `nil` value' do
+                add_item item_4, :bar => nil
+
+                expect(repo.items_for({})).to eq([])
+                expect(repo.items_for(:bar => nil)).to contain_exactly(item_4)
+              end
+
+              it 'returns the correct items when they are appended after a memoized lookup' do
+                expect {
+                  add_item item_4, :slow => true
+                }.to change { repo.items_for(:slow => true) }.
+                  from(a_collection_containing_exactly(item_2)).
+                  to(a_collection_containing_exactly(item_2, item_4))
+              end
+
+              let(:flip_proc) do
+                return_val = true
+                Proc.new { return_val.tap { |v| return_val = !v } }
+              end
+
+              context "with proc values" do
                 before do
                   add_item item_4, { :include_it => flip_proc }
                 end
 
-                it 'still performs memoization for metadata hashes that lack those keys' do
-                  call_counts = track_metadata_filter_apply_calls
-
-                  expect(repo.items_for(:slow => true, :other => "foo")).to contain_exactly(item_2)
-                  expect(repo.items_for(:slow => true, :other => "foo")).to contain_exactly(item_2)
-
-                  expect(call_counts[:slow => true]).to eq(1)
+                it 'evaluates the proc each time since the logic can return a different value each time' do
+                  expect(repo.items_for(:include_it => nil)).to contain_exactly(item_4)
+                  expect(repo.items_for(:include_it => nil)).to eq([])
+                  expect(repo.items_for(:include_it => nil)).to contain_exactly(item_4)
+                  expect(repo.items_for(:include_it => nil)).to eq([])
                 end
               end
 
-              def track_metadata_filter_apply_calls
-                Hash.new(0).tap do |call_counts|
-                  allow(MetadataFilter).to receive(:apply?).and_wrap_original do |original, predicate, item_meta, request_meta|
-                    call_counts[item_meta] += 1
-                    original.call(predicate, item_meta, request_meta)
-                  end
+              context "when initialized with the `:any?` predicate" do
+                let(:repo) { FilterableItemRepository::QueryOptimized.new(:any?) }
+
+                it 'matches against multi-entry items when any of the metadata entries match' do
+                  add_item item_4, :key_1 => "val_1", :key_2 => "val_2"
+
+                  expect(repo.items_for(:key_1 => "val_1")).to contain_exactly(item_4)
+                  expect(repo.items_for(:key_2 => "val_2")).to contain_exactly(item_4)
+                  expect(repo.items_for(:key_1 => "val_1", :key_2 => "val_2")).to contain_exactly(item_4)
+                end
+              end
+
+              context "when initialized with the `:all?` predicate" do
+                let(:repo) { FilterableItemRepository::QueryOptimized.new(:all?) }
+
+                it 'matches against multi-entry items when all of the metadata entries match' do
+                  add_item item_4, :key_1 => "val_1", :key_2 => "val_2"
+
+                  expect(repo.items_for(:key_1 => "val_1")).to eq([])
+                  expect(repo.items_for(:key_2 => "val_2")).to eq([])
+                  expect(repo.items_for(:key_1 => "val_1", :key_2 => "val_2")).to contain_exactly(item_4)
+                end
+              end
+
+              module_eval(&when_the_repo_has_items_with_metadata) if when_the_repo_has_items_with_metadata
+            end
+          end
+        end
+
+        it_behaves_like "adding items to the repository", :append do
+          let(:items_in_expected_order) { [item_1, item_2, item_3] }
+        end
+
+        it_behaves_like "adding items to the repository", :prepend do
+          let(:items_in_expected_order) { [item_3, item_2, item_1] }
+        end
+      end
+
+      describe FilterableItemRepository::UpdateOptimized do
+        it_behaves_like_a_filterable_item_repo
+      end
+
+      describe FilterableItemRepository::QueryOptimized do
+        it_behaves_like_a_filterable_item_repo do
+          describe "performance optimization" do
+            # NOTE: the specs in this context are potentially brittle because they are
+            # coupled to the implementation's usage of `MetadataFilter.apply?`. However,
+            # they demonstrate the perf optimization that was the reason we created
+            # this class, and thus have value in demonstrating the memoization is working
+            # properly and in documenting the reason the class exists in the first place.
+            # Still, if these prove to be brittle in the future, feel free to delete them since
+            # they are not concerned with externally visible behaviors.
+
+            it 'is optimized to check metadata filter application for a given pair of metadata hashes only once' do
+              # TODO: use mock expectations for this once https://github.com/rspec/rspec-mocks/pull/841 is fixed.
+              call_counts = track_metadata_filter_apply_calls
+
+              3.times do
+                expect(repo.items_for(:slow => true, :other => "foo")).to contain_exactly(item_2)
+              end
+
+              expect(call_counts[:slow => true]).to eq(1)
+            end
+
+            it 'ignores extraneous metadata keys when doing memoized lookups' do
+              # TODO: use mock expectations for this once https://github.com/rspec/rspec-mocks/pull/841 is fixed.
+              call_counts = track_metadata_filter_apply_calls
+
+              expect(repo.items_for(:slow => true, :other => "foo")).to contain_exactly(item_2)
+              expect(repo.items_for(:slow => true, :other => "bar")).to contain_exactly(item_2)
+              expect(repo.items_for(:slow => true, :goo => "bazz")).to contain_exactly(item_2)
+
+              expect(call_counts[:slow => true]).to eq(1)
+            end
+
+            context "when there are some proc keys" do
+              before do
+                add_item item_4, { :include_it => flip_proc }
+              end
+
+              it 'still performs memoization for metadata hashes that lack those keys' do
+                call_counts = track_metadata_filter_apply_calls
+
+                expect(repo.items_for(:slow => true, :other => "foo")).to contain_exactly(item_2)
+                expect(repo.items_for(:slow => true, :other => "foo")).to contain_exactly(item_2)
+
+                expect(call_counts[:slow => true]).to eq(1)
+              end
+            end
+
+            def track_metadata_filter_apply_calls
+              Hash.new(0).tap do |call_counts|
+                allow(MetadataFilter).to receive(:apply?).and_wrap_original do |original, predicate, item_meta, request_meta|
+                  call_counts[item_meta] += 1
+                  original.call(predicate, item_meta, request_meta)
                 end
               end
             end
           end
         end
-      end
-
-      it_behaves_like "adding items to the repository", :append do
-        let(:items_in_expected_order) { [item_1, item_2, item_3] }
-      end
-
-      it_behaves_like "adding items to the repository", :prepend do
-        let(:items_in_expected_order) { [item_3, item_2, item_1] }
       end
     end
   end

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -189,7 +189,7 @@ module RSpec
 
               expect(meta[:shared_group_inclusion_backtrace]).to match [ an_object_having_attributes(
                 :shared_group_name  => "some shared behavior",
-                :inclusion_location => a_string_including("#{__FILE__}:#{line}")
+                :inclusion_location => a_string_including("#{Metadata.relative_path __FILE__}:#{line}")
               ) ]
             end
           end
@@ -213,7 +213,7 @@ module RSpec
 
                 expect(meta[:shared_group_inclusion_backtrace]).to match [ an_object_having_attributes(
                   :shared_group_name  => "some shared behavior",
-                  :inclusion_location => a_string_including("#{__FILE__}:#{line}")
+                  :inclusion_location => a_string_including("#{Metadata.relative_path __FILE__}:#{line}")
                 ) ]
               end
             end
@@ -239,11 +239,11 @@ module RSpec
                 expect(meta[:shared_group_inclusion_backtrace]).to match [
                   an_object_having_attributes(
                     :shared_group_name  => "inner",
-                    :inclusion_location => a_string_including("#{__FILE__}:#{inner_line}")
+                    :inclusion_location => a_string_including("#{Metadata.relative_path __FILE__}:#{inner_line}")
                   ),
                   an_object_having_attributes(
                     :shared_group_name  => "outer",
-                    :inclusion_location => a_string_including("#{__FILE__}:#{outer_line}")
+                    :inclusion_location => a_string_including("#{Metadata.relative_path __FILE__}:#{outer_line}")
                   ),
                 ]
               end

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -134,6 +134,14 @@ module RSpec
             end
 
             describe "hooks for individual examples that have matching metadata" do
+              before do
+                skip "These specs pass in 2.0 mode on JRuby 1.7.8 but fail on " \
+                     "1.7.15 when the entire spec suite runs. They pass on " \
+                     "1.7.15 when this one spec file is run or if we filter to " \
+                     "just them. Given that 2.0 support on JRuby 1.7 is " \
+                     "experimental, we're just skipping these specs."
+              end if RUBY_VERSION == "2.0.0" && RSpec::Support::Ruby.jruby?
+
               it 'runs them' do
                 sequence = []
 

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -133,39 +133,60 @@ module RSpec
               expect(non_matching_group).not_to respond_to(:bar)
             end
 
-            it 'runs hooks for individual examples that have matching metadata' do
-              sequence = []
+            describe "hooks for individual examples that have matching metadata" do
+              it 'runs them' do
+                sequence = []
 
-              define_shared_group("name", :include_it) do
-                # These two should not be run for individual examples...
-                before(:context) { sequence << :before_context }
-                after(:context)  { sequence << :after_context }
+                define_shared_group("name", :include_it) do
+                  before(:context) { sequence << :before_context }
+                  after(:context)  { sequence << :after_context }
 
-                before(:example) { sequence << :before_example }
-                after(:example)  { sequence << :after_example  }
+                  before(:example) { sequence << :before_example }
+                  after(:example)  { sequence << :after_example  }
 
-                around(:example) do |ex|
-                  sequence << :around_example_before
-                  ex.run
-                  sequence << :around_example_after
+                  around(:example) do |ex|
+                    sequence << :around_example_before
+                    ex.run
+                    sequence << :around_example_after
+                  end
                 end
+
+                RSpec.describe "group" do
+                  example("ex1") { sequence << :unmatched_example_1 }
+                  example("ex2", :include_it) { sequence << :matched_example }
+                  example("ex3") { sequence << :unmatched_example_2 }
+                end.run
+
+                expect(sequence).to eq([
+                  :unmatched_example_1,
+                  :before_context,
+                  :around_example_before,
+                  :before_example,
+                  :matched_example,
+                  :after_example,
+                  :around_example_after,
+                  :after_context,
+                  :unmatched_example_2
+                ])
               end
 
-              RSpec.describe "group" do
-                example("ex1") { sequence << :unmatched_example_1 }
-                example("ex2", :include_it) { sequence << :matched_example }
-                example("ex3") { sequence << :unmatched_example_2 }
-              end.run
+              it 'runs the `after(:context)` hooks even if the `before(:context)` hook raises an error' do
+                sequence = []
 
-              expect(sequence).to eq([
-                :unmatched_example_1,
-                :around_example_before,
-                :before_example,
-                :matched_example,
-                :after_example,
-                :around_example_after,
-                :unmatched_example_2
-              ])
+                define_shared_group("name", :include_it) do
+                  before(:context) do
+                    sequence << :before_context
+                    raise "boom"
+                  end
+                  after(:context) { sequence << :after_context }
+                end
+
+                RSpec.describe "group" do
+                  example("ex", :include_it) { sequence << :example }
+                end.run
+
+                expect(sequence).to eq([ :before_context, :after_context ])
+              end
             end
           end
 


### PR DESCRIPTION
**This is an idea I'm toying with.  I lean towards including it but I'm not totally sold on the idea yet.**

<hr>

### The problem

We have two different mechanisms for defining metadata-filtered shared context. On the configuration object:

``` ruby
RSpec.configure do |config|
  config.around(:example, :db_1) { |ex| DB.transaction(:always_rollback => true, &ex) }
end
```

...and as a shared context:

``` ruby
RSpec.shared_context "with a DB transaction", :db_2 do
  around(:example) { |ex| DB.transaction(:always_rollback => true, &ex) }
end
```

The latter is generally more useful because `shared_context` supports all rspec-core constructs, including `let`, helper methods, etc...where as the config object only provides the means to define hooks that way.  So I'd consider the latter form to be generally "better" but it has a downside:

``` ruby
RSpec.describe "Group with both approaches applied", :db_1, :db_2 do
  # examples
end

RSpec.describe "Group with an example that has both approaches applied" do
  it "does stuff", :db_1, :db_2 do
  end
end
```

Both forms work fine in the first example (where the metadata has been applied to the group), but only the config-based approach (`:db_1`) works in the second example.  The problem is that the `shared_context` is included (or not) in example groups, not individual examples, whereas the config can apply just fine.  A user might reasonably expect the 2nd example to work, but as things currently stand, it won't.  I myself have run into this a few times, where I had something that I had defined as a `shared_context` but thought I had defined on `config`, and I tagged an example and it didn't work.

### Solution

I realized recently that ruby's object model (particularly the `singleton_class`) provides a means to very simply address this issue: we can include modules/shared contexts directly in the singleton class of the example group instance owned by an individual example.  This allows the contents of the module or shared context to apply to one example, but not others in the group.  I'm pleased with how simple the implementation was.

However, I'm not 100% sold on this, for a few reasons:

* It's potentially surprising behavior for people that have a good mental model of example groups vs examples...those users probably wouldn't expect this to work.
* It feels a little bit "magical" (even though in practice, it's actually really simple and is just leveraging ruby's object model).
* It adds some additional processing to each example when it runs, potentially making RSpec a bit slower.
* Including a module in an object's singleton class at run time busts the method cache, potentially having an even bigger affect on perf.  (However, every time rspec-mocks features are used, the method cache gets busted since it has to do similar things all the time).
* There's some slightly odd semantics with `before(:context)`/`after(:context)` hooks that are defined in the shared context.  As currently implemented, when the context is applied to one example, these do not run.  However, they potentially setup and teardown some state that other parts of the context (such as an `around` hook) use, so not running them could cause problems.  I'm on the fence about whether or not they should be run.
* This could be a breaking change for some folks. Although, I would not consider it a SemVer violation.
* It's potentially confusing that `config.extend` modules aren't treated the same way.  I didn't think it made sense to apply those modules the same, since they generally define class-level helper methods (e.g. macros) that are called from within a `describe` or `context` block.  (But can anyone thing of a need or use to treat them the same way?)

### TODO:

- [x] Get the build to pass on all rubies (I want to discuss this before putting effort into that).
- [x] Benchmark the perf difference this has.
- [x] Decide how to handle `:context` hooks.
- [x] Figure out how this should be documented.

Feedback wanted.

/cc @rspec/rspec 