### PR TITLE
Tweak a few things about the threadsafe let solution from #1858.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@ Enhancements:
   relative to each other. (Myron Marston, #1908)
 * Set example group constant earlier so errors when evaluating the context
   include the example group name (Myron Marson, #1911)
+* Make `let` and `subject` threadsafe. (Josh Cheek, #1858)
 
 Bug Fixes:
 

--- a/lib/rspec/core/mutex.rb
+++ b/lib/rspec/core/mutex.rb
@@ -1,0 +1,63 @@
+module RSpec
+  module Core
+    # On 1.8.7, it's in the stdlib.
+    # We don't want to load the stdlib, b/c this is a test tool, and can affect the test environment,
+    # causing tests to pass where they should fail.
+    #
+    # So we're transcribing/modifying it from https://github.com/ruby/ruby/blob/v1_8_7_374/lib/thread.rb#L56
+    # Some methods we don't need are deleted.
+    # Anything I don't understand (there's quite a bit, actually) is left in.
+    # Some formating changes are made to appease the robot overlord:
+    #   https://travis-ci.org/rspec/rspec-core/jobs/54410874
+    # @private
+    class Mutex
+      def initialize
+        @waiting = []
+        @locked = false
+        @waiting.taint
+        taint
+      end
+
+      # @private
+      def lock
+        while Thread.critical = true && @locked
+          @waiting.push Thread.current
+          Thread.stop
+        end
+        @locked = true
+        Thread.critical = false
+        self
+      end
+
+      # @private
+      def unlock
+        return unless @locked
+        Thread.critical = true
+        @locked = false
+        begin
+          t = @waiting.shift
+          t.wakeup if t
+        rescue ThreadError
+          retry
+        end
+        Thread.critical = false
+        begin
+          t.run if t
+        rescue ThreadError
+          :noop
+        end
+        self
+      end
+
+      # @private
+      def synchronize
+        lock
+        begin
+          yield
+        ensure
+          unlock
+        end
+      end
+    end unless defined?(::RSpec::Core::Mutex) # Avoid warnings for library wide checks spec
+  end
+end

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -115,10 +115,6 @@ module RSpec::Core
           options[:color] = o
         end
 
-        parser.on('--[no-]threadsafe', 'Turn on threadsafety where available') do |o|
-          options[:threadsafe] = o
-        end
-
         parser.on('-p', '--[no-]profile [COUNT]',
                   'Enable profiling of examples and list the slowest examples (default: 10).') do |argument|
           options[:profile_examples] = if argument.nil?

--- a/lib/rspec/core/reentrant_mutex.rb
+++ b/lib/rspec/core/reentrant_mutex.rb
@@ -14,7 +14,7 @@ module RSpec
       def initialize
         @owner = nil
         @count = 0
-        @mutex = MUTEX.new
+        @mutex = Mutex.new
       end
 
       def synchronize
@@ -40,68 +40,13 @@ module RSpec
       end
     end
 
-    # @private
-    # :nocov:
-    # This can be deleted once support for 1.8.7 is dropped
-    MUTEX = if defined? ::Mutex
-              # On 1.9 and up, this is in core, so we just use the real one
-              ::Mutex
-            else
-              # On 1.8.7, it's in the stdlib.
-              # We don't want to load the stdlib, b/c this is a test tool, and can affect the test environment,
-              # causing tests to pass where they should fail.
-              #
-              # So we're transcribing/modifying it from https://github.com/ruby/ruby/blob/v1_8_7_374/lib/thread.rb#L56
-              # Some methods we don't need are deleted.
-              # Anything I don't understand (there's quite a bit, actually) is left in.
-              # Some formating changes are made to appease the robot overlord:
-              #   https://travis-ci.org/rspec/rspec-core/jobs/54410874
-              Class.new do
-                def initialize
-                  @waiting = []
-                  @locked = false
-                  @waiting.taint
-                  taint
-                end
-
-                def lock
-                  while Thread.critical = true && @locked
-                    @waiting.push Thread.current
-                    Thread.stop
-                  end
-                  @locked = true
-                  Thread.critical = false
-                  self
-                end
-
-                def unlock
-                  return unless @locked
-                  Thread.critical = true
-                  @locked = false
-                  begin
-                    t = @waiting.shift
-                    t.wakeup if t
-                  rescue ThreadError
-                    retry
-                  end
-                  Thread.critical = false
-                  begin
-                    t.run if t
-                  rescue ThreadError
-                    :noop
-                  end
-                  self
-                end
-
-                def synchronize
-                  lock
-                  begin
-                    yield
-                  ensure
-                    unlock
-                  end
-                end
-              end
-            end
+    if defined? ::Mutex
+      # On 1.9 and up, this is in core, so we just use the real one
+      Mutex = ::Mutex
+    else # For 1.8.7
+      # :nocov:
+      RSpec::Support.require_rspec_core "mutex"
+      # :nocov:
+    end
   end
 end

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -211,18 +211,6 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
     end
   end
 
-  describe '--threadsafe', :threadsafe => true do
-    it 'sets :threadsafe => true' do
-      expect(parse_options('--threadsafe')).to include(:threadsafe => true)
-    end
-  end
-
-  describe '--no-threadsafe', :threadsafe => true do
-    it 'sets :threadsafe => false' do
-      expect(parse_options('--no-threadsafe')).to include(:threadsafe => false)
-    end
-  end
-
   describe "-I" do
     example "adds to :libs" do
       expect(parse_options('-I', 'a_dir')).to include(:libs => ['a_dir'])


### PR DESCRIPTION
1). Remove `--threadsafe` CLI option.

In general, we don't expose every config option via the CLI.
We want to make it easy for users to run `rspec --help` and
find the options that they are commonly going to want to customize
for a particular CLI run. I don't think `--threadsafe` is one of
those -- it's more something that'll be turned off globally for the
project or not touched at all, and as such, it adds noise to
the `--help` output to include it.

2). Extract Mutex class into its own file.

- Remove need for use of `MUTEX` over `Mutex`.
- No reason to force Ruby to parse the code
  for 1.8.7 Mutex implementation on other Rubies.

3). Remove threadsafe scenario.

A note about threadsafey is sufficient for the docs. Having
a full threadsafety example spec in the scenario is more
detail than users are likely to want to read.

/cc @JoshCheek 