### PR TITLE
Switch readme badges to svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rspec-core [![Build Status](https://secure.travis-ci.org/rspec/rspec-core.png?branch=master)](http://travis-ci.org/rspec/rspec-core) [![Code Climate](https://codeclimate.com/github/rspec/rspec-core.png)](https://codeclimate.com/github/rspec/rspec-core)
+# rspec-core [![Build Status](https://secure.travis-ci.org/rspec/rspec-core.svg?branch=master)](http://travis-ci.org/rspec/rspec-core) [![Code Climate](https://codeclimate.com/github/rspec/rspec-core.svg)](https://codeclimate.com/github/rspec/rspec-core)
 
 rspec-core provides the structure for writing executable examples of how your
 code should behave, and an `rspec` command with tools to constrain which


### PR DESCRIPTION
SVG readme badges are crisper :)

Before:
![screen shot 2014-11-25 at 14 33 43](https://cloud.githubusercontent.com/assets/162976/5177616/54833ca4-74b0-11e4-9ea0-4fdcff724695.png)

After:
![screen shot 2014-11-25 at 14 35 05](https://cloud.githubusercontent.com/assets/162976/5177617/5a8c138c-74b0-11e4-989d-59cbe03aa9ca.png)

This PR inspired by postmodern/ruby-install#191 and @parndt
