### PR TITLE
Escape rspec path

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -147,7 +147,7 @@ module RSpec
         cmd_parts << RUBY
         cmd_parts << ruby_opts
         cmd_parts << rspec_load_path
-        cmd_parts << rspec_path
+        cmd_parts << escape(rspec_path)
         cmd_parts << file_inclusion_specification
         cmd_parts << file_exclusion_specification
         cmd_parts << rspec_opts

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -36,14 +36,21 @@ module RSpec::Core
 
     context "default" do
       it "renders rspec" do
-        expect(spec_command).to match(/^#{ruby} #{default_load_path_opts} #{task.rspec_path}/)
+        expect(spec_command).to match(/^#{ruby} #{default_load_path_opts} '?#{task.rspec_path}'?/)
+      end
+    end
+
+    context "with space", :unless => RSpec::Support::OS.windows? do
+      it "renders rspec with space escaped" do
+        task.rspec_path = '/path with space/exe/rspec'
+        expect(spec_command).to match(/^#{ruby} #{default_load_path_opts} \/path\\ with\\ space\/exe\/rspec/)
       end
     end
 
     context "with ruby options" do
       it "renders them before the rspec path" do
         task.ruby_opts = "-w"
-        expect(spec_command).to match(/^#{ruby} -w #{default_load_path_opts} #{task.rspec_path}/)
+        expect(spec_command).to match(/^#{ruby} -w #{default_load_path_opts} '?#{task.rspec_path}'?/)
       end
     end
 


### PR DESCRIPTION
otherwise things like

   bundle exec rake spec

break in repos containing spaces in directory names

This is needed on 3.1 as well.