### PR TITLE
Fix filtering regression 3 2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+### 3.2.2 Development
+[Full Changelog](http://github.com/rspec/rspec-core/compare/v3.2.1...3-2-maintenance)
+
+Bug Fixes:
+
+* Fix regression in 3.2.0 that allowed tag-filtered examples to
+  run even if there was a location filter applied to the spec
+  file that was intended to limit the file to other examples.
+  (#1894, Myron Marston)
+
 ### 3.2.1 / 2015-02-23
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.2.0...v3.2.1)
 

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -122,5 +122,27 @@ RSpec.describe 'Filtering' do
       expect(last_cmd_stdout).to match(/3 examples, 0 failures/)
       expect(last_cmd_stdout).not_to match(/fails/)
     end
+
+    it 'applies command line tag filters only to files that lack a line number filter' do
+      write_file_formatted "spec/file_1_spec.rb", """
+        RSpec.describe 'File 1' do
+          it('is selected by line')   { }
+          it('is not selected', :tag) { }
+        end
+      """
+
+      write_file_formatted "spec/file_2_spec.rb", """
+        RSpec.describe 'File 2' do
+          it('is not selected')          { }
+          it('is selected by tag', :tag) { }
+        end
+      """
+
+      run_command "spec/file_1_spec.rb:2 spec/file_2_spec.rb --tag tag -fd"
+      expect(last_cmd_stdout).to include(
+        "2 examples, 0 failures",
+        "is selected by line", "is selected by tag"
+      ).and exclude("not selected")
+    end
   end
 end

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -13,6 +13,8 @@ RSpec.shared_context "aruba support" do
   attr_reader :last_cmd_stdout, :last_cmd_stderr
 
   def run_command(cmd)
+    RSpec.configuration.color = true
+
     temp_stdout = StringIO.new
     temp_stderr = StringIO.new
     RSpec::Core::Metadata.instance_variable_set(:@relative_path_regex, nil)
@@ -22,6 +24,7 @@ RSpec.shared_context "aruba support" do
     end
   ensure
     RSpec.reset
+    RSpec.configuration.color = true
     RSpec::Core::Metadata.instance_variable_set(:@relative_path_regex, nil)
 
     # Ensure it gets cached with a proper value -- if we leave it set to nil,


### PR DESCRIPTION
This fixes #1889 for 3.2.  I anticipate implementing a slightly different fix for master since the filter manager has changed in master for example ids.

Before 35137e0c9691f75fd9ad1aa7627698fbaba6c4f1, when a location filter and CLI tag filter were combined, the tag filter was completely ignored. Our fix here is a middle ground between the old behavior and the improvement of 35137e0c9691f75fd9ad1aa7627698fbaba6c4f1: for examples defined in a file
for which there is a location filter, we only apply the location filter; for other examples we still apply the non-location inclusion filters.