### PR TITLE
Allow Regexp class to be described

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -729,7 +729,7 @@ module RSpec
       # Convert to CamelCase.
       name = ' ' << group.description
       name.gsub!(/[^0-9a-zA-Z]+([0-9a-zA-Z])/) do
-        match = Regexp.last_match[1]
+        match = ::Regexp.last_match[1]
         match.upcase!
         match
       end

--- a/spec/integration/describe_spec.rb
+++ b/spec/integration/describe_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe Regexp do
+
+  it 'sets the core class as the described class' do
+    expect(described_class).to eq(Regexp)
+  end
+end

--- a/spec/integration/describe_spec.rb
+++ b/spec/integration/describe_spec.rb
@@ -1,6 +1,0 @@
-RSpec.describe Regexp do
-
-  it 'sets the core class as the described class' do
-    expect(described_class).to eq(Regexp)
-  end
-end

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -278,6 +278,12 @@ module RSpec
             it "returns the class" do
               expect(value_for String).to be(String)
             end
+
+            context "when the class is Regexp" do
+              it "returns the class" do
+                expect(value_for Regexp).to be(Regexp)
+              end
+            end
           end
         end
 


### PR DESCRIPTION
In 3.0.x and previously, the `Regexp` class could be described for testing. This regressed in 3.1.x and persists in master. This pull request fixes the issue.

The code to reproduce:
```ruby
describe Regexp do
  # Any code can go here, this fails on parsing.
end
```

The stacktrace:
```
/Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:575:in `block in base_name_for': undefined method `last_match' for RSpec::ExampleGroups::Regexp:Class (NoMethodError)
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:575:in `gsub!'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:575:in `base_name_for'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:557:in `assign_const'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:324:in `subclass'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:219:in `block in define_example_group_method'
	from /Users/modetojoy/work/bson-ruby/spec/bson/regexp_spec.rb:19:in `block in <top (required)>'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:325:in `module_exec'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:325:in `subclass'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/example_group.rb:219:in `block in define_example_group_method'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/dsl.rb:41:in `block in expose_example_group_alias'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/dsl.rb:79:in `block (2 levels) in expose_example_group_alias_globally'
	from /Users/modetojoy/work/bson-ruby/spec/bson/regexp_spec.rb:17:in `<top (required)>'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `block in load_spec_files'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `each'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/configuration.rb:1105:in `load_spec_files'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:96:in `setup'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:84:in `run'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:69:in `run'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/lib/rspec/core/runner.rb:37:in `invoke'
	from /Users/modetojoy/.rvm/gems/ruby-2.1.0@bson/gems/rspec-core-3.1.7/exe/rspec:4:in `<main>'
```

Why would one be testing a core class like `Regexp`? We extend the core class to provide extra functionality for BSON serialization, similar to JSON and XML. `Regexp` is one of the classes we extend. The specs can be found here: https://github.com/mongodb/bson-ruby/blob/master/spec/bson/regexp_spec.rb

I was not exactly sure where the spec for this pull request should go in the project, so I put it under integration for now just to demonstrate the issue and get a failing spec.