### PR TITLE
Revert "Warn users when overriding methods (via let, def or define_method) in the same example group."

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,8 +24,6 @@ Enhancements:
 * Add `--next-failure` CLI option which allows you to repeatedly focus
   on just one of the currently failing examples, then move on to the
   next failure, etc. (Myron Marston, #1888)
-* Warn when a helper method definition stomps an earlier definition
-  in the same example group. (Fabio Napoleoni, #1903)
 * Make `--order random` ordering stable, so that when you rerun a
   subset with a given seed, the examples will be order consistently
   relative to each other. (Myron Marston, #1908)

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -2,8 +2,6 @@ RSpec::Support.require_rspec_support 'recursive_const_methods'
 
 module RSpec
   module Core
-    # rubocop:disable Style/ClassLength
-
     # ExampleGroup and {Example} are the main structural elements of
     # rspec-core. Consider this example:
     #
@@ -658,16 +656,6 @@ module RSpec
       end
       private_class_method :method_missing
 
-      # @private
-      def self.method_added(method_name)
-        if (@__added_methods ||= Set.new).include?(method_name)
-          RSpec.warning "`#{self}##{method_name}` is being redefined " \
-                         "at #{RSpec::CallerFilter.first_non_rspec_line}. The original " \
-                         "definition will never be used and can be removed", :call_site => nil
-        end
-        @__added_methods << method_name
-      end
-
     private
 
       def method_missing(name, *args)
@@ -682,8 +670,6 @@ module RSpec
         super
       end
     end
-
-    # rubocop:enable Style/ClassLength
 
     # @private
     # Unnamed example group used by `SuiteHookContext`.

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1306,59 +1306,6 @@ module RSpec::Core
 
     end
 
-    describe "when methods are redefined" do
-
-      context "in the same example group" do
-
-        it 'emits a warning when overriding methods using `let`' do
-          expect {
-            RSpec.describe do
-              let(:foo) { 'first value' }
-              let(:foo) { 'second value' }
-            end
-          }.to output(a_string_including("#foo", "is being redefined at #{__FILE__}:#{__LINE__ - 2}")).to_stderr
-        end
-
-        it 'emits a warning when overriding methods using `def`' do
-          expect {
-            RSpec.describe do
-              let(:foo) { 'first value' }
-              def foo; 'second value'; end
-            end
-          }.to output(a_string_including("#foo", "is being redefined at #{__FILE__}:#{__LINE__ - 2}")).to_stderr
-        end
-
-        it 'emits a warning when overriding methods using `define_method`' do
-          expect {
-            RSpec.describe do
-              let(:foo) { 'first value' }
-              define_method(:foo) { 'second value' }
-            end
-          }.to output(a_string_including("#foo", "is being redefined at #{__FILE__}:#{__LINE__ - 2}")).to_stderr
-        end
-
-      end
-
-      context "in nested example groups" do
-
-        it 'does not emit warnings' do
-          expect {
-            RSpec.describe do
-              let(:foo) { 'first value' }
-              context 'in sub context' do
-                let(:foo) { 'second value' }
-                context 'in sub sub context' do
-                  def foo; 'third value'; end
-                end
-              end
-            end
-          }.to avoid_outputting.to_stdout.and avoid_outputting.to_stderr
-        end
-
-      end
-
-    end
-
     describe "ivars are not shared across examples" do
       it "(first example)" do
         @a = 1


### PR DESCRIPTION
This reverts the lib and spec pieces of e072e5358b85a971010bc1a22d04eeca646321c8.

The warning is overzealous. After upgrading a project to RSpec HEAD, I
got spammed with tons of warnings of situations that weren't actually
problematic.  For example, it's common to define a `let` in a shared
context that provides a default value, and than to purposefully override
that in a host group where the shared context is included. We shouldn't
warn in such a situation, but this did warn.

See #1903 for the original code this reverts.

/cc @fabn