### PR TITLE
Update coverage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,8 @@ Bug Fixes:
 * Handle invalid UTF-8 strings within exception methods. (Benjamin Fleischer, #1760)
 * Fix Rake Task quoting of file names with quotes to work properly on
   Windows. (Myron Marston, #1887)
+* Fix `RSpec::Core::RakeTask#failure_message` so that it gets printed
+  when the task failed. (Myron Marston, #1905)
 
 ### 3.2.2 / 2015-03-11
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.2.1...v3.2.2)

--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -47,8 +47,6 @@ module RSpec
 
       def backtrace_line(line)
         Metadata.relative_path(line) unless exclude?(line)
-      rescue SecurityError
-        nil
       end
 
       def exclude?(line)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1261,7 +1261,8 @@ module RSpec
         def safe_extend(mod, host)
           host.extend(mod) unless host.singleton_class < mod
         end
-      else
+      else # for 1.8.7
+        # :nocov:
         # @private
         def safe_include(mod, host)
           host.__send__(:include, mod) unless host.included_modules.include?(mod)
@@ -1271,6 +1272,7 @@ module RSpec
         def safe_extend(mod, host)
           host.extend(mod) unless (class << host; self; end).included_modules.include?(mod)
         end
+        # :nocov:
       end
 
       # @private
@@ -1665,6 +1667,7 @@ module RSpec
       end
 
       if RSpec::Support::OS.windows?
+        # :nocov:
         def absolute_pattern?(pattern)
           pattern =~ /\A[A-Z]:\\/ || windows_absolute_network_path?(pattern)
         end
@@ -1673,6 +1676,7 @@ module RSpec
           return false unless ::File::ALT_SEPARATOR
           pattern.start_with?(::File::ALT_SEPARATOR + ::File::ALT_SEPARATOR)
         end
+        # :nocov:
       else
         def absolute_pattern?(pattern)
           pattern.start_with?(File::Separator)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -460,14 +460,6 @@ module RSpec
         "example at #{location}"
       end
 
-      def skip_message
-        if String === skip
-          skip
-        else
-          Pending::NO_REASON_GIVEN
-        end
-      end
-
       # Represents the result of executing an example.
       # Behaves like a hash for backwards compatibility.
       class ExecutionResult

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -482,6 +482,7 @@ module RSpec
           superclass.before_context_ivars
         end
       else # 1.8.7
+        # :nocov:
         # @private
         def self.superclass_before_context_ivars
           if superclass.respond_to?(:before_context_ivars)
@@ -496,6 +497,7 @@ module RSpec
             ancestors.find { |a| a.respond_to?(:before_context_ivars) }.before_context_ivars
           end
         end
+        # :nocov:
       end
 
       # @private
@@ -603,8 +605,10 @@ module RSpec
       end
 
       if RUBY_VERSION.to_f < 1.9
+        # :nocov:
         # @private
         INSTANCE_VARIABLE_TO_IGNORE = '@__inspect_output'.freeze
+        # :nocov:
       else
         # @private
         INSTANCE_VARIABLE_TO_IGNORE = :@__inspect_output
@@ -627,10 +631,12 @@ module RSpec
       end
 
       unless method_defined?(:singleton_class) # for 1.8.7
+        # :nocov:
         # @private
         def singleton_class
           class << self; self; end
         end
+        # :nocov:
       end
 
       # Raised when an RSpec API is called in the wrong scope, such as `before`
@@ -774,6 +780,7 @@ module RSpec
     end
 
     if RUBY_VERSION == '1.9.2'
+      # :nocov:
       class << self
         alias _base_name_for base_name_for
         def base_name_for(group)
@@ -781,6 +788,7 @@ module RSpec
         end
       end
       private_class_method :_base_name_for
+      # :nocov:
     end
 
     def self.disambiguate(name, const_scope)

--- a/lib/rspec/core/filter_manager.rb
+++ b/lib/rspec/core/filter_manager.rb
@@ -183,10 +183,6 @@ module RSpec
         apply_standalone_filter(*args) || super
       end
 
-      def use(*args)
-        apply_standalone_filter(*args) || super
-      end
-
       def include_example?(example)
         @rules.empty? || super
       end

--- a/lib/rspec/core/flat_map.rb
+++ b/lib/rspec/core/flat_map.rb
@@ -7,9 +7,11 @@ module RSpec
           array.flat_map(&block)
         end
       else # for 1.8.7
+        # :nocov:
         def flat_map(array, &block)
           array.map(&block).flatten(1)
         end
+        # :nocov:
       end
 
       module_function :flat_map

--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -138,13 +138,7 @@ module RSpec::Core::Formatters
         formatter = RSpec::LegacyFormatters.load_formatter formatter_class, *args
         @reporter.register_listener formatter, *formatter.notifications
       else
-        line = ::RSpec::CallerFilter.first_non_rspec_line
-        if line
-          call_site = "Formatter added at: #{line}"
-        else
-          call_site = "The formatter was added via command line flag or your "\
-                      "`.rspec` file."
-        end
+        call_site = "Formatter added at: #{::RSpec::CallerFilter.first_non_rspec_line}"
 
         RSpec.warn_deprecation <<-WARNING.gsub(/\s*\|/, ' ')
           |The #{formatter_class} formatter uses the deprecated formatter

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -64,10 +64,6 @@ module RSpec
         def current_indentation
           '  ' * @group_level
         end
-
-        def example_group_chain
-          example_group.parent_groups.reverse
-        end
       end
     end
   end

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -74,8 +74,6 @@ module RSpec
                                   :message => exception.message,
                                   :backtrace => failure.formatted_backtrace.join("\n")
                                 }
-                              else
-                                false
                               end
           extra = extra_failure_content(failure)
 
@@ -85,8 +83,7 @@ module RSpec
             example.execution_result.run_time,
             @failed_examples.size,
             exception_details,
-            (extra == "") ? false : extra,
-            true
+            (extra == "") ? false : extra
           )
           @printer.flush
         end

