### PR TITLE
Provide friendly errors when users call RSpec APIs from the wrong context.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,13 @@ Enhancements:
 * Emit warnings when `:suite` hooks are registered on an example group
   (where it has always been ignored) or are registered with metadata
   (which has always been ignored). (Myron Marston, #1805)
+* Provide a friendly error message when users call RSpec example group
+  APIs (e.g. `context`, `describe`, `it`, `let`, `before`, etc) from
+  within an example where those APIs are unavailable. (Myron Marston, #1819)
+* Provide a friendly error message when users call RSpec example
+  APIs (e.g. `expect`, `double`, `stub_const`, etc) from
+  within an example group where those APIs are unavailable.
+  (Myron Marston, #1819)
 
 Bug Fixes:
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -571,6 +571,39 @@ module RSpec
       def inspect
         "#<#{self.class} #{@__inspect_output}>"
       end
+
+      # Raised when an RSpec API is called in the wrong scope, such as `before`
+      # being called from within an example rather than from within an example
+      # group block.
+      WrongScopeError = Class.new(NoMethodError)
+
+      def self.method_missing(name, *args)
+        if method_defined?(name)
+          raise WrongScopeError,
+                "`#{name}` is not available on an example group (e.g. a " \
+                "`describe` or `context` block). It is only available from " \
+                "within individual examples (e.g. `it` blocks) or from " \
+                "constructs that run in the scope of an example (e.g. " \
+                "`before`, `let`, etc)."
+        end
+
+        super
+      end
+      private_class_method :method_missing
+
+    private
+
+      def method_missing(name, *args)
+        if self.class.respond_to?(name)
+          raise WrongScopeError,
+                "`#{name}` is not available from within an example (e.g. an " \
+                "`it` block) or from constructs that run in the scope of an " \
+                "example (e.g. `before`, `let`, etc). It is only available " \
+                "on an example group (e.g. a `describe` or `context` block)."
+        end
+
+        super
+      end
     end
 
     # @private


### PR DESCRIPTION
I think this will make RSpec more approachable for newcomers.
