### PR TITLE
Fixing the default behaviour of `expose_dsl_globally`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -44,6 +44,7 @@ Bug Fixes:
   when the task failed. (Myron Marston, #1905)
 * Make `let` work properly when defined in a shared context that is applied
   to an individual example via metadata. (Myron Marston, #1912)
+* Ensure `rspec/autorun` respects configuration defaults. (Jon Rowe, #1933)
 
 ### 3.2.3 / 2015-04-06
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.2.2...v3.2.3)

--- a/features/configuration/enable_global_dsl.feature
+++ b/features/configuration/enable_global_dsl.feature
@@ -24,10 +24,11 @@ Feature: Global namespace DSL
 
   For backwards compatibility it defaults to `true`.
 
+  @allow-should-syntax
   Scenario: By default RSpec allows the DSL to be used globally
     Given a file named "spec/example_spec.rb" with:
       """ruby
-      RSpec.describe "specs here" do
+      describe "specs here" do
         it "passes" do
         end
       end

--- a/features/configuration/enable_global_dsl.feature
+++ b/features/configuration/enable_global_dsl.feature
@@ -36,6 +36,19 @@ Feature: Global namespace DSL
    When I run `rspec`
    Then the output should contain "1 example, 0 failures"
 
+  @allow-should-syntax
+  Scenario: By default rspec/autorun allows the DSL to be used globally
+    Given a file named "spec/example_spec.rb" with:
+      """ruby
+      require 'rspec/autorun'
+      describe "specs here" do
+        it "passes" do
+        end
+      end
+      """
+   When I run `ruby spec/example_spec.rb`
+   Then the output should contain "1 example, 0 failures"
+
   Scenario: When exposing globally is disabled the top level DSL no longer works
     Given a file named "spec/example_spec.rb" with:
       """ruby

--- a/lib/rspec/autorun.rb
+++ b/lib/rspec/autorun.rb
@@ -1,2 +1,3 @@
 require 'rspec/core'
+# Ensure the default config is loaded
 RSpec::Core::Runner.autorun

--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -81,12 +81,9 @@ module RSpec
   # @see RSpec.configure
   # @see Core::Configuration
   def self.configuration
-    @configuration ||= begin
-                         config = RSpec::Core::Configuration.new
-                         config.expose_dsl_globally = true
-                         config
-                       end
+    @configuration ||= RSpec::Core::Configuration.new
   end
+  configuration.expose_dsl_globally = true
 
   # Yields the global configuration to a block.
   # @yield [Configuration] global configuration


### PR DESCRIPTION
I'm going to tackle #1931 but in doing so I came across a cucumber scenario I believe is broken (the scenario doesn't describe what it does, and changing the scenario to match the description results in a failure) ping @myronmarston 