### PR TITLE
Beef up tests for when rspec-expectations is not available.

### DIFF
--- a/features/expectation_framework_integration/configure_expectation_framework.feature
+++ b/features/expectation_framework_integration/configure_expectation_framework.feature
@@ -45,7 +45,8 @@ Feature: configure expectation framework
     Then the examples should all pass
 
   Scenario: Configure test/unit assertions
-    Given a file named "example_spec.rb" with:
+    Given rspec-expectations is not installed
+      And a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
         config.expect_with :test_unit
@@ -72,7 +73,8 @@ Feature: configure expectation framework
     And  the output should contain "3 examples, 1 failure"
 
   Scenario: Configure minitest assertions
-    Given a file named "example_spec.rb" with:
+    Given rspec-expectations is not installed
+      And a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
         config.expect_with :minitest
@@ -146,7 +148,8 @@ Feature: configure expectation framework
     Then the examples should all pass
 
   Scenario: Configure test/unit and minitest assertions
-    Given a file named "example_spec.rb" with:
+    Given rspec-expectations is not installed
+      And a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
         config.expect_with :test_unit, :minitest

--- a/features/step_definitions/core_standalone_steps.rb
+++ b/features/step_definitions/core_standalone_steps.rb
@@ -10,3 +10,7 @@ Given(/^only rspec-core is installed$/) do
   # rspec-expectations from the load path.
   set_env('REMOVE_OTHER_RSPEC_LIBS_FROM_LOAD_PATH', 'true')
 end
+
+Given(/^rspec-expectations is not installed$/) do
+  step "only rspec-core is installed"
+end


### PR DESCRIPTION
Specifically, in #1826, we changed the conditional for
whether or not to assign a generated description from
RSpec::Matchers for examples with no doc string. Before
#1826, the conditional was: 

``` ruby
assign_generated_description if RSpec.configuration.expecting_with_rspec?
```

In #1826 it changed to:

``` ruby
assign_generated_description if defined?(::RSpec::Matchers)
```

We didn’t update the spec meant for that case to match, but it continued
to pass (as a false positive) due to rspec/rspec-mocks#874. @samphippen’s
fix in rspec/rspec-mocks#884 surfaced the issue (as the spec now failed)
so I decided to improve the tests.

- The spec now simulates the `RSpec::Matchers` constant being undefined
  to simulate the correct condition. We also have to prevent it from
  being autoloaded.
- The cukes for minitest/test-unit did not sufficiently cover this case,
  because the aforementioned autoload would autoload RSpec::Matchers,
  so we have to simulate rspec-expectations being completely uninstalled.
  Then the cukes properly fail if we break the `if defined?(::RSpec::Matchers)`
  conditional.

@samphippen -- this is a better solution to what you were trying to solve in #1873.