### PR TITLE
add type and version information to json formatter

### DIFF
--- a/lib/rspec/core/formatters/json_formatter.rb
+++ b/lib/rspec/core/formatters/json_formatter.rb
@@ -12,7 +12,10 @@ module RSpec
 
         def initialize(output)
           super
-          @output_hash = {}
+          @output_hash = {
+            :type => 'rspec-json',
+            :version => RSpec::Core::Version::STRING
+          }
         end
 
         def message(notification)

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
     this_file = relative_path(__FILE__)
 
     expected = {
+      :type => 'rspec-json',
+      :version => RSpec::Core::Version::STRING,
       :examples => [
         {
           :description => "succeeds",
@@ -89,7 +91,10 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
     it "outputs the results as a JSON string" do
       expect(output.string).to eq ""
       send_notification :close, null_notification
-      expect(output.string).to eq("{}")
+      expect(output.string).to eq({
+        :type => 'rspec-json',
+        :version => RSpec::Core::Version::STRING
+      }.to_json)
     end
   end
 


### PR DESCRIPTION
- add type to allow clients to detect file format
- add version to determine which version of rspec-core generated the
  file