### PR TITLE
Expose reporter to running examples

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### Development
+
+Enhancements:
+
+* Expose the reporter used to run examples via `RSpec::Core::Example#reporter`.
+  (Jon Rowe, #1866)
+* Make `RSpec::Core::Reporter#message` a public supported API. (Jon Rowe, #1866)
+
 ### 3.2.0 / 2015-02-03
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.1.7...v3.2.0)
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -143,7 +143,7 @@ module RSpec
 
         @example_group_instance = @exception = nil
         @clock = RSpec::Core::Time
-        @reporter = RSpec::Core::NullReporter.new
+        @reporter = RSpec::Core::NullReporter
       end
 
       # @return [RSpec::Core::Reporter] the current reporter for the example

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -143,7 +143,11 @@ module RSpec
 
         @example_group_instance = @exception = nil
         @clock = RSpec::Core::Time
+        @reporter = RSpec::Core::NullReporter.new
       end
+
+      # @return [RSpec::Core::Reporter] the current reporter for the example
+      attr_reader :reporter
 
       # Returns the example group class that provides the context for running
       # this example.
@@ -160,6 +164,7 @@ module RSpec
       # @param example_group_instance the instance of an ExampleGroup subclass
       def run(example_group_instance, reporter)
         @example_group_instance = example_group_instance
+        @reporter = reporter
         hooks.register_global_singleton_context_hooks(self, RSpec.configuration.hooks)
         RSpec.configuration.configure_example(self)
         RSpec.current_example = self

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -499,7 +499,7 @@ module RSpec
       end
 
       # Runs all the examples in this group.
-      def self.run(reporter=RSpec::Core::NullReporter.new)
+      def self.run(reporter=RSpec::Core::NullReporter)
         if RSpec.world.wants_to_quit
           RSpec.world.clear_remaining_example_groups if top_level?
           return

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -164,10 +164,9 @@ module RSpec::Core
   # @private
   # # Used in place of a {Reporter} for situations where we don't want reporting output.
   class NullReporter
-  private
-
-    def method_missing(*)
+    def self.method_missing(*)
       # ignore
     end
+    private_class_method :method_missing
   end
 end

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -40,7 +40,6 @@ module RSpec::Core
       @listeners[notification].to_a
     end
 
-    # @api
     # @overload report(count, &block)
     # @overload report(count, &block)
     # @param expected_example_count [Integer] the number of examples being run
@@ -73,7 +72,9 @@ module RSpec::Core
       notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
     end
 
-    # @private
+    # @param message [#to_s] A message object to send to formatters
+    #
+    # Send a custom message to supporting formatters.
     def message(message)
       notify :message, Notifications::MessageNotification.new(message)
     end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -732,4 +732,19 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       expect(ex).to pass
     end
   end
+
+  describe "exposing the examples reporter" do
+    it "returns a null reporter when the example hasnt run yet" do
+      example = RSpec.describe.example
+      expect(example.reporter).to be_a RSpec::Core::NullReporter
+    end
+
+    it "returns the reporter used to run the example when executed" do
+      reporter = double(:reporter).as_null_object
+      group = RSpec.describe
+      example = group.example
+      example.run group.new, reporter
+      expect(example.reporter).to be reporter
+    end
+  end
 end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -736,7 +736,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
   describe "exposing the examples reporter" do
     it "returns a null reporter when the example hasnt run yet" do
       example = RSpec.describe.example
-      expect(example.reporter).to be_a RSpec::Core::NullReporter
+      expect(example.reporter).to be RSpec::Core::NullReporter
     end
 
     it "returns the reporter used to run the example when executed" do


### PR DESCRIPTION
Expose reporter to running examples and make the `Reporter#message` api public. Fixes #1851.