### PR TITLE
Make `let` work properly when shared context is applied to a single example.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,8 @@ Bug Fixes:
 * Fix how the DSL methods are defined so that RSpec is compatible with
   gems that define methods of the same name on `Kernel` (such as
   the `its-it` gem). (Alex Kwiatkowski, Ryan Ong, #1907)
+* Make `let` work properly when defined in a shared context that is applied
+  to an individual example via metadata. (Myron Marston, #1912)
 
 ### 3.2.2 / 2015-03-11
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.2.1...v3.2.2)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1226,12 +1226,17 @@ module RSpec
       # Used internally to extend the singleton class of a single example's
       # example group instance with modules using `include` and/or `extend`.
       def configure_example(example)
+        singleton_group = example.example_group_instance.singleton_class
+
         # We replace the metadata so that SharedExampleGroupModule#included
         # has access to the example's metadata[:location].
-        example.example_group_instance.singleton_class.with_replaced_metadata(example.metadata) do
-          @include_modules.items_for(example.metadata).each do |mod|
+        singleton_group.with_replaced_metadata(example.metadata) do
+          modules = @include_modules.items_for(example.metadata)
+          modules.each do |mod|
             safe_include(mod, example.example_group_instance.singleton_class)
           end
+
+          MemoizedHelpers.define_helpers_on(singleton_group) unless modules.empty?
         end
       end
 

--- a/spec/rspec/core/shared_context_spec.rb
+++ b/spec/rspec/core/shared_context_spec.rb
@@ -66,6 +66,23 @@ RSpec.describe RSpec::SharedContext do
     expect(group.new.foo).to eq('foo')
   end
 
+  it "supports let when applied to an individual example via metadata" do
+    shared = Module.new do
+      extend RSpec::SharedContext
+      let(:foo) { "bar" }
+    end
+
+    RSpec.configuration.include shared, :include_it
+
+    ex = value = nil
+    RSpec.describe "group" do
+      ex = example("ex1", :include_it) { value = foo }
+    end.run
+
+    expect(ex.execution_result).to have_attributes(:status => :passed, :exception => nil)
+    expect(value).to eq("bar")
+  end
+
   it 'supports explicit subjects' do
     shared = Module.new do
       extend RSpec::SharedContext

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -134,6 +134,22 @@ module RSpec
               expect(non_matching_group).not_to respond_to(:bar)
             end
 
+            describe "when it has a `let` and applies to an individual example via metadata" do
+              it 'defines the `let` method correctly' do
+                define_shared_group("name", :include_it) do
+                  let(:foo) { "bar" }
+                end
+
+                ex = value = nil
+                RSpec.describe "group" do
+                  ex = example("ex1", :include_it) { value = foo }
+                end.run
+
+                expect(ex.execution_result).to have_attributes(:status => :passed, :exception => nil)
+                expect(value).to eq("bar")
+              end
+            end
+
             describe "hooks for individual examples that have matching metadata" do
               before do
                 skip "These specs pass in 2.0 mode on JRuby 1.7.8 but fail on " \


### PR DESCRIPTION
Without this fix, it fails with an error like:

```
#<NoMethodError: super: no superclass method `foo' for #<RSpec::ExampleGroups::Group_24:0x007f9dbd8e55a0>>
```