### PR TITLE
It should be `flatten(1)`.

### DIFF
--- a/lib/rspec/core/flat_map.rb
+++ b/lib/rspec/core/flat_map.rb
@@ -8,7 +8,7 @@ module RSpec
         end
       else # for 1.8.7
         def flat_map(array, &block)
-          array.map(&block).flatten(2)
+          array.map(&block).flatten(1)
         end
       end
 


### PR DESCRIPTION
We changed it to `flatten(1)` in cd52601a7fe0ea4c3f4f3f290f4336921afa11f7
but then accidentally changed it to `flatten(2)` in
940b7abda7e3a02ddd4d0ba44c4f9c8b16761b35. Not sure how...