--- a/lib/rspec/core/formatters/html_printer.rb
+++ b/lib/rspec/core/formatters/html_printer.rb
@@ -35,7 +35,7 @@ module RSpec
 
         # rubocop:disable Style/ParameterLists
         def print_example_failed(pending_fixed, description, run_time, failure_id,
-                                 exception, extra_content, escape_backtrace=false)
+                                 exception, extra_content)
           # rubocop:enable Style/ParameterLists
           formatted_run_time = "%.5f" % run_time
 
@@ -45,11 +45,7 @@ module RSpec
           @output.puts "      <div class=\"failure\" id=\"failure_#{failure_id}\">"
           if exception
             @output.puts "        <div class=\"message\"><pre>#{h(exception[:message])}</pre></div>"
-            if escape_backtrace
-              @output.puts "        <div class=\"backtrace\"><pre>#{h exception[:backtrace]}</pre></div>"
-            else
-              @output.puts "        <div class=\"backtrace\"><pre>#{exception[:backtrace]}</pre></div>"
-            end
+            @output.puts "        <div class=\"backtrace\"><pre>#{h exception[:backtrace]}</pre></div>"
           end
           @output.puts extra_content if extra_content
           @output.puts "      </div>"

--- a/lib/rspec/core/formatters/snippet_extractor.rb
+++ b/lib/rspec/core/formatters/snippet_extractor.rb
@@ -7,26 +7,30 @@ module RSpec
       # and applies synax highlighting and line numbers using html.
       class SnippetExtractor
         # @private
