### PR TITLE
Fix parameters handling with implicit spec files

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -790,7 +790,7 @@ module RSpec
       # @private
       def files_or_directories_to_run=(*files)
         files = files.flatten
-        files << default_path if (command == 'rspec' || Runner.running_in_drb?) && default_path && files.empty?
+        files << default_path if (command.start_with?('rspec') || Runner.running_in_drb?) && default_path && files.empty?
         @files_or_directories_to_run = files
         @files_to_run = nil
       end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -565,6 +565,12 @@ module RSpec::Core
           expect(config.files_to_run).not_to be_empty
         end
 
+        it "loads file in the default path when run by rspec with additional parameters" do
+          allow(config).to receive(:command) { 'rspec --fail-fast' }
+          assign_files_or_directories_to_run []
+          expect(config.files_to_run).not_to be_empty
+        end
+
         it "loads files in the default path when run with DRB (e.g., spork)" do
           allow(config).to receive(:command) { 'spork' }
           allow(RSpec::Core::Runner).to receive(:running_in_drb?) { true }


### PR DESCRIPTION
If no spec patterns are presented, rspec will run with empty spec list. This bug can demonstrated like this(taken from my work-related repo):

```
% rspec
....................................................................................................................................................................................................................................................................................................................

Finished in 14.48 seconds (files took 3.59 seconds to load)
308 examples, 0 failures
```

and

```
% bin/rspec --fail-fast
No examples found.


Finished in 0.0007 seconds (files took 21.11 seconds to load)
0 examples, 0 failures
```

It fails really fast indeed :smile: 
