### PR TITLE
Make memoized helpers threadsafe

### DIFF
--- a/benchmarks/threadsafe_let_block.rb
+++ b/benchmarks/threadsafe_let_block.rb
@@ -1,0 +1,312 @@
+require 'rspec/core'
+require 'rspec/expectations'
+
+# switches between these implementations - https://github.com/rspec/rspec-core/pull/1858/files
+# benchmark requested in this PR         - https://github.com/rspec/rspec-core/pull/1858
+#
+# I ran these from lib root by adding "gem 'benchmark-ips'" to ../Gemfile-custom
+# then ran `bundle install --standalone --binstubs bundle/bin`
+# then ran `ruby --disable-gems -I lib -I "$PWD/bundle" -r bundler/setup -S benchmarks/threadsafe_let_block.rb`
+
+# The old, non-thread safe implementation, imported from the `master` branch and pared down.
+module OriginalNonThreadSafeMemoizedHelpers
+  def __memoized
+    @__memoized ||= {}
+  end
+
+  module ClassMethods
+    def let(name, &block)
+      # We have to pass the block directly to `define_method` to
+      # allow it to use method constructs like `super` and `return`.
+      raise "#let or #subject called without a block" if block.nil?
+      OriginalNonThreadSafeMemoizedHelpers.module_for(self).__send__(:define_method, name, &block)
+
+      # Apply the memoization. The method has been defined in an ancestor
+      # module so we can use `super` here to get the value.
+      if block.arity == 1
+        define_method(name) { __memoized.fetch(name) { |k| __memoized[k] = super(RSpec.current_example, &nil) } }
+      else
+        define_method(name) { __memoized.fetch(name) { |k| __memoized[k] = super(&nil) } }
+      end
+    end
+  end
+
+  def self.module_for(example_group)
+    get_constant_or_yield(example_group, :LetDefinitions) do
+      mod = Module.new do
+        include Module.new {
+          example_group.const_set(:NamedSubjectPreventSuper, self)
+        }
+      end
+
+      example_group.const_set(:LetDefinitions, mod)
+      mod
+    end
+  end
+
+  # @private
+  def self.define_helpers_on(example_group)
+    example_group.__send__(:include, module_for(example_group))
+  end
+
+  def self.get_constant_or_yield(example_group, name)
+    if example_group.const_defined?(name, (check_ancestors = false))
+      example_group.const_get(name, check_ancestors)
+    else
+      yield
+    end
+  end
+end
+
+class HostBase
+  # wires the implementation
+  # adds `let(:name) { nil }`
+  # returns `Class.new(self) { let(:name) { super() } }`
+  def self.prepare_using(memoized_helpers, options={})
+    include memoized_helpers
+    extend memoized_helpers::ClassMethods
+    memoized_helpers.define_helpers_on(self)
+
+    define_method(:initialize, &options[:initialize]) if options[:initialize]
+    let(:name) { nil }
+
+    verify_memoizes memoized_helpers, options[:verify]
+
+    Class.new(self) do
+      memoized_helpers.define_helpers_on(self)
+      let(:name) { super() }
+    end
+  end
+
+  def self.verify_memoizes(memoized_helpers, additional_verification)
+    # Since we're using custom code, ensure it actually memoizes as we expect...
+    counter_class = Class.new(self) do
+      include RSpec::Matchers
+      memoized_helpers.define_helpers_on(self)
+      counter = 0
+      let(:count) { counter += 1 }
+    end
+    extend RSpec::Matchers
+
+    instance_1 = counter_class.new
+    expect(instance_1.count).to eq(1)
+    expect(instance_1.count).to eq(1)
+
+    instance_2 = counter_class.new
+    expect(instance_2.count).to eq(2)
+    expect(instance_2.count).to eq(2)
+
+    instance_3 = counter_class.new
+    instance_3.instance_eval &additional_verification if additional_verification
+  end
+end
+
+class OriginalNonThreadSafeHost < HostBase
+  Subclass = prepare_using OriginalNonThreadSafeMemoizedHelpers
+end
+
+class ThreadSafeHost < HostBase
+  Subclass = prepare_using RSpec::Core::MemoizedHelpers,
+    :initialize => lambda { |*| @__memoized = ThreadsafeMemoized.new },
+    :verify     => lambda { |*| expect(__memoized).to be_a_kind_of RSpec::Core::MemoizedHelpers::ThreadsafeMemoized }
+end
+
+class ConfigNonThreadSafeHost < HostBase
+  Subclass = prepare_using RSpec::Core::MemoizedHelpers,
+    :initialize => lambda { |*| @__memoized = NonThreadSafeMemoized.new },
+    :verify     => lambda { |*| expect(__memoized).to be_a_kind_of RSpec::Core::MemoizedHelpers::NonThreadSafeMemoized }
+end
+
+def title(title)
+  hr    = "#" * (title.length + 6)
+  blank = "#  #{' ' * title.length}  #"
+  [hr, blank, "#  #{title}  #", blank, hr]
+end
+
+require 'benchmark/ips'
+
+puts title "versions"
+puts "RUBY_VERSION             #{RUBY_VERSION}"
+puts "RUBY_PLATFORM            #{RUBY_PLATFORM}"
+puts "RUBY_ENGINE              #{RUBY_ENGINE}"
+puts "ruby -v                  #{`ruby -v`}"
+puts "Benchmark::IPS::VERSION  #{Benchmark::IPS::VERSION}"
+puts "rspec-core SHA           #{`git log --pretty=format:%H -1`}"
+puts
+
+puts title "1 call to let -- each sets the value"
+Benchmark.ips do |x|
+  x.report("non-threadsafe (original)") { OriginalNonThreadSafeHost.new.name }
+  x.report("non-threadsafe (config)  ") { ConfigNonThreadSafeHost.new.name }
+  x.report("threadsafe               ") { ThreadSafeHost.new.name }
+  x.compare!
+end
+
+puts title "10 calls to let -- 9 will find memoized value"
+Benchmark.ips do |x|
+  x.report("non-threadsafe (original)") do
+    i = OriginalNonThreadSafeHost.new
+    i.name; i.name; i.name; i.name; i.name
+    i.name; i.name; i.name; i.name; i.name
+  end
+
+  x.report("non-threadsafe (config)  ") do
+    i = ConfigNonThreadSafeHost.new
+    i.name; i.name; i.name; i.name; i.name
+    i.name; i.name; i.name; i.name; i.name
+  end
+
+  x.report("threadsafe               ") do
+    i = ThreadSafeHost.new
+    i.name; i.name; i.name; i.name; i.name
+    i.name; i.name; i.name; i.name; i.name
+  end
+
+  x.compare!
+end
+
+puts title "1 call to let which invokes super"
+
+Benchmark.ips do |x|
+  x.report("non-threadsafe (original)") { OriginalNonThreadSafeHost::Subclass.new.name }
+  x.report("non-threadsafe (config)  ") { ConfigNonThreadSafeHost::Subclass.new.name }
+  x.report("threadsafe               ") { ThreadSafeHost::Subclass.new.name }
+  x.compare!
+end
+
+puts title "10 calls to let which invokes super"
+Benchmark.ips do |x|
+  x.report("non-threadsafe (original)") do
+    i = OriginalNonThreadSafeHost::Subclass.new
+    i.name; i.name; i.name; i.name; i.name
+    i.name; i.name; i.name; i.name; i.name
+  end
+
+  x.report("non-threadsafe (config)  ") do
+    i = ConfigNonThreadSafeHost::Subclass.new
+    i.name; i.name; i.name; i.name; i.name
+    i.name; i.name; i.name; i.name; i.name
+  end
+
+  x.report("threadsafe               ") do
+    i = ThreadSafeHost::Subclass.new
+    i.name; i.name; i.name; i.name; i.name
+    i.name; i.name; i.name; i.name; i.name
+  end
+
+  x.compare!
+end
+
+__END__
+
+##############
+#            #
+#  versions  #
+#            #
+##############
+RUBY_VERSION             2.2.0
+RUBY_PLATFORM            x86_64-darwin13
+RUBY_ENGINE              ruby
+ruby -v                  ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-darwin13]
+Benchmark::IPS::VERSION  2.1.1
+rspec-core SHA           1ee7a8d8cde6ba2dd13d35e90e824e8e5ba7db76
+
+##########################################
+#                                        #
+#  1 call to let -- each sets the value  #
+#                                        #
+##########################################
+Calculating -------------------------------------
+non-threadsafe (original)
+                        53.722k i/100ms
+non-threadsafe (config)
+                        44.998k i/100ms
+threadsafe
+                        26.123k i/100ms
+-------------------------------------------------
+non-threadsafe (original)
+                        830.988k (± 6.3%) i/s -      4.190M
+non-threadsafe (config)
+                        665.662k (± 6.7%) i/s -      3.330M
+threadsafe
+                        323.575k (± 5.6%) i/s -      1.620M
+
+Comparison:
+non-threadsafe (original):   830988.5 i/s
+non-threadsafe (config)  :   665661.9 i/s - 1.25x slower
+threadsafe               :   323574.9 i/s - 2.57x slower
+
+###################################################
+#                                                 #
+#  10 calls to let -- 9 will find memoized value  #
+#                                                 #
+###################################################
+Calculating -------------------------------------
+non-threadsafe (original)
+                        28.724k i/100ms
+non-threadsafe (config)
+                        25.357k i/100ms
+threadsafe
+                        18.349k i/100ms
+-------------------------------------------------
+non-threadsafe (original)
+                        346.302k (± 6.1%) i/s -      1.752M
+non-threadsafe (config)
+                        309.970k (± 5.4%) i/s -      1.547M
+threadsafe
+                        208.946k (± 5.2%) i/s -      1.046M
+
+Comparison:
+non-threadsafe (original):   346302.0 i/s
+non-threadsafe (config)  :   309970.2 i/s - 1.12x slower
+threadsafe               :   208946.3 i/s - 1.66x slower
+
+#######################################
+#                                     #
+#  1 call to let which invokes super  #
+#                                     #
+#######################################
+Calculating -------------------------------------
+non-threadsafe (original)
+                        42.458k i/100ms
+non-threadsafe (config)
+                        37.367k i/100ms
+threadsafe
+                        21.088k i/100ms
+-------------------------------------------------
+non-threadsafe (original)
+                        591.906k (± 6.3%) i/s -      2.972M
+non-threadsafe (config)
+                        511.295k (± 4.7%) i/s -      2.578M
+threadsafe
+                        246.080k (± 5.8%) i/s -      1.244M
+
+Comparison:
+non-threadsafe (original):   591906.3 i/s
+non-threadsafe (config)  :   511295.0 i/s - 1.16x slower
+threadsafe               :   246079.6 i/s - 2.41x slower
+
+#########################################
+#                                       #
+#  10 calls to let which invokes super  #
+#                                       #
+#########################################
+Calculating -------------------------------------
+non-threadsafe (original)
+                        24.282k i/100ms
+non-threadsafe (config)
+                        22.762k i/100ms
+threadsafe
+                        14.685k i/100ms
+-------------------------------------------------
+non-threadsafe (original)
+                        297.423k (± 5.0%) i/s -      1.505M
+non-threadsafe (config)
+                        264.046k (± 5.6%) i/s -      1.320M
+threadsafe
+                        170.853k (± 4.7%) i/s -    866.415k
+
+Comparison:
+non-threadsafe (original):   297422.6 i/s
+non-threadsafe (config)  :   264045.8 i/s - 1.13x slower
+threadsafe               :   170853.1 i/s - 1.74x slower

