### PR TITLE
Show seed at start of suite run

### DIFF
--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -70,6 +70,7 @@ module RSpec::Core
       @start = time
       @load_time = (@start - @configuration.start_time).to_f
       notify :start, Notifications::StartNotification.new(expected_example_count, @load_time)
+      notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
     end
 
     # @private

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -49,6 +49,16 @@ module RSpec::Core
 
         reporter.start 3, (start_time + 5)
       end
+
+      it 'notifies formatters of the seed used' do
+        formatter = double("formatter")
+        reporter.register_listener formatter, :seed
+
+        expect(formatter).to receive(:seed).with(
+          an_object_having_attributes(:seed => config.seed, :seed_used? => config.seed_used?)
+        )
+        reporter.start 1
+      end
     end
 
     context "given one formatter" do


### PR DESCRIPTION
Have the reporter notify formatters of the seed used on `start`
Attempt at tackling #1719 
