### PR TITLE
Fix filter manager location filtering

### DIFF
--- a/benchmarks/precalculate_absolute_file_path_or_not.rb
+++ b/benchmarks/precalculate_absolute_file_path_or_not.rb
@@ -1,0 +1,29 @@
+require 'benchmark/ips'
+
+metadata = { :file_path => "some/path.rb" }
+meta_with_absolute = metadata.merge(:absolute_file_path => File.expand_path(metadata[:file_path]))
+
+Benchmark.ips do |x|
+  x.report("fetch absolute path from hash") do
+    meta_with_absolute[:absolute_file_path]
+  end
+
+  x.report("calculate absolute path") do
+    File.expand_path(metadata[:file_path])
+  end
+end
+
+__END__
+
+Precalculating the absolute file path is much, much faster!
+
+Calculating -------------------------------------
+fetch absolute path from hash
+                       102.164k i/100ms
+calculate absolute path
+                         9.331k i/100ms
+-------------------------------------------------
+fetch absolute path from hash
+                          7.091M (±11.6%) i/s -     34.736M
+calculate absolute path
+                        113.141k (± 8.6%) i/s -    569.191k

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -97,7 +97,7 @@ module RSpec
         loaded_spec_files = RSpec.configuration.loaded_spec_files
 
         Metadata.ascending(metadata) do |meta|
-          return meta[:location] if loaded_spec_files.include?(File.expand_path meta[:file_path])
+          return meta[:location] if loaded_spec_files.include?(meta[:absolute_file_path])
         end
       end
 

--- a/lib/rspec/core/filter_manager.rb
+++ b/lib/rspec/core/filter_manager.rb
@@ -111,10 +111,6 @@ module RSpec
         exclusions.add_with_low_priority(args.last)
       end
 
-      def exclude?(example)
-        exclusions.include_example?(example)
-      end
-
       def include(*args)
         inclusions.add(args.last)
       end
@@ -125,6 +121,12 @@ module RSpec
 
       def include_with_low_priority(*args)
         inclusions.add_with_low_priority(args.last)
+      end
+
+    private
+
+      def exclude?(example)
+        exclusions.include_example?(example)
       end
 
       def include?(example)

--- a/lib/rspec/core/filter_manager.rb
+++ b/lib/rspec/core/filter_manager.rb
@@ -148,7 +148,7 @@ module RSpec
       # defined in the same file as the location filters. Excluded specs in
       # other files should still be excluded.
       def priority_include?(example, locations)
-        return false if locations[File.expand_path(example.metadata[:file_path])].empty?
+        return false if locations[example.metadata[:absolute_file_path]].empty?
         MetadataFilter.filter_applies?(:locations, locations, example.metadata)
       end
     end

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -146,10 +146,11 @@ module RSpec
                                      file_path_and_line_number_from(caller)
                                    end
 
-          file_path              = Metadata.relative_path(file_path)
-          metadata[:file_path]   = file_path
-          metadata[:line_number] = line_number.to_i
-          metadata[:location]    = "#{file_path}:#{line_number}"
+          relative_file_path            = Metadata.relative_path(file_path)
+          metadata[:file_path]          = relative_file_path
+          metadata[:line_number]        = line_number.to_i
+          metadata[:location]           = "#{relative_file_path}:#{line_number}"
+          metadata[:absolute_file_path] = File.expand_path(relative_file_path)
         end
 
         def file_path_and_line_number_from(backtrace)
@@ -311,6 +312,7 @@ module RSpec
         :parent_example_group,
         :execution_result,
         :file_path,
+        :absolute_file_path,
         :full_description,
         :line_number,
         :location,

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -58,7 +58,7 @@ module RSpec
 
         def example_group_declaration_lines(locations, metadata)
           FlatMap.flat_map(Metadata.ascend(metadata)) do |meta|
-            locations[File.expand_path(meta[:file_path])]
+            locations[meta[:absolute_file_path]]
           end.uniq
         end
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -259,7 +259,7 @@ module RSpec::Core
       end
 
       def find_failed_line
-        example_path = File.expand_path(example.file_path).downcase
+        example_path = example.metadata[:absolute_file_path].downcase
         exception.backtrace.find do |line|
           next unless (line_path = line[/(.+?):(\d+)(|:\d+)/, 1])
           File.expand_path(line_path).downcase == example_path

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -1,6 +1,6 @@
 require 'support/aruba_support'
 
