### PR TITLE
Notify seed before notifying start

### DIFF
--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -78,8 +78,8 @@ module RSpec::Core
     def start(expected_example_count, time=RSpec::Core::Time.now)
       @start = time
       @load_time = (@start - @configuration.start_time).to_f
-      notify :start, Notifications::StartNotification.new(expected_example_count, @load_time)
       notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
+      notify :start, Notifications::StartNotification.new(expected_example_count, @load_time)
     end
 
     # @param message [#to_s] A message object to send to formatters

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -38,16 +38,6 @@ module RSpec::Core
     describe 'start' do
       before { config.start_time = start_time }
 
-      it 'notifies formatters of the seed used' do
-        formatter = double("formatter")
-        reporter.register_listener formatter, :seed
-
-        expect(formatter).to receive(:seed).with(
-          an_object_having_attributes(:seed => config.seed, :seed_used? => config.seed_used?)
-        )
-        reporter.start 1
-      end
-
       it 'notifies the formatter of start with example count' do
         formatter = double("formatter")
         reporter.register_listener formatter, :start
@@ -60,11 +50,13 @@ module RSpec::Core
         reporter.start 3, (start_time + 5)
       end
 
-      it 'notifies the formatter of the seed before notifing of start' do
+      it 'notifies the formatter of the seed used before notifing of start' do
         formatter = double("formatter")
         reporter.register_listener formatter, :seed
         reporter.register_listener formatter, :start
-        expect(formatter).to receive(:seed).ordered
+        expect(formatter).to receive(:seed).ordered.with(
+          an_object_having_attributes(:seed => config.seed, :seed_used? => config.seed_used?)
+        )
         expect(formatter).to receive(:start).ordered
         reporter.start 1
       end

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -38,6 +38,16 @@ module RSpec::Core
     describe 'start' do
       before { config.start_time = start_time }
 
+      it 'notifies formatters of the seed used' do
+        formatter = double("formatter")
+        reporter.register_listener formatter, :seed
+
+        expect(formatter).to receive(:seed).with(
+          an_object_having_attributes(:seed => config.seed, :seed_used? => config.seed_used?)
+        )
+        reporter.start 1
+      end
+
       it 'notifies the formatter of start with example count' do
         formatter = double("formatter")
         reporter.register_listener formatter, :start
@@ -50,13 +60,12 @@ module RSpec::Core
         reporter.start 3, (start_time + 5)
       end
 
-      it 'notifies formatters of the seed used' do
+      it 'notifies the formatter of the seed before notifing of start' do
         formatter = double("formatter")
         reporter.register_listener formatter, :seed
-
-        expect(formatter).to receive(:seed).with(
-          an_object_having_attributes(:seed => config.seed, :seed_used? => config.seed_used?)
-        )
+        reporter.register_listener formatter, :start
+        expect(formatter).to receive(:seed).ordered
+        expect(formatter).to receive(:start).ordered
         reporter.start 1
       end
     end


### PR DESCRIPTION
This fixes the output of formatters such as Fuubar.

Before:
![screen shot 2015-02-16 at 16 34 43](https://cloud.githubusercontent.com/assets/487728/6214588/f0b1b3b4-b5f9-11e4-91c4-f66999be27b6.png)

After:
![screen shot 2015-02-16 at 16 36 56](https://cloud.githubusercontent.com/assets/487728/6214618/0e0cc96c-b5fa-11e4-9dd1-c9e1e445a558.png)
