### PR TITLE
Handle exception message with invalid UTF-8; For rbx

### DIFF
--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -205,8 +205,16 @@ module RSpec::Core
         def encoding_of(string)
           string.encoding
         end
+
+        def encoded_string(string)
+          RSpec::Support::EncodedString.new(string, Encoding.default_external)
+        end
       else
         def encoding_of(_string)
+        end
+
+        def encoded_string(string)
+          RSpec::Support::EncodedString.new(string)
         end
       end
 
@@ -225,7 +233,7 @@ module RSpec::Core
           begin
             lines = ["Failure/Error: #{read_failed_line.strip}"]
             lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
-            exception.message.to_s.split("\n").each do |line|
+            encoded_string(exception.message.to_s).split("\n").each do |line|
               lines << "  #{line}" if exception.message
             end
             lines

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -234,7 +234,7 @@ module RSpec::Core
             lines = ["Failure/Error: #{read_failed_line.strip}"]
             lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
             encoded_string(exception.message.to_s).split("\n").each do |line|
-              lines << "  #{line}" if exception.message
+              lines << "  #{line}"
             end
             lines
           end

--- a/spec/rspec/core/notifications_spec.rb
+++ b/spec/rspec/core/notifications_spec.rb
@@ -100,5 +100,18 @@ RSpec.describe "FailedExampleNotification" do
       expect(lines[0]).to match %r{\AFailure\/Error}
       expect(lines[1]).to match %r{\A\s*Test exception\z}
     end
+
+    if String.method_defined?(:encoding)
+      it "returns failures_lines with invalid bytes replace by '?'" do
+        message_with_invalid_byte_sequence =
+          "\xEF \255 \xAD I have bad bytes".force_encoding(Encoding::UTF_8)
+        allow(exception).to receive(:message).
+          and_return(message_with_invalid_byte_sequence)
+
+        lines = notification.message_lines
+        expect(lines[0]).to match %r{\AFailure\/Error}
+        expect(lines[1].strip).to eq("? ? ? I have bad bytes")
+      end
+    end
   end
 end


### PR DESCRIPTION
See https://travis-ci.org/mikel/mail/jobs/33707769#L129

```plain
An exception occurred running /home/travis/build/mikel/mail/gemfiles/vendor/bundle/rbx/2.1/gems/rspec-core-3.0.4/exe/rspec:
    invalid byte sequence in UTF-8 (ArgumentError)
Backtrace:
    Rubinius::Splitter.valid_encoding? at kernel/common/splitter.rb:17
    Rubinius::Splitter.split at kernel/common/splitter.rb:22
    String#split at kernel/common/string.rb:515
    RSpec::Core::Notifications::FailedExampleNotification#failure_lines at \
          gemfiles/vendor/bundle/rbx/2.1/gems/rspec-core-3.0.4/lib/rspec/core/notifications.rb:220
```

To reproduce with just the one test

```sh
 rspec spec/rspec/core/formatters/base_text_formatter_spec.rb:108
```