-        class NullConverter
-          def convert(code)
+        module NullConverter
+          def self.convert(code)
             %Q(#{code}\n<span class="comment"># Install the coderay gem to get syntax highlighting</span>)
           end
         end
 
         # @private
-        class CoderayConverter
-          def convert(code)
+        module CoderayConverter
+          def self.convert(code)
             CodeRay.scan(code, :ruby).html(:line_numbers => false)
           end
         end
 
+        # rubocop:disable Style/ClassVars
+        @@converter = NullConverter
         begin
           require 'coderay'
-          # rubocop:disable Style/ClassVars
-          @@converter = CoderayConverter.new
+          @@converter = CoderayConverter
+          # rubocop:disable Lint/HandleExceptions
         rescue LoadError
-          @@converter = NullConverter.new
+          # it'll fall back to the NullConverter assigned above
+          # rubocop:enable Lint/HandleExceptions
         end
+
         # rubocop:enable Style/ClassVars
 
         # @api private
@@ -43,6 +47,7 @@ module RSpec
           highlighted = @@converter.convert(raw_code)
           post_process(highlighted, line)
         end
+        # rubocop:enable Style/ClassVars
 
         # @api private
         #

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -394,10 +394,12 @@ EOS
           def hook_description
             "around hook at #{Metadata.relative_path(block.source_location.join(':'))}"
           end
-        else
+        else # for 1.8.7
+          # :nocov:
           def hook_description
             "around hook"
           end
+          # :nocov:
         end
       end
 
@@ -622,9 +624,11 @@ EOS
             @owner.parent_groups
           end
         else # Ruby < 2.1 (see https://bugs.ruby-lang.org/issues/8035)
+          # :nocov:
           def owner_parent_groups
             @owner_parent_groups ||= [@owner] + @owner.parent_groups
           end
+          # :nocov:
         end
       end
     end

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -443,6 +443,7 @@ EOS
         # Gets the named constant or yields.
         # On 1.8, const_defined? / const_get do not take into
         # account the inheritance hierarchy.
+        # :nocov:
         def self.get_constant_or_yield(example_group, name)
           if example_group.const_defined?(name)
             example_group.const_get(name)
@@ -450,6 +451,7 @@ EOS
             yield
           end
         end
+        # :nocov:
       else
         # @private
         #

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -100,12 +100,6 @@ module RSpec
       end
 
       # @private
-      def self.backtrace_from(block)
-        return caller unless block.respond_to?(:source_location)
-        [block.source_location.join(':')]
-      end
-
-      # @private
       def self.id_from(metadata)
         "#{metadata[:rerun_file_path]}[#{metadata[:scoped_id]}]"
       end

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -127,6 +127,7 @@ module RSpec
         end
 
         unless [].respond_to?(:each_with_object) # For 1.8.7
+          # :nocov:
           undef items_for
           def items_for(request_meta)
             @items_and_filters.inject([]) do |to_return, (item, item_meta)|
@@ -135,6 +136,7 @@ module RSpec
               to_return
             end
           end
+          # :nocov:
         end
       end
 
@@ -217,6 +219,7 @@ module RSpec
         end
 
         unless [].respond_to?(:each_with_object) # For 1.8.7
+          # :nocov:
           undef proc_keys_from
           def proc_keys_from(metadata)
             metadata.inject([]) do |to_return, (key, value)|
@@ -224,6 +227,7 @@ module RSpec
               to_return
             end
           end
+          # :nocov:
         end
       end
     end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -209,13 +209,15 @@ module RSpec::Core
         def encoded_string(string)
           RSpec::Support::EncodedString.new(string, Encoding.default_external)
         end
-      else
+      else # for 1.8.7
+        # :nocov:
         def encoding_of(_string)
         end
 
         def encoded_string(string)
           RSpec::Support::EncodedString.new(string)
         end
+        # :nocov:
       end
 
       def backtrace_formatter

--- a/lib/rspec/core/ordering.rb
+++ b/lib/rspec/core/ordering.rb
@@ -4,9 +4,11 @@ module RSpec
       # @private
       RandomNumberGenerator = ::Random
     else
+      # :nocov:
       RSpec::Support.require_rspec_core "backport_random"
       # @private
       RandomNumberGenerator = RSpec::Core::Backports::Random
+      # :nocov:
     end
 
     # @private
@@ -42,6 +44,7 @@ module RSpec
             list.shuffle(:random => rng)
           end
         else
+          # :nocov:
           def shuffle(list, rng)
             shuffled = list.dup
             shuffled.size.times do |i|
@@ -52,6 +55,7 @@ module RSpec
 
             shuffled
           end
+          # :nocov:
         end
       end
 

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -123,9 +123,11 @@ module RSpec
       end
 
       if RSpec::Support::OS.windows?
+        # :nocov:
         def escape(shell_command)
           "'#{shell_command.gsub("'", "\\\\'")}'"
         end
+        # :nocov:
       else
         require 'shellwords'
 

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -63,16 +63,12 @@ module RSpec
       # @private
       def run_task(verbose)
         command = spec_command
+        puts command if verbose
 
-        begin
-          puts command if verbose
-          success = system(command)
-        rescue
-          puts failure_message if failure_message
-        end
+        return if system(command)
+        puts failure_message if failure_message
 
-        return unless fail_on_error && !success
-
+        return unless fail_on_error
         $stderr.puts "#{command} failed" if verbose
         exit $?.exitstatus
       end

--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -195,10 +195,12 @@ module RSpec
         if Proc.method_defined?(:source_location)
           def ensure_block_has_source_location(_block); end
         else # for 1.8.7
+          # :nocov:
           def ensure_block_has_source_location(block)
             source_location = yield.split(':')
             block.extend Module.new { define_method(:source_location) { source_location } }
           end
+          # :nocov:
         end
       end
     end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -137,13 +137,7 @@ module RSpec
         example_groups.clear
         if filter_manager.empty?
           reporter.message("No examples found.")
-        elsif exclusion_filter.empty?
-          message = everything_filtered_message
-          if @configuration.run_all_when_everything_filtered?
-            message << "; ignoring #{inclusion_filter.description}"
-          end
-          reporter.message(message)
-        elsif inclusion_filter.empty?
+        elsif exclusion_filter.empty? || inclusion_filter.empty?
           reporter.message(everything_filtered_message)
         end
       end

--- a/script/rspec_with_simplecov
+++ b/script/rspec_with_simplecov
@@ -24,14 +24,14 @@ begin
   # Simplecov emits some ruby warnings when loaded, so silence them.
   old_verbose, $VERBOSE = $VERBOSE, false
 
-  unless ENV['NO_COVERAGE'] || RUBY_VERSION < '1.9.3'
+  unless ENV['NO_COVERAGE'] || RUBY_VERSION.to_f < 2.1
     require 'simplecov'
 
     SimpleCov.start do
       add_filter "./bundle/"
       add_filter "./tmp/"
       add_filter "./spec/"
-      minimum_coverage(RUBY_PLATFORM == 'java' ? 93 : 97)
+      minimum_coverage(100)
     end
   end
 rescue LoadError

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -206,6 +206,7 @@ module RSpec::Core
       end
 
       it "deals gracefully with a security error" do
+        Metadata.instance_eval { @relative_path_regex = nil }
         with_safe_set_to_level_that_triggers_security_errors do
           self.formatter.__send__(:backtrace_line, __FILE__)
           # on some rubies, this doesn't raise a SecurityError; this test just

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -206,7 +206,7 @@ module RSpec::Core
       end
 
       it "deals gracefully with a security error" do
-        safely do
+        with_safe_set_to_level_that_triggers_security_errors do
           self.formatter.__send__(:backtrace_line, __FILE__)
           # on some rubies, this doesn't raise a SecurityError; this test just
           # assures that if it *does* raise an error, the error is caught inside

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1341,6 +1341,20 @@ module RSpec::Core
       end
     end
 
+    describe "#backtrace_inclusion_patterns" do
+      before { config.backtrace_exclusion_patterns << /.*/ }
+
+      it 'can be assigned to' do
+        config.backtrace_inclusion_patterns = [/foo/]
+        expect(config.backtrace_formatter.exclude?("food")).to be false
+      end
+
+      it 'can be appended to' do
+        config.backtrace_inclusion_patterns << /foo/
+        expect(config.backtrace_formatter.exclude?("food")).to be false
+      end
+    end
+
     describe "#filter_gems_from_backtrace" do
       def exclude?(line)
         config.backtrace_formatter.exclude?(line)
@@ -1354,6 +1368,22 @@ module RSpec::Core
           config.filter_gems_from_backtrace "foo", "bar"
         }.to change { exclude?(line_1) }.from(false).to(true).
          and change { exclude?(line_2) }.from(false).to(true)
