### PR TITLE
Example ids

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Lint/LiteralInInterpolation:
 
 # This should go down over time.
 MethodLength:
-  Max: 155
+  Max: 40
 
 # Exclude the default spec_helper to make it easier to uncomment out
 # default settings (for both users and the Cucumber suite).

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,11 @@ Enhancements:
   `RSpec::Core::Reporter#publish(event_name, hash_of_attributes)`. (Jon Rowe, #1869)
 * Remove dependency on the standard library `Set` and replace with `RSpec::Core::Set`.
   (Jon Rowe, #1870)
+* Assign a unique id to each example and group so that they can be
+  uniquely identified, even for shared examples (and similar situations)
+  where the location isn't unique. (Myron Marston, #1884)
+* Use the example id in the rerun command printed for failed examples
+  when the location is not unique. (Myron Marston, #1884)
 
 Bug Fixes:
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1613,6 +1613,9 @@ module RSpec
           captures = match.captures
           path, lines = captures[0], captures[1][1..-1].split(":").map { |n| n.to_i }
           filter_manager.add_location path, lines
+        else
+          path, scoped_ids = path.split(/[\[\]]/)
+          filter_manager.add_ids(path, scoped_ids.split(/\s*,\s*/)) if scoped_ids
         end
 
         return [] if path == default_path

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1606,6 +1606,9 @@ module RSpec
         end
       end
 
+      # @private
+      ON_SQUARE_BRACKETS = /[\[\]]/
+
       def extract_location(path)
         match = /^(.*?)((?:\:\d+)+)$/.match(path)
 
@@ -1614,7 +1617,7 @@ module RSpec
           path, lines = captures[0], captures[1][1..-1].split(":").map { |n| n.to_i }
           filter_manager.add_location path, lines
         else
-          path, scoped_ids = path.split(/[\[\]]/)
+          path, scoped_ids = path.split(ON_SQUARE_BRACKETS)
           filter_manager.add_ids(path, scoped_ids.split(/\s*,\s*/)) if scoped_ids
         end
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -101,6 +101,12 @@ module RSpec
         end
       end
 
+      # @return [String] the unique id of this example. Pass
+      #   this at the command line to re-run this exact example.
+      def id
+        Metadata.id_from(metadata)
+      end
+
       # @attr_reader
       #
       # Returns the first exception raised in the context of running this
@@ -138,7 +144,9 @@ module RSpec
         @example_block       = example_block
 
         @metadata = Metadata::ExampleHash.create(
-          @example_group_class.metadata, user_metadata, description, example_block
+          @example_group_class.metadata, user_metadata,
+          example_group_class.method(:next_runnable_index_for),
+          description, example_block
         )
 
         @example_group_instance = @exception = nil

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -92,13 +92,24 @@ module RSpec
         inspect_output
       end
 
-      # Returns the argument that can be passed to the `rspec` command to rerun this example.
-      def rerun_argument
-        loaded_spec_files = RSpec.configuration.loaded_spec_files
+      # Returns the location-based argument that can be passed to the `rspec` command to rerun this example.
+      def location_rerun_argument
+        @location_rerun_argument ||= begin
+          loaded_spec_files = RSpec.configuration.loaded_spec_files
 
-        Metadata.ascending(metadata) do |meta|
-          return meta[:location] if loaded_spec_files.include?(meta[:absolute_file_path])
+          Metadata.ascending(metadata) do |meta|
+            return meta[:location] if loaded_spec_files.include?(meta[:absolute_file_path])
+          end
         end
+      end
+
+      # Returns the location-based argument that can be passed to the `rspec` command to rerun this example.
+      #
+      # @deprecated Use {#location_rerun_argument} instead.
+      # @note If there are multiple examples identified by this location, they will use {#id}
+      #   to rerun instead, but this method will still return the location (that's why it is deprecated!).
+      def rerun_argument
+        location_rerun_argument
       end
 
       # @return [String] the unique id of this example. Pass

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -322,6 +322,8 @@ module RSpec
       # @private
       RESERVED_KEYS = [
         :description,
+        :description_args,
+        :described_class,
         :example_group,
         :parent_example_group,
         :execution_result,
@@ -332,7 +334,8 @@ module RSpec
         :line_number,
         :location,
         :scoped_id,
-        :block
+        :block,
+        :shared_group_inclusion_backtrace
       ]
     end
 

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -17,6 +17,7 @@ module RSpec
           silence_metadata_example_group_deprecations do
             return filter_applies_to_any_value?(key, value, metadata) if Array === metadata[key] && !(Proc === value)
             return location_filter_applies?(value, metadata)          if key == :locations
+            return id_filter_applies?(value, metadata)                if key == :ids
             return filters_apply?(key, value, metadata)               if Hash === value
 
             return false unless metadata.key?(key)
@@ -40,6 +41,14 @@ module RSpec
 
         def filter_applies_to_any_value?(key, value, metadata)
           metadata[key].any? { |v| filter_applies?(key, v,  key => value) }
+        end
+
+        def id_filter_applies?(rerun_paths_to_scoped_ids, metadata)
+          scoped_ids = rerun_paths_to_scoped_ids.fetch(metadata[:rerun_file_path]) { return false }
+
+          Metadata.ascend(metadata).any? do |meta|
+            scoped_ids.include?(meta[:scoped_id])
+          end
         end
 
         def location_filter_applies?(locations, metadata)

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -520,7 +520,8 @@ module RSpec::Core
 
       def rerun_argument_for(example)
         location = example.location_rerun_argument
-        duplicate_rerun_locations.include?(location) ? example.id : location
+        return location unless duplicate_rerun_locations.include?(location)
+        conditionally_quote(example.id)
       end
 
       def duplicate_rerun_locations
@@ -533,6 +534,34 @@ module RSpec::Core
             end
           end
         end
+      end
+
+      # Known shells that require quoting: zsh, csh, tcsh.
+      #
+      # Feel free to add other shells to this list that are known to
+      # allow `rspec ./some_spec.rb[1:1]` syntax without quoting the id.
+      #
+      # @private
+      SHELLS_ALLOWING_UNQUOTED_IDS = %w[ bash ksh ]
+
+      def conditionally_quote(id)
+        return id if shell_allows_unquoted_ids?
+        "'#{id.gsub("'", "\\\\'")}'"
+      end
+
+      def shell_allows_unquoted_ids?
+        return @shell_allows_unquoted_ids if defined?(@shell_allows_unquoted_ids)
+
+        @shell_allows_unquoted_ids = SHELLS_ALLOWING_UNQUOTED_IDS.include?(
+          # Note: ENV['SHELL'] isn't necessarily the shell the user is currently running.
+          # According to http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html:
+          # "This variable shall represent a pathname of the user's preferred command language interpreter."
+          #
+          # It's the best we can easily do, though. We err on the side of safety (quoting
+          # the id when not actually needed) so it's not a big deal if the user is actually
+          # using a different shell.
+          ENV['SHELL'].to_s.split('/').last
+        )
       end
     end
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -485,7 +485,7 @@ module RSpec::Core
       def colorized_rerun_commands(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         "\nFailed examples:\n\n" +
         failed_examples.map do |example|
-          colorizer.wrap("rspec #{example.rerun_argument}", RSpec.configuration.failure_color) + " " +
+          colorizer.wrap("rspec #{rerun_argument_for(example)}", RSpec.configuration.failure_color) + " " +
           colorizer.wrap("# #{example.full_description}",   RSpec.configuration.detail_color)
         end.join("\n")
       end
@@ -514,6 +514,25 @@ module RSpec::Core
         end
 
         formatted
+      end
+
+    private
+
+      def rerun_argument_for(example)
+        location = example.location_rerun_argument
+        duplicate_rerun_locations.include?(location) ? example.id : location
+      end
+
+      def duplicate_rerun_locations
+        @duplicate_rerun_locations ||= begin
+          locations = RSpec.world.all_examples.map(&:location_rerun_argument)
+
+          Set.new.tap do |s|
+            locations.group_by { |l| l }.each do |l, ls|
+              s << l if ls.count > 1
+            end
+          end
+        end
       end
     end
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -542,7 +542,7 @@ module RSpec::Core
       # allow `rspec ./some_spec.rb[1:1]` syntax without quoting the id.
       #
       # @private
-      SHELLS_ALLOWING_UNQUOTED_IDS = %w[ bash ksh ]
+      SHELLS_ALLOWING_UNQUOTED_IDS = %w[ bash ksh fish ]
 
       def conditionally_quote(id)
         return id if shell_allows_unquoted_ids?

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -21,6 +21,7 @@ module RSpec::Core
       options
     end
 
+    # rubocop:disable MethodLength
     def parser(options)
       OptionParser.new do |parser|
         parser.banner = "Usage: rspec [options] [files or directories]\n\n"
@@ -143,11 +144,15 @@ module RSpec::Core
 
   **** Filtering/tags ****
 
-    In addition to the following options for selecting specific files, groups,
-    or examples, you can select a single example by appending the line number to
+    In addition to the following options for selecting specific files, groups, or
+    examples, you can select individual examples by appending the line number(s) to
     the filename:
 
-      rspec path/to/a_spec.rb:37
+      rspec path/to/a_spec.rb:37:87
+
+    You can also pass example ids enclosed in square brackets:
+
+      rspec path/to/a_spec.rb[1:5,1:6] # run the 5th and 6th examples/groups defined in the 1st group
 
 FILTERING
 
@@ -224,5 +229,6 @@ FILTERING
 
       end
     end
+    # rubocop:enable MethodLength
   end
 end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -13,6 +13,7 @@ module RSpec
       def initialize(configuration=RSpec.configuration)
         @configuration = configuration
         @example_groups = []
+        @example_group_counts_by_spec_file = Hash.new(0)
         @filtered_examples = Hash.new do |hash, group|
           hash[group] = begin
             examples = group.examples.dup
@@ -55,7 +56,13 @@ module RSpec
       # Register an example group.
       def register(example_group)
         example_groups << example_group
+        @example_group_counts_by_spec_file[example_group.metadata[:file_path]] += 1
         example_group
+      end
+
+      # @private
+      def num_example_groups_defined_in(file)
+        @example_group_counts_by_spec_file[file]
       end
 
       # @private

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -88,6 +88,12 @@ module RSpec
           inject(0) { |a, e| a + e.filtered_examples.size }
       end
 
+      # @private
+      def all_examples
+        flattened_groups = FlatMap.flat_map(example_groups) { |g| g.descendants }
+        FlatMap.flat_map(flattened_groups) { |g| g.examples }
+      end
+
       # @api private
       #
       # Find line number of previous declaration.

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe 'Filtering' do
 
   it 'prints a rerun command for shared examples in external files that works to rerun' do
     write_file "spec/support/shared_examples.rb", """
-      RSpec.shared_examples 'a failing example' do
-        example { expect(1).to eq(2) }
+      RSpec.shared_examples 'with a failing example' do
+        example { expect(1).to eq(2) } # failing
+        example { expect(2).to eq(2) } # passing
       end
     """
 
@@ -15,7 +16,7 @@ RSpec.describe 'Filtering' do
       load File.expand_path('../support/shared_examples.rb', __FILE__)
 
       RSpec.describe 'A group with shared examples' do
-        include_examples 'a failing example'
+        include_examples 'with a failing example'
       end
 
       RSpec.describe 'A group with a passing example' do
@@ -24,7 +25,7 @@ RSpec.describe 'Filtering' do
     """
 
     run_command ""
-    expect(last_cmd_stdout).to include("2 examples, 1 failure")
+    expect(last_cmd_stdout).to include("3 examples, 1 failure")
     run_rerun_command_for_failing_spec
     expect(last_cmd_stdout).to include("1 example, 1 failure")
     # There was originally a bug when doing it again...

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -147,6 +147,10 @@ RSpec.describe 'Filtering' do
       run_command "./spec/file_1_spec.rb[1:1,1:3] ./spec/file_2_spec.rb[1:2]"
       expect(last_cmd_stdout).to match(/3 examples, 0 failures/)
 
+      # Using spaces between scoped ids, and quoting the whole thing...
+      run_command "'./spec/file_1_spec.rb[1:1, 1:3]' ./spec/file_2_spec.rb[1:2]"
+      expect(last_cmd_stdout).to match(/3 examples, 0 failures/)
+
       # Without the leading `.`...
       run_command "spec/file_1_spec.rb[1:1,1:3] spec/file_2_spec.rb[1:2]"
       expect(last_cmd_stdout).to match(/3 examples, 0 failures/)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -752,13 +752,6 @@ module RSpec::Core
       end
     end
 
-    describe "path with line number" do
-      it "assigns the line number as a location filter" do
-        assign_files_or_directories_to_run "path/to/a_spec.rb:37"
-        expect(inclusion_filter).to eq({:locations => {File.expand_path("path/to/a_spec.rb") => [37]}})
-      end
-    end
-
     context "with full_description set" do
       it "overrides filters" do
         config.filter_run :focused => true

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -796,6 +796,42 @@ module RSpec::Core
       end
     end
 
+    context "with an example id" do
+      it "assigns the file and id as an ids filter" do
+        assign_files_or_directories_to_run "./path/to/a_spec.rb[1:2]"
+        expect(inclusion_filter).to eq(:ids => { "./path/to/a_spec.rb" => ["1:2"] })
+      end
+    end
+
+    context "with a single file with multiple example ids" do
+      it "assigns the file and ids as an ids filter" do
+        assign_files_or_directories_to_run "./path/to/a_spec.rb[1:2,1:3]"
+        expect(inclusion_filter).to eq(:ids => { "./path/to/a_spec.rb" => ["1:2", "1:3"] })
+      end
+
+      it "ignores whitespace between scoped ids" do
+        assign_files_or_directories_to_run "./path/to/a_spec.rb[1:2 , 1:3]"
+        expect(inclusion_filter).to eq(:ids => { "./path/to/a_spec.rb" => ["1:2", "1:3"] })
+      end
+    end
+
+    context "with multiple files with ids" do
+      it "assigns all of them to the ids filter" do
+        assign_files_or_directories_to_run "./path/to/a_spec.rb[1:2,1:3]", "./path/to/b_spec.rb[1:4]"
+        expect(inclusion_filter).to eq(:ids => {
+          "./path/to/a_spec.rb" => ["1:2", "1:3"],
+          "./path/to/b_spec.rb" => ["1:4"]
+        })
+      end
+    end
+
+    context "with the same file specified multiple times with different scoped ids" do
+      it "unions all the ids" do
+        assign_files_or_directories_to_run "./path/to/a_spec.rb[1:2]", "./path/to/a_spec.rb[1:3]"
+        expect(inclusion_filter).to eq(:ids => { "./path/to/a_spec.rb" => ["1:2", "1:3"] })
+      end
+    end
+
     it "assigns the example name as the filter on description" do
       config.full_description = "foo"
       expect(inclusion_filter).to eq({:full_description => /foo/})

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -32,10 +32,10 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
 
     describe "rerun command for failed examples" do
       it "uses the location to identify the example" do
+        line = __LINE__ + 2
         example_group = RSpec.describe("example group") do
           it("fails") { fail }
         end
-        line = __LINE__ - 2
 
         expect(output_from_running example_group).to include("rspec #{RSpec::Core::Metadata::relative_path("#{__FILE__}:#{line}")} # example group fails")
       end

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -53,14 +53,38 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
       end
 
       context "for an example that is not uniquely identified by the location" do
-        it "uses the id instead" do
-          example_group = RSpec.describe("example group") do
-            1.upto(2) do |i|
-              it("compares #{i} against 2") { expect(i).to eq(2) }
+        let(:example_group_in_this_file) { example_group_defined_in(__FILE__) }
+
+        def example_group_defined_in(file)
+          instance_eval <<-EOS, file, 1
+            $group = RSpec.describe("example group") do
+              1.upto(2) do |i|
+                it("compares \#{i} against 2") { expect(i).to eq(2) }
+              end
             end
+          EOS
+          $group
+        end
+
+        let(:id) { "#{RSpec::Core::Metadata::relative_path("#{__FILE__}")}[1:1]" }
+
+        it "uses the id instead" do
+          with_env_vars 'SHELL' => '/usr/local/bin/bash' do
+            expect(output_from_running example_group_in_this_file).to include("rspec #{id} # example group compares 1 against 2")
+          end
+        end
+
+        context "on a shell that may not handle unquoted ids" do
+          around { |ex| with_env_vars('SHELL' => '/usr/local/bin/cash', &ex) }
+
+          it 'quotes the id to be safe so the rerun command can be copied and pasted' do
+            expect(output_from_running example_group_in_this_file).to include("rspec '#{id}'")
           end
 
-          expect(output_from_running example_group).to include("rspec #{RSpec::Core::Metadata::relative_path("#{__FILE__}[1:1]")} # example group compares 1 against 2")
+          it 'correctly escapes file names that have quotes in them' do
+            group_in_other_file = example_group_defined_in("./path/with'quote_spec.rb")
+            expect(output_from_running group_in_other_file).to include("rspec './path/with\\'quote_spec.rb[1:1]'")
+          end
         end
       end
 

--- a/spec/rspec/core/metadata_filter_spec.rb
+++ b/spec/rspec/core/metadata_filter_spec.rb
@@ -107,6 +107,37 @@ module RSpec
           }.to raise_error(ArgumentError)
         end
 
+        context "with an :ids filter" do
+          it 'matches examples with a matching id and rerun_file_path' do
+            metadata = { :scoped_id => "1:2", :rerun_file_path => "some/file" }
+            expect(filter_applies?(:ids, { "some/file" => ["1:2"] }, metadata)).to be true
+          end
+
+          it 'does not match examples without a matching id' do
+            metadata = { :scoped_id => "1:2", :rerun_file_path => "some/file" }
+            expect(filter_applies?(:ids, { "some/file" => ["1:3"] }, metadata)).to be false
+          end
+
+          it 'does not match examples without a matching rerun_file_path' do
+            metadata = { :scoped_id => "1:2", :rerun_file_path => "some/file" }
+            expect(filter_applies?(:ids, { "some/file_2" => ["1:2"] }, metadata)).to be false
+          end
+
+          it 'matches the scoped id from a parent example group' do
+            metadata = { :scoped_id => "1:2", :rerun_file_path => "some/file", :example_group => { :scoped_id => "1" } }
+            expect(filter_applies?(:ids, { "some/file" => ["1"] }, metadata)).to be true
+            expect(filter_applies?(:ids, { "some/file" => ["2"] }, metadata)).to be false
+          end
+
+          it 'matches only on entire id segments so (1 is not treated as a parent group of 11)' do
+            metadata = { :scoped_id => "1:2", :rerun_file_path => "some/file", :example_group => { :scoped_id => "1" } }
+            expect(filter_applies?(:ids, { "some/file" => ["1"] }, metadata)).to be true
+
+            metadata = { :scoped_id => "11", :rerun_file_path => "some/file" }
+            expect(filter_applies?(:ids, { "some/file" => ["1"] }, metadata)).to be false
+          end
+        end
+
         context "with a nested hash" do
           it 'matches when the nested entry matches' do
             metadata = { :foo => { :bar => "words" } }

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -31,6 +31,15 @@ module RSpec
 
       end
 
+      specify 'RESERVED_KEYS contains all keys assigned by RSpec (and vice versa)' do
+        group        = RSpec.describe("group")
+        example      = group.example("example") { }
+        nested_group = group.describe("nested")
+
+        assigned_keys = group.metadata.keys | example.metadata.keys | nested_group.metadata.keys
+        expect(RSpec::Core::Metadata::RESERVED_KEYS).to match_array(assigned_keys)
+      end
+
       context "when created" do
         Metadata::RESERVED_KEYS.each do |key|
           it "prohibits :#{key} as a hash key for an example group" do

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -159,6 +159,90 @@ module RSpec
         end
       end
 
+      describe ":id" do
+        define :have_id_with do |scoped_id|
+          expected_id = "#{Metadata.relative_path(__FILE__)}[#{scoped_id}]"
+
+          match do |group_or_example|
+            group_or_example.metadata[:scoped_id] == scoped_id &&
+            group_or_example.id == expected_id
+          end
+
+          failure_message do |group_or_example|
+            "expected #{group_or_example.inspect}\n" \
+            "   to have id: #{expected_id}\n" \
+            "   but had id: #{group_or_example.id}\n" \
+            "   and have scoped id: #{scoped_id}\n" \
+            "   but had  scoped id: #{group_or_example.metadata[:scoped_id]}"
+          end
+        end
+
+        context "on a top-level group" do
+          it "is set to file[<group index>]" do
+            expect(RSpec.describe).to have_id_with("1")
+            expect(RSpec.describe).to have_id_with("2")
+          end
+
+          it "starts the count at 1 for each file" do
+            instance_eval <<-EOS, "spec_1.rb", 1
+              $group_1 = RSpec.describe
+              $group_2 = RSpec.describe
+            EOS
+
+            instance_eval <<-EOS, "spec_2.rb", 1
+              $group_3 = RSpec.describe
+              $group_4 = RSpec.describe
+            EOS
+
+            expect($group_1.id).to end_with("spec_1.rb[1]")
+            expect($group_2.id).to end_with("spec_1.rb[2]")
+            expect($group_3.id).to end_with("spec_2.rb[1]")
+            expect($group_4.id).to end_with("spec_2.rb[2]")
+          end
+        end
+
+        context "on a nested group" do
+          it "is set to file[<group index>:<group index>]" do
+            top_level_group = RSpec.describe
+            expect(top_level_group.describe).to have_id_with("1:1")
+            expect(top_level_group.describe).to have_id_with("1:2")
+          end
+        end
+
+        context "on an example" do
+          it "is set to file[<group index>:<example index>]" do
+            group = RSpec.describe
+            expect(group.example).to have_id_with("1:1")
+            expect(group.example).to have_id_with("1:2")
+          end
+        end
+
+        context "when examples are interleaved with example groups" do
+          it "counts both when assigning the index" do
+            group = RSpec.describe
+            expect(group.example ).to have_id_with("1:1")
+            expect(group.describe).to have_id_with("1:2")
+            expect(group.example ).to have_id_with("1:3")
+            expect(group.example ).to have_id_with("1:4")
+            expect(group.describe).to have_id_with("1:5")
+          end
+        end
+
+        context "on an example defined in a shared group defined in a separate file" do
+          it "uses the host group's file name as the prefix" do
+            # Using eval in order to make ruby think this got defined in another file.
+            instance_eval <<-EOS, "some/external/file.rb", 1
+              RSpec.shared_examples "shared" do
+                example { }
+              end
+            EOS
+
+            group = RSpec.describe { include_examples "shared" }
+            expect(group.examples.first.id).to start_with(Metadata.relative_path(__FILE__))
+          end
+        end
+      end
+
       describe ":shared_group_inclusion_backtrace" do
         context "for an example group" do
           it "is not set since we do not yet need it internally (but we can add it in the future if needed)" do

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -23,6 +23,33 @@ module RSpec::Core
       end
     end
 
+    describe "#all_examples" do
+      it "contains all examples from all levels of nesting" do
+        RSpec.describe do
+          example("ex1")
+
+          context "nested" do
+            example("ex2")
+
+            context "nested" do
+              example("ex3")
+              example("ex4")
+            end
+          end
+
+          example("ex5")
+        end
+
+        RSpec.describe do
+          example("ex6")
+        end
+
+        expect(RSpec.world.all_examples.map(&:description)).to match_array(%w[
+          ex1 ex2 ex3 ex4 ex5 ex6
+        ])
+      end
+    end
+
     describe "#preceding_declaration_line (again)" do
       let(:group) do
         RSpec.describe("group") do

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -16,9 +16,10 @@ RSpec.shared_context "aruba support" do
     temp_stdout = StringIO.new
     temp_stderr = StringIO.new
     RSpec::Core::Metadata.instance_variable_set(:@relative_path_regex, nil)
+    cmd_parts = Shellwords.split(cmd)
 
     in_current_dir do
-      RSpec::Core::Runner.run(cmd.split, temp_stderr, temp_stdout)
+      RSpec::Core::Runner.run(cmd_parts, temp_stderr, temp_stdout)
     end
   ensure
     RSpec.reset

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -214,7 +214,7 @@ module FormatterSupport
                         :full_description  => "Example",
                         :execution_result  => result,
                         :location          => "",
-                        :rerun_argument    => "",
+                        :location_rerun_argument => "",
                         :metadata          => {
                           :shared_group_inclusion_backtrace => []
                         }


### PR DESCRIPTION
* This introduces a new metadata key `:rerun_file_path`.  This is usually the same as `:file_path` but can be different for situations such as an abstract example defined in a shared example group.  In that situation `:file_path` would be file the shared example group is defined in (e.g. `spec/support/model_shared_examples.rb`), whereas `:rerun_file_path` would be the file would be something like `spec/models/my_model_spec.rb` -- a particular spec file that includes the shared example group.  The `:rerun_file_path` is the file arg you would have to pass to `rspec` to cause the example to be re-run.
* I wound up with a slightly different format for example ids than what was discussed in #1767 (e.g. `./spec/rspec/core/example_spec.rb[1:14]`). You can also specify multiple examples or groups: `./spec/rspec/core/example_spec.rb[1:14,1:15]`. I thought the brackets make a nice syntax for separating the id part from the file part, and it makes it clear that you are passing an example id, whereas in the syntax suggested in #1767, it's harder to differentiate between an id filter and a location filter -- `file_name:1` would be ambiguous about whether it's a line number or id filter.  This allows us to support passing ids simply as the main args to `rspec`, e.g. `rspec ./spec/rspec/core/example_spec.rb[1:1] ./spec/rspec/core/example_group_spec.rb[1:1]`, which I think is better than a specific `--ids` flag.  One downside to this syntax is that zsh makes you wrap it in quotes due to the use of `[...]`.  Bash doesn't, though.  I'm not sure about Windows, but it's the syntax Rake uses for task arguments so I figured it's already been vetted and proved out by rake and I have to assume rake works fine on windows.
* The rerun command printed for each failed example will now use the example id if the location would match multiple examples, so that the rerun command is always guaranteed to match only the specific example it is intended for.  (This is commonly needed for failed examples from shared example groups).  One issue with this change: if you run zsh (as I do), you can't simply copy and paste the rerun command anymore in these situations, since zsh forces you to escape the `[]` characters.  It'd be nice to do something about that but I'm not sure what.

TODOs:
- [x] Ensure rerun command can be copied/pasted in zsh
- [x] Add changelog entries

