### PR TITLE
Tell users where the invalid options came from.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -36,6 +36,9 @@ Enhancements:
   (Myron Marston, #1917)
 * For `config.include`, `config.extend` and `config.prepend`, apply the
   module to previously defined matching example groups. (Eugene Kenny, #1935)
+* When invalid options are parsed, notify users where they came from
+  (e.g. `.rspec` or `~/.rspec` or `ENV['SPEC_OPTS']`) so they can
+  easily find the source of the problem. (Myron Marston, #1940)
 
 Bug Fixes:
 

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -120,7 +120,11 @@ module RSpec
 
       def env_options
         return {} unless ENV['SPEC_OPTS']
-        parse_args_ignoring_files_or_dirs_to_run(Shellwords.split(ENV["SPEC_OPTS"]))
+
+        parse_args_ignoring_files_or_dirs_to_run(
+          Shellwords.split(ENV["SPEC_OPTS"]),
+          "ENV['SPEC_OPTS']"
+        )
       end
 
       def command_line_options
@@ -144,11 +148,12 @@ module RSpec
       end
 
       def options_from(path)
-        parse_args_ignoring_files_or_dirs_to_run(args_from_options_file(path))
+        args = args_from_options_file(path)
+        parse_args_ignoring_files_or_dirs_to_run(args, path)
       end
 
-      def parse_args_ignoring_files_or_dirs_to_run(args)
-        options = Parser.parse(args)
+      def parse_args_ignoring_files_or_dirs_to_run(args, source)
+        options = Parser.parse(args, source)
         options.delete(:files_or_directories_to_run)
         options
       end
@@ -168,11 +173,11 @@ module RSpec
       end
 
       def project_options_file
-        ".rspec"
+        "./.rspec"
       end
 
       def local_options_file
-        ".rspec-local"
+        "./.rspec-local"
       end
 
       def global_options_file

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -4,8 +4,8 @@ require 'optparse'
 module RSpec::Core
   # @private
   class Parser
-    def self.parse(args)
-      new(args).parse
+    def self.parse(args, source=nil)
+      new(args).parse(source)
     end
 
     attr_reader :original_args
@@ -14,7 +14,7 @@ module RSpec::Core
       @original_args = original_args
     end
 
-    def parse
+    def parse(source=nil)
       return { :files_or_directories_to_run => [] } if original_args.empty?
       args = original_args.dup
 
@@ -22,7 +22,9 @@ module RSpec::Core
       begin
         parser(options).parse!(args)
       rescue OptionParser::InvalidOption => e
-        abort "#{e.message}\n\nPlease use --help for a listing of valid options"
+        failure = e.message
+        failure << " (defined in #{source})" if source
+        abort "#{failure}\n\nPlease use --help for a listing of valid options"
       end
 
       options[:files_or_directories_to_run] = args


### PR DESCRIPTION
Addresses the confusion reported in rspec/rspec-rails#1356.