+      end
+    end
+
+    describe "#profile_examples" do
+      it "defaults to false" do
+        expect(config.profile_examples).to be false
+      end
+
+      it "can be set to an integer value" do
+        config.profile_examples = 17
+        expect(config.profile_examples).to eq(17)
+      end
+
+      it "returns 10 when set simply enabled" do
+        config.profile_examples = true
+        expect(config.profile_examples).to eq(10)
       end
     end
 

--- a/spec/rspec/core/drb_spec.rb
+++ b/spec/rspec/core/drb_spec.rb
@@ -82,6 +82,15 @@ RSpec.describe RSpec::Core::DRbRunner, :isolated_directory => true, :isolated_ho
       DRb::stop_service
     end
 
+    it "falls back to `druby://:0` when `druby://localhost:0` fails" do
+      # see https://bugs.ruby-lang.org/issues/496 for background
+      expect(::DRb).to receive(:start_service).with("druby://localhost:0").and_raise(SocketError)
+      expect(::DRb).to receive(:start_service).with("druby://:0").and_call_original
+
+      result = runner("--drb-port", @drb_port, passing_spec_filename).run(err, out)
+      expect(result).to be(0)
+    end
+
     it "returns 0 if spec passes" do
       result = runner("--drb-port", @drb_port, passing_spec_filename).run(err, out)
       expect(result).to be(0)

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1419,8 +1419,7 @@ module RSpec::Core
         let(:group) { RSpec.describe }
 
         before do
