### PR TITLE
Remove extra blank line from seed output.

### DIFF
--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -64,9 +64,11 @@ module RSpec
         # @param _notification [NullNotification] (Ignored)
         def close(_notification)
           return unless IO === output
-          return if output.closed? || output == $stdout
+          return if output.closed?
 
-          output.close
+          output.puts
+
+          output.close unless output == $stdout
         end
       end
     end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -332,7 +332,7 @@ module RSpec::Core
       # @return [String] The seed information fully formatted in the way that
       #   RSpec's built-in formatters emit.
       def fully_formatted
-        "\nRandomized with seed #{seed}\n\n"
+        "\nRandomized with seed #{seed}\n"
       end
     end
 


### PR DESCRIPTION
This is a follow up to #1761.

The seed output had two new lines, which worked well
at the end (since we want a blank line after our
output) but it looked funny for the new seed notification
at the start.

For comparison, here's what the output used to look like:

```
Run options:
  include {:focus=>true}
  exclude {:ruby=>#<Proc:./spec/spec_helper.rb:79>}

All examples were filtered out; ignoring {:focus=>true}
........

Finished in 0.02398 seconds (files took 0.19841 seconds to load)
8 examples, 0 failures

Randomized with seed 64721

```

Here's what it looks like currently:

```
Run options:
  include {:focus=>true}
  exclude {:ruby=>#<Proc:./spec/spec_helper.rb:79>}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 51597

........

Finished in 0.01477 seconds (files took 0.12285 seconds to load)
8 examples, 0 failures

Randomized with seed 51597

```

And here's what it looks like after the changes in this PR:

```
Run options:
  include {:focus=>true}
  exclude {:ruby=>#<Proc:./spec/spec_helper.rb:79>}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 11891
........

Finished in 0.01435 seconds (files took 0.12004 seconds to load)
8 examples, 0 failures

Randomized with seed 11891

```
