### PR TITLE
Assign example group constant earlier.

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -361,7 +361,6 @@ module RSpec
       def self.subclass(parent, description, args, &example_group_block)
         subclass = Class.new(parent)
         subclass.set_it_up(description, *args, &example_group_block)
-        ExampleGroups.assign_const(subclass)
         subclass.module_exec(&example_group_block) if example_group_block
 
         # The LetDefinitions module must be included _after_ other modules
@@ -392,6 +391,7 @@ module RSpec
           superclass.method(:next_runnable_index_for),
           description, *args, &example_group_block
         )
+        ExampleGroups.assign_const(self)
 
         hooks.register_globals(self, RSpec.configuration.hooks)
         RSpec.configuration.configure_group(self)

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -168,6 +168,16 @@ module RSpec::Core
         }.to raise_error(/ExampleGroups::CallingAnUndefinedMethod/)
       end
 
+      it "assigns the const before including shared contexts via metadata so error messages from eval'ing the context include the name" do
+        RSpec.shared_context("foo", :foo) { bar }
+
+        expect {
+          RSpec.describe("Including shared context via metadata", :foo)
+        }.to raise_error(NameError,
+          a_string_including('ExampleGroups::IncludingSharedContextViaMetadata', 'bar')
+        )
+      end
+
       it 'does not have problems with example groups named "Core"', :unless => RUBY_VERSION == '1.9.2' do
         RSpec.describe("Core")
         expect(defined?(::RSpec::ExampleGroups::Core)).to be_truthy


### PR DESCRIPTION
This ensures it is set as soon as possible, before
shared contexts included via metadata are evaluated,
so that if there’s an error, the example group class
name will be included in it.