-          allow(RSpec.world).to receive(:wants_to_quit) { true }
-          allow(RSpec.world).to receive(:clear_remaining_example_groups)
+          RSpec.world.wants_to_quit = true
         end
 
         it "returns without starting the group" do
@@ -1430,16 +1429,19 @@ module RSpec::Core
 
         context "at top level" do
           it "purges remaining groups" do
-            expect(RSpec.world).to receive(:clear_remaining_example_groups)
-            self.group.run(reporter)
+            expect {
+              self.group.run(reporter)
+            }.to change { RSpec.world.example_groups }.from([self.group]).to([])
           end
         end
 
         context "in a nested group" do
           it "does not purge remaining groups" do
             nested_group = self.group.describe
-            expect(RSpec.world).not_to receive(:clear_remaining_example_groups)
-            nested_group.run(reporter)
+
+            expect {
+              nested_group.run(reporter)
+            }.not_to change { RSpec.world.example_groups }.from([self.group])
           end
         end
       end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
     expect { ignoring_warnings { pp example_instance }}.to output(/RSpec::Core::Example/).to_stdout
   end
 
+  describe "#rerun_argument" do
+    it "returns the location-based rerun argument" do
+      allow(RSpec.configuration).to receive_messages(:loaded_spec_files => [__FILE__])
+      example = RSpec.describe.example
+      expect(example.rerun_argument).to eq("#{RSpec::Core::Metadata.relative_path(__FILE__)}:#{__LINE__ - 1}")
+    end
+  end
+
   describe "#exception" do
     it "supplies the first exception raised, if any" do
       RSpec.configuration.output_stream = StringIO.new

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -13,7 +13,13 @@ require 'rspec/core/reporter'
 RSpec.describe RSpec::Core::Formatters::JsonFormatter do
   include FormatterSupport
 
-  it "outputs json (brittle high level functional test)" do
+  it "can be loaded via `--format json`" do
+    formatter_output = run_example_specs_with_formatter("json", false)
+    parsed = JSON.parse(formatter_output)
+    expect(parsed.keys).to include("examples", "summary", "summary_line")
+  end
+
+  it "outputs expected json (brittle high level functional test)" do
     group = RSpec.describe("one apiece") do
       it("succeeds") { expect(1).to eq 1 }
       it("fails") { fail "eek" }

--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -9,7 +9,7 @@ module RSpec
         end
 
         it "falls back on a default message when it doesn't find the file" do
-         expect(RSpec::Core::Formatters::SnippetExtractor.new.lines_around("blech", 8)).to eq("# Couldn't get snippet for blech")
+          expect(RSpec::Core::Formatters::SnippetExtractor.new.lines_around("blech", 8)).to eq("# Couldn't get snippet for blech")
         end
 
         it "falls back on a default message when it gets a security error" do
