### PR TITLE
`--only-failures` takes precedence over `run_all_when_everything_filtered`

### DIFF
--- a/features/command_line/only_failures.feature
+++ b/features/command_line/only_failures.feature
@@ -11,6 +11,7 @@ Feature: Only Failures
       """ruby
       RSpec.configure do |c|
         c.example_status_persistence_file_path = "examples.txt"
+        c.run_all_when_everything_filtered = true
       end
       """
     And a file named ".rspec" with:
@@ -102,6 +103,10 @@ Feature: Only Failures
 
     When I run `rspec --next-failure`
     Then the output should contain "All examples were filtered out"
+
+  Scenario: Running `rspec --only-failures` with spec files that pass doesn't run anything
+    When I run `rspec spec/passing_spec.rb --only-failures`
+    Then it should pass with "0 examples, 0 failures"
 
   Scenario: Clear error given when using `--only-failures` without configuring `example_status_persistence_file_path`
     Given I have not configured `example_status_persistence_file_path`

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -28,6 +28,11 @@ Then /^the example(?:s)? should(?: all)? pass$/ do
   step %q{the exit status should be 0}
 end
 
+Then /^it should pass with "(.*?)"$/ do |string|
+  step %Q{the output should contain "#{string}"}
+  step %q{the exit status should be 0}
+end
+
 Then /^the example(?:s)? should(?: all)? fail$/ do
   step %q{the output should not contain "0 examples"}
   step %q{the output should not contain "0 failures"}

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -119,7 +119,7 @@ module RSpec
           end
         end
 
-        if @configuration.run_all_when_everything_filtered? && example_count.zero?
+        if @configuration.run_all_when_everything_filtered? && example_count.zero? && !@configuration.only_failures?
           reporter.message("#{everything_filtered_message}; ignoring #{inclusion_filter.description}")
           filtered_examples.clear
           inclusion_filter.clear

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -136,6 +136,19 @@ module RSpec::Core
       context "when --only-failures is passed" do
         before { configuration.force(:only_failures => true) }
 
+        context "and all examples are filtered out" do
+          before do
+            configuration.filter_run_including :foo => 'bar'
+          end
+
+          it 'will ignore run_all_when_everything_filtered' do
+            configuration.run_all_when_everything_filtered = true
+            expect(world.filtered_examples).to_not receive(:clear)
+            expect(world.inclusion_filter).to_not receive(:clear)
+            world.announce_filters
+          end
+        end
+
         context "and `example_status_persistence_file_path` is not configured" do
           it 'aborts with a message explaining the config option must be set first' do
             configuration.example_status_persistence_file_path = nil


### PR DESCRIPTION
This is a solution to #1941 makes `--only-failures` takes precedence over `run_all_when_everything_filtered` and exit correctly when there are no failures