### PR TITLE
Fix an exception when the DeprecationFormatter is initialized with an IO stream that doesn't respond to :path.

### DIFF
--- a/lib/rspec/core/formatters/deprecation_formatter.rb
+++ b/lib/rspec/core/formatters/deprecation_formatter.rb
@@ -210,7 +210,8 @@ module RSpec
           end
 
           def summarize(summary_stream, deprecation_count)
-            summary_stream.puts "\n#{Helpers.pluralize(deprecation_count, 'deprecation')} logged to #{@file.path}"
+            path = @file.respond_to?(:path) ? @file.path : @file.inspect
+            summary_stream.puts "\n#{Helpers.pluralize(deprecation_count, 'deprecation')} logged to #{path}"
             puts RAISE_ERROR_CONFIG_NOTICE
           end
         end

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -111,6 +111,12 @@ module RSpec::Core::Formatters
           expect(summary_stream.string).to match(/1 deprecation/)
           expect(File.read(deprecation_stream.path)).to eq("foo is deprecated.\n#{DeprecationFormatter::RAISE_ERROR_CONFIG_NOTICE}")
         end
+
+        it "can handle when the stream is reopened to a system stream" do
+          send_notification :deprecation, notification(:deprecated => 'foo')
+          deprecation_stream.reopen(IO.for_fd(IO.sysopen('/dev/null', "w+")))
+          send_notification :deprecation_summary, null_notification
+        end
       end
 
       context "with an Error deprecation_stream" do


### PR DESCRIPTION
When using spring, sometimes @file points to IO:/dev/null, which doesn't respond to "path" and raises an exception. This fixes that problem.

Please let me know if you'd like me to change anything or add any more color. Thanks!

For reference, here is the stack trace that this fixes:

```
/Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/formatters/deprecation_formatter.rb:212:in `summarize': undefined method `path' for #<IO:/dev/null> (NoMethodError)
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/formatters/deprecation_formatter.rb:130:in `deprecation_summary'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/formatters/deprecation_formatter.rb:41:in `deprecation_summary'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/reporter.rb:134:in `block in notify'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/reporter.rb:133:in `each'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/reporter.rb:133:in `notify'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/reporter.rb:115:in `finish'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/reporter.rb:55:in `report'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:107:in `run_specs'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:85:in `run'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in `invoke'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/rspec-core-3.1.7/exe/rspec:4:in `<top (required)>'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:241:in `load'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:241:in `block in load'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:232:in `load_dependency'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:241:in `load'
        from /Users/kevin/programming/boundless/www/bin/rspec:16:in `<top (required)>'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:241:in `load'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:241:in `block in load'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:232:in `load_dependency'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/activesupport-4.1.5/lib/active_support/dependencies.rb:241:in `load'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Users/kevin/.rbenv/versions/2.1.0/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from -e:1:in `<main>'
```