@@ -18,6 +18,31 @@ module RSpec
             message = RSpec::Core::Formatters::SnippetExtractor.new.lines_around("blech", 8)
           end
           expect(message).to eq("# Couldn't get snippet for blech")
+        end
+
+        describe "snippet extraction" do
+          let(:snippet) do
+            SnippetExtractor.new.snippet(["#{__FILE__}:#{__LINE__}"])
+          end
+
+          before do
+            # `send` is required for 1.8.7...
+            @orig_converter = SnippetExtractor.send(:class_variable_get, :@@converter)
+          end
+
+          after do
+            SnippetExtractor.send(:class_variable_set, :@@converter, @orig_converter)
+          end
+
+          it 'suggests you install coderay when it cannot be loaded' do
+            SnippetExtractor.send(:class_variable_set, :@@converter, SnippetExtractor::NullConverter)
+
+            expect(snippet).to include("Install the coderay gem")
+          end
+
+          it 'does not suggest installing coderay normally' do
+            expect(snippet).to exclude("Install the coderay gem")
+          end
         end
       end
     end

--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -14,7 +14,7 @@ module RSpec
 
         it "falls back on a default message when it gets a security error" do
           message = nil
-          safely do
+          with_safe_set_to_level_that_triggers_security_errors do
             message = RSpec::Core::Formatters::SnippetExtractor.new.lines_around("blech", 8)
           end
           expect(message).to eq("# Couldn't get snippet for blech")

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -15,6 +15,8 @@ module RSpec
         end
         # I have no idea what line = line.sub(/\A([^:]+:\d+)$/, '\\1') is supposed to do
         it "gracefully returns nil if run in a secure thread" do
+          # Ensure our call to `File.expand_path` is not cached as that is the insecure operation.
+          Metadata.instance_eval { @relative_path_regex = nil }
           with_safe_set_to_level_that_triggers_security_errors do
             value = Metadata.relative_path(".")
             # on some rubies, File.expand_path is not a security error, so accept "." as well

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -15,7 +15,7 @@ module RSpec
         end
         # I have no idea what line = line.sub(/\A([^:]+:\d+)$/, '\\1') is supposed to do
         it "gracefully returns nil if run in a secure thread" do
-          safely do
+          with_safe_set_to_level_that_triggers_security_errors do
             value = Metadata.relative_path(".")
             # on some rubies, File.expand_path is not a security error, so accept "." as well
             expect([nil, "."]).to include(value)

--- a/spec/rspec/core/notifications_spec.rb
+++ b/spec/rspec/core/notifications_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "FailedExampleNotification" do
       let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"]) }
 
       it "is handled gracefully" do
-        safely do
+        with_safe_set_to_level_that_triggers_security_errors do
           expect { notification.send(:read_failed_line) }.not_to raise_error
         end
       end

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -1,3 +1,5 @@
+require 'rspec/core/project_initializer'
+
 module RSpec::Core
   RSpec.describe OptionParser do
     before do
@@ -57,6 +59,33 @@ module RSpec::Core
       useless_lines = /^\s*--?\w+\s*$\n/
 
       expect { generate_help_text }.to_not output(useless_lines).to_stdout
+    end
+
+    %w[ -v --version ].each do |option|
+      describe option do
+        it "prints the version and exits" do
+          parser = Parser.new
+          expect(parser).to receive(:exit)
+
+          expect {
+            parser.parse([option])
+          }.to output("#{RSpec::Core::Version::STRING}\n").to_stdout
+        end
+      end
+    end
+
+    describe "--init" do
+      it "initializes a project and exits" do
+        project_init = instance_double(ProjectInitializer)
+        allow(ProjectInitializer).to receive_messages(:new => project_init)
+
+        parser = Parser.new
+
+        expect(project_init).to receive(:run).ordered
+        expect(parser).to receive(:exit).ordered
+
+        parser.parse(["--init"])
+      end
     end
 
     describe "-I" do

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -80,6 +80,23 @@ module RSpec::Core
       end
     end
 
