### PR TITLE
Also document around/exception behavior.

### DIFF
--- a/features/hooks/around_hooks.feature
+++ b/features/hooks/around_hooks.feature
@@ -85,6 +85,29 @@ Feature: `around` hooks
     When I run `rspec example_spec.rb`
     Then the output should contain "this should show up in the output"
 
+  Scenario: An around hook continues to run even if the example throws an exception
+    Given a file named "example_spec.rb" with:
+      """ruby
+        RSpec.describe "something" do
+          around(:example) do |example|
+            puts "around example setup"
+            example.run
+            puts "around example cleanup"
+          end
+
+          it "still executes the entire around hook" do
+            fail "the example blows up"
+          end
+        end
+      """
+    When I run `rspec example_spec.rb`
+    Then the output should contain "1 example, 1 failure"
+    And the output should contain:
+      """
+      around example setup
+      around example cleanup
+      """
+
   Scenario: Define a global `around` hook
     Given a file named "example_spec.rb" with:
       """ruby


### PR DESCRIPTION
If this were a unit test, this would be a strange place to be talking about behavior which is implemented down in example.rb.

But from the point of view of documentation, I think it could be quite helpful to tell people that they don't need to mess around with `ensure` to make sure their cleanup runs when writing an around hook. This came up in code review for me today.