--- a/features/helper_methods/let.feature
+++ b/features/helper_methods/let.feature
@@ -48,3 +48,42 @@ Feature: let and let!
       """
     When I run `rspec let_bang_spec.rb`
     Then the examples should all pass
+
+  Scenario: Use --threadsafe to set `RSpec.configuration.threadsafe` (defaults to true)
+    Given a file named "let_threadsafe.rb" with:
+      """ruby
+      require 'thread'
+      accesses = Queue.new
+      turns    = Queue.new
+
+      RSpec.describe "threadsafe let" do
+        let :resource do
+          turns.shift
+          accesses << :from_let
+        end
+
+        it "will only ever access the let block once" do
+          first_access  = Thread.new { resource }
+          second_access = Thread.new { resource }
+          loop do
+            Thread.pass
+            break if first_access.stop? && second_access.stop?
+          end
+          turns << nil
+          turns << nil
+          first_access.join
+          second_access.join
+          accesses << :from_example
+          expect(accesses.shift).to eq :from_let
+          expect(accesses.shift).to eq :from_example
+        end
+      end
+      """
+    When I run `rspec let_threadsafe.rb --threadsafe`
+    Then the examples should all pass
+
+    When I run `rspec let_threadsafe.rb --no-threadsafe`
+    Then the output should contain "1 example, 1 failure"
+
+    When I run `rspec let_threadsafe.rb`
+    Then the examples should all pass

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -308,6 +308,11 @@ module RSpec
       # Record the start time of the spec suite to measure load time.
       add_setting :start_time
 
+      # @macro add_setting
+      # Use threadsafe options where available.
+      # Currently this will place a mutex around memoized values such as let blocks.
+      add_setting :threadsafe
+
       # @private
       add_setting :tty
       # @private
@@ -361,6 +366,7 @@ module RSpec
         @requires = []
         @libs = []
         @derived_metadata_blocks = FilterableItemRepository::QueryOptimized.new(:any?)
+        @threadsafe = true
       end
 
       # @private

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -462,7 +462,7 @@ module RSpec
       def self.run_before_context_hooks(example_group_instance)
         set_ivars(example_group_instance, superclass_before_context_ivars)
 
-        ContextHookMemoizedHash::Before.isolate_for_context_hook(example_group_instance) do
+        ContextHookMemoized::Before.isolate_for_context_hook(example_group_instance) do
           hooks.run(:before, :context, example_group_instance)
         end
       ensure
@@ -497,7 +497,7 @@ module RSpec
       def self.run_after_context_hooks(example_group_instance)
         set_ivars(example_group_instance, before_context_ivars)
 
-        ContextHookMemoizedHash::After.isolate_for_context_hook(example_group_instance) do
+        ContextHookMemoized::After.isolate_for_context_hook(example_group_instance) do
           hooks.run(:after, :context, example_group_instance)
         end
       ensure
@@ -613,6 +613,7 @@ module RSpec
 
       def initialize(inspect_output=nil)
         @__inspect_output = inspect_output || '(no description provided)'
+        super() # no args get passed
       end
 
       # @private

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -115,6 +115,10 @@ module RSpec::Core
           options[:color] = o
         end
 
+        parser.on('--[no-]threadsafe', 'Turn on threadsafety where available') do |o|
+          options[:threadsafe] = o
+        end
+
         parser.on('-p', '--[no-]profile [COUNT]',
                   'Enable profiling of examples and list the slowest examples (default: 10).') do |argument|
           options[:profile_examples] = if argument.nil?

--- a/lib/rspec/core/reentrant_mutex.rb
+++ b/lib/rspec/core/reentrant_mutex.rb
@@ -1,0 +1,107 @@
+module RSpec
+  module Core
+    # Allows a thread to lock out other threads from a critical section of code,
+    # while allowing the thread with the lock to reenter that section.
+    #
+    # Based on Monitor as of 2.2 - https://github.com/ruby/ruby/blob/eb7ddaa3a47bf48045d26c72eb0f263a53524ebc/lib/monitor.rb#L9
+    #
+    # Depends on Mutex, but Mutex is only available as part of core since 1.9.1:
+    #   exists - http://ruby-doc.org/core-1.9.1/Mutex.html
+    #   dne    - http://ruby-doc.org/core-1.9.0/Mutex.html
+    #
+    # @private
+    class ReentrantMutex
+      def initialize
+        @owner = nil
+        @count = 0
+        @mutex = MUTEX.new
+      end
+
+      def synchronize
+        enter
+        yield
+      ensure
+        exit
+      end
+
+    private
+
+      def enter
+        @mutex.lock if @owner != Thread.current
+        @owner = Thread.current
+        @count += 1
+      end
+
+      def exit
+        @count -= 1
+        return unless @count == 0
+        @owner = nil
+        @mutex.unlock
+      end
+    end
+
+    # @private
+    # :nocov:
+    # This can be deleted once support for 1.8.7 is dropped
+    MUTEX = if defined? ::Mutex
+              # On 1.9 and up, this is in core, so we just use the real one
+              ::Mutex
+            else
+              # On 1.8.7, it's in the stdlib.
+              # We don't want to load the stdlib, b/c this is a test tool, and can affect the test environment,
+              # causing tests to pass where they should fail.
+              #
+              # So we're transcribing/modifying it from https://github.com/ruby/ruby/blob/v1_8_7_374/lib/thread.rb#L56
+              # Some methods we don't need are deleted.
+              # Anything I don't understand (there's quite a bit, actually) is left in.
+              # Some formating changes are made to appease the robot overlord:
+              #   https://travis-ci.org/rspec/rspec-core/jobs/54410874
+              Class.new do
+                def initialize
+                  @waiting = []
+                  @locked = false
+                  @waiting.taint
+                  taint
+                end
+
+                def lock
+                  while Thread.critical = true && @locked
+                    @waiting.push Thread.current
+                    Thread.stop
+                  end
+                  @locked = true
+                  Thread.critical = false
+                  self
+                end
+
+                def unlock
+                  return unless @locked
+                  Thread.critical = true
+                  @locked = false
+                  begin
+                    t = @waiting.shift
+                    t.wakeup if t
+                  rescue ThreadError
+                    retry
+                  end
+                  Thread.critical = false
+                  begin
+                    t.run if t
+                  rescue ThreadError
+                    :noop
+                  end
+                  self
+                end
+
+                def synchronize
+                  lock
+                  begin
+                    yield
+                  ensure
+                    unlock
+                  end
+                end
+              end
+            end
+  end
+end

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -47,7 +47,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : "~> 1.5")
   s.add_development_dependency "coderay",  "~> 1.0.9"
 
-  s.add_development_dependency "mocha",    "~> 0.13.0"
-  s.add_development_dependency "rr",       "~> 1.0.4"
-  s.add_development_dependency "flexmock", "~> 0.9.0"
+  s.add_development_dependency "mocha",        "~> 0.13.0"
+  s.add_development_dependency "rr",           "~> 1.0.4"
+  s.add_development_dependency "flexmock",     "~> 0.9.0"
+  s.add_development_dependency "thread_order", "~> 1.1.0"
 end

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -211,6 +211,18 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
     end
   end
 
+  describe '--threadsafe', :threadsafe => true do
+    it 'sets :threadsafe => true' do
+      expect(parse_options('--threadsafe')).to include(:threadsafe => true)
+    end
+  end
+
+  describe '--no-threadsafe', :threadsafe => true do
+    it 'sets :threadsafe => false' do
+      expect(parse_options('--no-threadsafe')).to include(:threadsafe => false)
+    end
+  end
+
   describe "-I" do
     example "adds to :libs" do
       expect(parse_options('-I', 'a_dir')).to include(:libs => ['a_dir'])

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -2093,6 +2093,20 @@ module RSpec::Core
       include_examples "warning of deprecated `:example_group` during filtering configuration", :before, :each
     end
 
+    describe '#threadsafe', :threadsafe => true do
+      it 'defaults to false' do
+        expect(config.threadsafe).to eq true
+      end
+
+      it 'can be configured to true or false' do
+        config.threadsafe = true
+        expect(config.threadsafe).to eq true
+
+        config.threadsafe = false
+        expect(config.threadsafe).to eq false
+      end
+    end
+
     # assigns files_or_directories_to_run and triggers post-processing
     # via `files_to_run`.
     def assign_files_or_directories_to_run(*value)

--- a/spec/rspec/core/reentrant_mutex_spec.rb
+++ b/spec/rspec/core/reentrant_mutex_spec.rb
@@ -1,0 +1,30 @@
+require 'rspec/core/reentrant_mutex'
+require 'thread_order'
+
+# There are no assertions specifically
+# They are pass if they don't deadlock
+RSpec.describe RSpec::Core::ReentrantMutex do
+  let!(:mutex) { described_class.new }
+  let!(:order) { ThreadOrder.new }
+  after { order.apocalypse! }
+
+  it 'can repeatedly synchronize within the same thread' do
+    mutex.synchronize { mutex.synchronize { } }
+  end
+
+  it 'locks other threads out while in the synchronize block' do
+    order.declare(:before) { mutex.synchronize { } }
+    order.declare(:within) { mutex.synchronize { } }
+    order.declare(:after)  { mutex.synchronize { } }
+
+    order.pass_to :before, :resume_on => :exit
+    mutex.synchronize { order.pass_to :within, :resume_on => :sleep }
+    order.pass_to :after, :resume_on => :exit
+  end
+
+  it 'resumes the next thread once all its synchronize blocks have completed' do
+    order.declare(:thread) { mutex.synchronize { } }
+    mutex.synchronize { order.pass_to :thread, :resume_on => :sleep }
+    order.join_all
+  end
+end


### PR DESCRIPTION
Make memoized is a threadsafe object instead of a hash

Accordingly, rename RSpec::Core::MemoizedHelpers::ContextHookMemoizedHash -> ContextHookMemoized

Motivation
----------

When working in a truly threaded environment (e.g. Rbx and JRuby),
you can write a test like the one below, which should pass.
But, it will fail sometimes, because two threads request the uninitialized counter
concurrently. The first one to receive the value will then be
incrementing a counter, that is later overwritten when the second
thread's let block returns.

You can verify this by running the code sample below in Rubinius.
After some number of attempts, the value will be less than 10k.
If you then make the `let` block a `let!` block, it will memoize
before the threads are created, and the values will be correct again.
While this is a reasonable solution, it is incredibly confusing
when it arises (I spent a lot of hours trying to find the bug in my code),
and requires that the user understand it's something they need to
be aware of and guard against.

```ruby
class Counter
  def initialize
    @mutex = Mutex.new
    @count = 0
  end

  attr_reader :count

  def increment
    @mutex.synchronize { @count += 1 }
  end
end

RSpec.describe Counter do
  let(:counter) { Counter.new }

  it 'increments the count in a threadsafe manner' do
    threads = 10.times.map do
      Thread.new { 1000.times { counter.increment } }
    end
    threads.each &:join
    expect(counter.count).to eq 10_000
  end
end
```

Decisions
---------

Create an object because only #fetch was being called on the hash,
and to make that threadsafe required adding a new method.
At that point, there is no value in having it subclass Hash,
having to support an entire API that nothing else uses.
So just make it an object which wraps a hash and presents a memoized
getter/setter. Also named the method in such a way as to make it
very clear that it's not a hash, so a dev won't mistakenly think
they are working with one when they aren't.

I had initially tried writing the test with Fibers. It was much shorter.
But Fibers don't work, because they execute within the same thread,
so you can't identify the difference between another thread setting
the memoized value that we need to respect, and a call to super()
setting the value, which we need to override.
(eg https://github.com/rspec/rspec-core/blob/655a52b03fd00c3d64554c4268e8da3ac0bd587c/spec/rspec/core/memoized_helpers_spec.rb#L169)