+    context "when `failure_message` is configured" do
+      before do
+        allow(task).to receive(:exit)
+        task.failure_message = "Bad news"
+      end
+
+      it 'prints it if the RSpec run failed' do
+        task.ruby_opts = '-e "exit(1);" ;#'
+        expect { task.run_task false }.to output(/Bad news/).to_stdout
+      end
+
+      it 'does not print it if the RSpec run succeeded' do
+        task.ruby_opts = '-e "exit(0);" ;#'
+        expect { task.run_task false }.not_to output(/Bad/).to_stdout
+      end
+    end
+
     context 'with custom exit status' do
       def silence_output(&block)
         expect(&block).to output(anything).to_stdout.and output(anything).to_stderr

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -53,6 +53,7 @@ module RSpec
 
           it "is not exposed to the global namespace when monkey patching is disabled" do
             RSpec.configuration.expose_dsl_globally = false
+            expect(RSpec.configuration.expose_dsl_globally?).to eq(false)
             expect(Kernel).to_not respond_to(shared_method_name)
           end
 

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -237,6 +237,8 @@ RSpec.describe RSpec do
     expect(err).to eq("")
     expect(out.split("\n")).to eq(%w[ RSpec::Mocks RSpec::Expectations ])
     expect(status.exitstatus).to eq(0)
+
+    expect(RSpec.const_missing(:Expectations)).to be(RSpec::Expectations)
   end
 
   it 'correctly raises an error when an invalid const is referenced' do

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -1,5 +1,5 @@
 module FormatterSupport
-  def run_example_specs_with_formatter(formatter_option)
+  def run_example_specs_with_formatter(formatter_option, normalize_output=true)
     options = RSpec::Core::ConfigurationOptions.new(%W[spec/rspec/core/resources/formatter_specs.rb --format #{formatter_option} --order defined])
 
     err, out = StringIO.new, StringIO.new
@@ -13,6 +13,7 @@ module FormatterSupport
     runner.run(err, out)
 
     output = out.string
+    return output unless normalize_output
     output.gsub!(/\d+(?:\.\d+)?(s| seconds)/, "n.nnnn\\1")
 
     caller_line = RSpec::Core::Metadata.relative_path(caller.first)

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -11,7 +11,7 @@ module RSpecHelpers
     result
   end
 
-  def safely
+  def with_safe_set_to_level_that_triggers_security_errors
     Thread.new do
       ignoring_warnings { $SAFE = 3 }
       yield


### PR DESCRIPTION
I recently learned that `# :nocov:` can be used to tag a chunk of code so simplecov doesn't consider it.  Before learning that, I never bothered to try to get our coverage up because we have so many places where we do alternate method implementations for certain versions of ruby or for windows or whatever.  With `# :nocov:`, it's trivial to tag those so that we can actually meaningfully consider coverage.

I've [written a bit](http://myronmars.to/n/dev-blog/2012/05/in-defense-of-100-test-coverage) about my test coverage philosophy in the past.  Besides all the alternate method implementations, keeping coverage up for RSpec's actually not hard, and I think we get enough value out of it to enforce it.  I've seen a couple PRs from contributors where they added tests but because of how it was written it wasn't even executing the implementation it was intended to.  Enforcing coverage will cause our travis build to catch such things for us.

In this PR, I've gotten coverage up to 100% and configured simplecov to enforce it on our "main" builds (travis builds for MRI >= 2.0), and I've stopped loading simplecov for other builds.  The uncovered code generally fell into 3 categories:

* Dead code that can be deleted.  There was a fair bit of it.  Often it's private methods that aren't called but in some cases it was logically unreachable code and/or conditional code in a private method that would only be hit if a caller passed a certain arg that none of the callers pass.
* Code that's not for MRI >= 2.0.  I just tagged it with `# :nocov:`.
* Code that can and should be covered by a test.  In one case (ad53e7f8acd469e160a21121f23851183423ddfe), the act of trying to add coverage showed me that there was a long-standing bug.

Ideally, I'd like to see this same treatment done for expectations/mocks/support.  Anyone want to take that on?

/cc @rspec/rspec 