### PR TITLE
Fix location filtering for example in nested group in shared group in external file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -54,6 +54,9 @@ Bug Fixes:
 * When a shared example defined in an external file fails, use the host
   example group (from a loaded spec file) for the re-run command to
   ensure the command will actually work. (Myron Marston, #1835)
+* Fix location filtering to work properly for examples defined in
+  a nested example group within a shared example group defined in
+  an external file. (Bradley Schaefer, Xavier Shay, Myron Marston, #1837)
 
 ### 3.1.8 Development
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -96,7 +96,7 @@ module RSpec
       def rerun_argument
         loaded_spec_files = RSpec.configuration.loaded_spec_files
 
-        Metadata.ascend(metadata) do |meta|
+        Metadata.ascending(metadata) do |meta|
           return meta[:location] if loaded_spec_files.include?(File.expand_path meta[:file_path])
         end
       end

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -51,16 +51,23 @@ module RSpec
       end
 
       # @private
-      # Iteratively walks up from the given example metadata through all
+      # Iteratively walks up from the given metadata through all
       # example group ancestors, yielding each metadata hash along the way.
-      def self.ascend(example_metadata)
-        yield example_metadata
-        group_metadata = example_metadata.fetch(:example_group)
+      def self.ascending(metadata)
+        yield metadata
+        return unless (group_metadata = metadata.fetch(:example_group) { metadata[:parent_example_group] })
 
         loop do
           yield group_metadata
           break unless (group_metadata = group_metadata[:parent_example_group])
         end
+      end
+
+      # @private
+      # Returns an enumerator that iteratively walks up the given metadata through all
+      # example group ancestors, yielding each metadata hash along the way.
+      def self.ascend(metadata)
+        enum_for(:ascending, metadata)
       end
 
       # @private

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -54,13 +54,11 @@ module RSpec
         end
 
         def relevant_line_numbers(metadata)
-          return [] unless metadata
-          [metadata[:line_number]].compact + (relevant_line_numbers(parent_of metadata))
+          Metadata.ascend(metadata).map { |meta| meta[:line_number] }
         end
 
         def example_group_declaration_line(locations, metadata)
-          parent = parent_of(metadata)
-          return nil unless parent
+          return nil unless (parent = metadata.fetch(:example_group) { metadata[:parent_example_group] })
           locations[File.expand_path(parent[:file_path])]
         end
 
@@ -68,14 +66,6 @@ module RSpec
           subhash = metadata[key]
           return false unless Hash === subhash || HashImitatable === subhash
           value.all? { |k, v| filter_applies?(k, v, subhash) }
-        end
-
-        def parent_of(metadata)
-          if metadata.key?(:example_group)
-            metadata[:example_group]
-          else
-            metadata[:parent_example_group]
-          end
         end
 
         def silence_metadata_example_group_deprecations

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -43,9 +43,8 @@ module RSpec
         end
 
         def location_filter_applies?(locations, metadata)
-          # it ignores location filters for other files
-          line_number = example_group_declaration_line(locations, metadata)
-          line_number ? line_number_filter_applies?(line_number, metadata) : true
+          line_numbers = example_group_declaration_lines(locations, metadata)
+          line_numbers ? line_number_filter_applies?(line_numbers, metadata) : true
         end
 
         def line_number_filter_applies?(line_numbers, metadata)
@@ -57,9 +56,10 @@ module RSpec
           Metadata.ascend(metadata).map { |meta| meta[:line_number] }
         end
 
-        def example_group_declaration_line(locations, metadata)
-          return nil unless (parent = metadata.fetch(:example_group) { metadata[:parent_example_group] })
-          locations[File.expand_path(parent[:file_path])]
+        def example_group_declaration_lines(locations, metadata)
+          FlatMap.flat_map(Metadata.ascend(metadata)) do |meta|
+            locations[File.expand_path(meta[:file_path])]
+          end.uniq
         end
 
         def filters_apply?(key, value, metadata)

--- a/spec/integration/shared_example_rerun_commands_spec.rb
+++ b/spec/integration/shared_example_rerun_commands_spec.rb
@@ -36,4 +36,31 @@ RSpec.describe 'Shared Example Rerun Commands' do
     command = last_cmd_stdout[/Failed examples:\s+rspec (\S+) #/, 1]
     run_command command
   end
+
+  context "with a shared example containing a context in a separate file" do
+    it "runs the example nested inside the shared" do
+      write_file_formatted 'spec/shared_example.rb', """
+        RSpec.shared_examples_for 'a shared example' do
+          it 'succeeds' do
+          end
+
+          context 'with a nested context' do
+            it 'succeeds (nested)' do
+            end
+          end
+        end
+      """
+
+      write_file_formatted 'spec/simple_spec.rb', """
+        require File.join(File.dirname(__FILE__), 'shared_example.rb')
+
+        RSpec.describe 'top level' do
+          it_behaves_like 'a shared example'
+        end
+      """
+
+      run_command 'spec/simple_spec.rb:3 -fd'
+      expect(last_cmd_stdout).to match(/2 examples, 0 failures/)
+    end
+  end
 end

--- a/spec/rspec/core/metadata_filter_spec.rb
+++ b/spec/rspec/core/metadata_filter_spec.rb
@@ -84,10 +84,6 @@ module RSpec
           end
         end
 
-        it "ignores location filters for other files" do
-          expect(filter_applies?(:locations, {"/path/to/other_spec.rb" => [3,5,7]}, example_metadata)).to be_truthy
-        end
-
         it "matches a proc with no arguments that evaluates to true" do
           expect(filter_applies?(:if, lambda { true }, example_metadata)).to be_truthy
         end

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -24,6 +24,11 @@ RSpec.shared_context "aruba support" do
     RSpec.reset
     RSpec::Core::Metadata.instance_variable_set(:@relative_path_regex, nil)
 
+    # Ensure it gets cached with a proper value -- if we leave it set to nil,
+    # and the next spec operates in a different dir, it could get set to an
+    # invalid value.
+    RSpec::Core::Metadata.relative_path_regex
+
     @last_cmd_stdout = temp_stdout.string
     @last_cmd_stderr = temp_stderr.string
     stdout.write(@last_cmd_stdout)

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -34,6 +34,20 @@ RSpec.shared_context "aruba support" do
     stdout.write(@last_cmd_stdout)
     stderr.write(@last_cmd_stderr)
   end
+
+  def write_file_formatted(file_name, contents)
+    # remove blank line at the start of the string and
+    # strip extra indentation.
+    formatted_contents = unindent(contents.sub(/\A\n/, ""))
+    write_file file_name, formatted_contents
+  end
+
+  # Intended for use with indented heredocs.
+  # taken from Ruby Tapas:
+  # https://rubytapas.dpdcart.com/subscriber/post?id=616#files
+  def unindent(s)
+    s.gsub(/^#{s.scan(/^[ \t]+(?=\S)/).min}/, "")
+  end
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
For examples defined in an example group in a shared example group in an external file, it did not work properly because the location filtering only considered the immediate parent example group’s file path, which did not match the passed location filter. By considering all parent example group file paths, it filters properly.

Fixes #835.

Note: this commit began from a failing spec that originated with @soulcutter and was fixed up by @xaviershay.