-RSpec.describe 'Shared Example Rerun Commands' do
+RSpec.describe 'Filtering' do
   include_context "aruba support"
   before { clean_current_dir }
 

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Shared Example Rerun Commands' do
   end
 
   context "passing a line-number-filtered file and a non-filtered file" do
-    it "applies the line number filtering only to the filtered file, running all specs in the non-filtered file" do
+    it "applies the line number filtering only to the filtered file, running all specs in the non-filtered file except excluded ones" do
       write_file_formatted "spec/file_1_spec.rb", """
         RSpec.describe 'File 1' do
           it('passes') {      }
@@ -107,9 +107,14 @@ RSpec.describe 'Shared Example Rerun Commands' do
       """
 
       write_file_formatted "spec/file_2_spec.rb", """
+        RSpec.configure do |c|
+          c.filter_run_excluding :exclude_me
+        end
+
         RSpec.describe 'File 2' do
           it('passes') { }
           it('passes') { }
+          it('fails', :exclude_me) { fail }
         end
       """
 

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -64,6 +64,39 @@ RSpec.describe 'Shared Example Rerun Commands' do
     end
   end
 
+  context "passing a line-number filter" do
+    it "trumps exclusions, except for :if/:unless (which are absolute exclusions)" do
+      write_file_formatted 'spec/a_spec.rb', """
+        RSpec.configure do |c|
+          c.filter_run_excluding :slow
+        end
+
+        RSpec.describe 'A slow group', :slow do
+          example('ex 1') { }
+          example('ex 2') { }
+        end
+
+        RSpec.describe 'A group with a slow example' do
+          example('ex 3'              ) { }
+          example('ex 4', :slow       ) { }
+          example('ex 5', :if => false) { }
+        end
+      """
+
+      run_command "spec/a_spec.rb -fd"
+      expect(last_cmd_stdout).to include("1 example, 0 failures", "ex 3").and exclude("ex 1", "ex 2", "ex 4", "ex 5")
+
+      run_command "spec/a_spec.rb:5 -fd" # selecting 'A slow group'
+      expect(last_cmd_stdout).to include("2 examples, 0 failures", "ex 1", "ex 2").and exclude("ex 3", "ex 4", "ex 5")
+
+      run_command "spec/a_spec.rb:12 -fd" # selecting slow example
+      expect(last_cmd_stdout).to include("1 example, 0 failures", "ex 4").and exclude("ex 1", "ex 2", "ex 3", "ex 5")
+
+      run_command "spec/a_spec.rb:13 -fd" # selecting :if => false example
+      expect(last_cmd_stdout).to include("0 examples, 0 failures").and exclude("ex 1", "ex 2", "ex 3", "ex 4", "ex 5")
+    end
+  end
+
   context "passing a line-number-filtered file and a non-filtered file" do
     it "applies the line number filtering only to the filtered file, running all specs in the non-filtered file" do
       write_file_formatted "spec/file_1_spec.rb", """

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -472,27 +472,12 @@ module RSpec::Core
       end
 
       context "with <path>:<line_number>" do
-        it "overrides inclusion filters set on config" do
-          config.filter_run_including :foo => :bar
-          assign_files_or_directories_to_run "path/to/file.rb:37"
-          expect(inclusion_filter.size).to eq(1)
-          expect(inclusion_filter[:locations].keys.first).to match(/path\/to\/file\.rb$/)
-          expect(inclusion_filter[:locations].values.first).to eq([37])
-        end
-
         it "overrides inclusion filters set before config" do
           config.force(:inclusion_filter => {:foo => :bar})
           assign_files_or_directories_to_run "path/to/file.rb:37"
           expect(inclusion_filter.size).to eq(1)
           expect(inclusion_filter[:locations].keys.first).to match(/path\/to\/file\.rb$/)
           expect(inclusion_filter[:locations].values.first).to eq([37])
-        end
-
-        it "clears exclusion filters set on config" do
-          config.exclusion_filter = { :foo => :bar }
-          assign_files_or_directories_to_run "path/to/file.rb:37"
-          expect(exclusion_filter).to be_empty,
-            "expected exclusion filter to be empty:\n#{exclusion_filter}"
         end
 
         it "clears exclusion filters set before config" do

--- a/spec/rspec/core/filter_manager_spec.rb
+++ b/spec/rspec/core/filter_manager_spec.rb
@@ -260,49 +260,53 @@ module RSpec::Core
         value
       end
 
+      def exclude?(example)
+        filter_manager.prune([example]).empty?
+      end
+
       describe "the default :if filter" do
         it "does not exclude a spec with  { :if => true } metadata" do
           example = example_with_metadata(:if => true)
-          expect(filter_manager.exclude?(example)).to be_falsey
+          expect(exclude?(example)).to be_falsey
         end
 
         it "excludes a spec with  { :if => false } metadata" do
           example = example_with_metadata(:if => false)
-          expect(filter_manager.exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be_truthy
         end
 
         it "excludes a spec with  { :if => nil } metadata" do
           example = example_with_metadata(:if => nil)
-          expect(filter_manager.exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be_truthy
         end
 
         it "continues to be an exclusion even if exclusions are cleared" do
           example = example_with_metadata(:if => false)
           filter_manager.exclusions.clear
-          expect(filter_manager.exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be_truthy
         end
       end
 
       describe "the default :unless filter" do
         it "excludes a spec with  { :unless => true } metadata" do
           example = example_with_metadata(:unless => true)
-          expect(filter_manager.exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be_truthy
         end
 
         it "does not exclude a spec with { :unless => false } metadata" do
           example = example_with_metadata(:unless => false)
-          expect(filter_manager.exclude?(example)).to be_falsey
+          expect(exclude?(example)).to be_falsey
         end
 
         it "does not exclude a spec with { :unless => nil } metadata" do
           example = example_with_metadata(:unless => nil)
-          expect(filter_manager.exclude?(example)).to be_falsey
+          expect(exclude?(example)).to be_falsey
         end
 
         it "continues to be an exclusion even if exclusions are cleared" do
           example = example_with_metadata(:unless => true)
           filter_manager.exclusions.clear
-          expect(filter_manager.exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be_truthy
         end
       end
     end

--- a/spec/rspec/core/metadata_filter_spec.rb
+++ b/spec/rspec/core/metadata_filter_spec.rb
@@ -7,9 +7,9 @@ module RSpec
         def create_metadatas
           container = self
 
-          RSpec.describe "parent group", :caller => ["foo_spec.rb:#{__LINE__}"] do; container.parent_group_metadata = metadata
-            describe "group", :caller => ["foo_spec.rb:#{__LINE__}"] do; container.group_metadata = metadata
-              container.example_metadata = it("example", :caller => ["foo_spec.rb:#{__LINE__}"], :if => true).metadata
+          RSpec.describe "parent group", :caller => ["/foo_spec.rb:#{__LINE__}"] do; container.parent_group_metadata = metadata
+            describe "group", :caller => ["/foo_spec.rb:#{__LINE__}"] do; container.group_metadata = metadata
+              container.example_metadata = it("example", :caller => ["/foo_spec.rb:#{__LINE__}"], :if => true).metadata
             end
           end
         end

--- a/spec/rspec/core/notifications_spec.rb
+++ b/spec/rspec/core/notifications_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "FailedExampleNotification" do
   let(:notification) { ::RSpec::Core::Notifications::FailedExampleNotification.new(example) }
 
   before do
-    allow(example).to receive(:file_path) { __FILE__ }
+    example.metadata[:absolute_file_path] = __FILE__
   end
 
   # ported from `base_formatter_spec` should be refactored by final


### PR DESCRIPTION
This is a follow up to #1839.  I realized that with the changes there, if you ran `rspec 1_spec.rb:14 2_spec.rb` exclusion filters would not be applied to specs in `2_spec.rb` because the presence of a location filter disabled all exclusion filters. However, since location filters are contextual to a file and we now allow additional files to be loaded and run, I think we should continue to apply exclusion filters to other files.  This fixes that.

The last commit is an optional perf optimization.  I noticed that we were doing `File.expand_path(metadata[:file_path])` in many locations and thought it would be faster to calculate the absolute file path only once and store it in the metadata hash.  My benchmark confirms this is much faster (by an order-of-magnitude) but I do have one concern: doing this requires us to treat `:absolute_file_path` as a reserved metadata key, which could be a breaking change if there are any users who are using that as a custom metadata key.  That seems pretty unlikely though.

What do others think?

/cc @rspec/rspec 