### PR TITLE
Apply helper modules to existing groups when added

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1134,6 +1134,7 @@ module RSpec
       def include(mod, *filters)
         meta = Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
         @include_modules.append(mod, meta)
+        configure_existing_groups(mod, meta, :safe_include)
       end
 
       # Tells RSpec to extend example groups with `mod`. Methods defined in
@@ -1169,6 +1170,7 @@ module RSpec
       def extend(mod, *filters)
         meta = Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
         @extend_modules.append(mod, meta)
+        configure_existing_groups(mod, meta, :safe_extend)
       end
 
       if RSpec::Support::RubyFeatures.module_prepends_supported?
@@ -1207,6 +1209,7 @@ module RSpec
         def prepend(mod, *filters)
           meta = Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
           @prepend_modules.append(mod, meta)
+          configure_existing_groups(mod, meta, :safe_prepend)
         end
       end
 
@@ -1223,6 +1226,14 @@ module RSpec
       # @private
       def configure_group_with(group, module_list, application_method)
         module_list.items_for(group.metadata).each do |mod|
+          __send__(application_method, mod, group)
+        end
+      end
+
+      # @private
+      def configure_existing_groups(mod, meta, application_method)
+        RSpec.world.all_example_groups.each do |group|
+          next unless meta.empty? || MetadataFilter.apply?(:any?, meta, group.metadata)
           __send__(application_method, mod, group)
         end
       end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -78,9 +78,13 @@ module RSpec
       end
 
       # @private
+      def all_example_groups
+        FlatMap.flat_map(example_groups) { |g| g.descendants }
+      end
+
+      # @private
       def all_examples
-        flattened_groups = FlatMap.flat_map(example_groups) { |g| g.descendants }
-        FlatMap.flat_map(flattened_groups) { |g| g.examples }
+        FlatMap.flat_map(all_example_groups) { |g| g.examples }
       end
 
       # @api private

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -879,6 +879,17 @@ module RSpec::Core
           expect(group).not_to respond_to(:you_call_this_a_blt?)
           expect(group.new.you_call_this_a_blt?).to eq("egad man, where's the mayo?!?!?")
         end
+
+        it "includes the given module into each existing example group" do
+          group = RSpec.describe('does like, stuff and junk', :magic_key => :include) { }
+
+          RSpec.configure do |c|
+            c.include(InstanceLevelMethods)
+          end
+
+          expect(group).not_to respond_to(:you_call_this_a_blt?)
+          expect(group.new.you_call_this_a_blt?).to eq("egad man, where's the mayo?!?!?")
+        end
       end
 
       context "with a filter" do
@@ -888,6 +899,17 @@ module RSpec::Core
           end
 
           group = RSpec.describe('does like, stuff and junk', :magic_key => :include) { }
+          expect(group).not_to respond_to(:you_call_this_a_blt?)
+          expect(group.new.you_call_this_a_blt?).to eq("egad man, where's the mayo?!?!?")
+        end
+
+        it "includes the given module into each existing matching example group" do
+          group = RSpec.describe('does like, stuff and junk', :magic_key => :include) { }
+
+          RSpec.configure do |c|
+            c.include(InstanceLevelMethods, :magic_key => :include)
+          end
+
           expect(group).not_to respond_to(:you_call_this_a_blt?)
           expect(group.new.you_call_this_a_blt?).to eq("egad man, where's the mayo?!?!?")
         end
@@ -981,6 +1003,15 @@ module RSpec::Core
         expect(group).to respond_to(:that_thing)
       end
 
+      it "extends the given module into each existing matching example group" do
+        group = RSpec.describe(ThatThingISentYou, :magic_key => :extend) { }
+
+        RSpec.configure do |c|
+          c.extend(ThatThingISentYou, :magic_key => :extend)
+        end
+
+        expect(group).to respond_to(:that_thing)
+      end
     end
 
     describe "#prepend", :if => RSpec::Support::RubyFeatures.module_prepends_supported? do
@@ -1008,6 +1039,16 @@ module RSpec::Core
           group = RSpec.describe('yo') { }
           expect(group.new.foo).to eq("foobar")
         end
+
+        it "prepends the given module into each existing example group" do
+          group = RSpec.describe('yo') { }
+
+          RSpec.configure do |c|
+            c.prepend(SomeRandomMod)
+          end
+
+          expect(group.new.foo).to eq("foobar")
+        end
       end
 
       context "with a filter" do
@@ -1017,6 +1058,16 @@ module RSpec::Core
           end
 
           group = RSpec.describe('yo', :magic_key => :include) { }
+          expect(group.new.foo).to eq("foobar")
+        end
+
+        it "prepends the given module into each existing matching example group" do
+          group = RSpec.describe('yo', :magic_key => :include) { }
+
+          RSpec.configure do |c|
+            c.prepend(SomeRandomMod, :magic_key => :include)
+          end
+
           expect(group.new.foo).to eq("foobar")
         end
       end

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -23,6 +23,27 @@ module RSpec::Core
       end
     end
 
+    describe "#all_example_groups" do
+      it "contains all example groups from all levels of nesting" do
+        RSpec.describe "eg1" do
+          context "eg2" do
+            context "eg3"
+            context "eg4"
+          end
+
+          context "eg5"
+        end
+
+        RSpec.describe "eg6" do
+          example
+        end
+
+        expect(RSpec.world.all_example_groups.map(&:description)).to match_array(%w[
+          eg1 eg2 eg3 eg4 eg5 eg6
+        ])
+      end
+    end
+
     describe "#all_examples" do
       it "contains all examples from all levels of nesting" do
         RSpec.describe do


### PR DESCRIPTION
Fixes #1934.

When a helper module is configured, it is now applied to all existing matching example groups. This means that the order in which example groups are defined and helper modules are configured no longer matters.

I changed the behaviour across `include`, `extend` and `pending` here for consistency, even though only `include` was affected by the singleton example group bug.