### PR TITLE
Stop using aruba’s removed `regexp`.

### DIFF
--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -8,13 +8,13 @@ end
 
 Then /^the output should not contain any of these:$/ do |table|
   table.raw.flatten.each do |string|
-    expect(all_output).not_to match(regexp(string))
+    expect(all_output).not_to include(string)
   end
 end
 
 Then /^the output should contain one of the following:$/ do |table|
   matching_output = table.raw.flatten.select do |string|
-    all_output =~ regexp(string)
+    all_output.include?(string)
   end
 
   expect(matching_output.count).to eq(1)
@@ -66,7 +66,7 @@ Then /^the backtrace\-normalized output should contain:$/ do |partial_output|
     line =~ /(^\s+# [^:]+:\d+)/ ? $1 : line # http://rubular.com/r/zDD7DdWyzF
   end.join("\n")
 
-  expect(normalized_output).to match(regexp(partial_output))
+  expect(normalized_output).to include(partial_output)
 end
 
 Then /^the output should not contain any error backtraces$/ do

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -42,11 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake",     "~> 10.0.0"
   s.add_development_dependency "cucumber", "~> 1.3"
   s.add_development_dependency "minitest", "~> 5.3"
-
-  # Aruba 0.6.2 removed an API we rely on. For now we are excluding
-  # that version until we find out if they will restore it. See:
-  # https://github.com/cucumber/aruba/commit/5b2c7b445bc80083e577b793e4411887ef295660#commitcomment-9284628
-  s.add_development_dependency "aruba",    "~> 0.5", "!= 0.6.2"
+  s.add_development_dependency "aruba",    "~> 0.6"
 
   s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : "~> 1.5")
   s.add_development_dependency "coderay",  "~> 1.0.9"


### PR DESCRIPTION
See https://github.com/cucumber/aruba/issues/227 for background.