### PR TITLE
Aggregate failures Integration

### DIFF
--- a/.jrubyrc
+++ b/.jrubyrc
@@ -1,0 +1,5 @@
+# Remove `.java` lines from JRuby stacktraces. Necessary for a passing travis build
+# on JRuby in 1.8 mode for the new failure aggregator specs. Our generated test
+# fixture doesn't know how to deal with excess java lines so it's best to ignore
+# those lines.
+backtrace.mask=true

--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,8 @@ Enhancements:
   (e.g. `.rspec` or `~/.rspec` or `ENV['SPEC_OPTS']`) so they can
   easily find the source of the problem. (Myron Marston, #1940)
 * Add pending message contents to the json formatter output. (Jon Rowe, #1949)
+* Add shared group backtrace to the output displayed by the built-in
+  formatters for pending examples that have been fixed. (Myron Marston, #1946)
 
 Bug Fixes:
 

--- a/features/.nav
+++ b/features/.nav
@@ -46,6 +46,7 @@
   - default_path.feature
 - expectation_framework_integration:
   - configure_expectation_framework.feature
+  - failure_aggregation.feature
 - mock_framework_integration:
   - use_rspec.feature
   - use_flexmock.feature

--- a/features/expectation_framework_integration/aggregating_failures.feature
+++ b/features/expectation_framework_integration/aggregating_failures.feature
@@ -1,0 +1,173 @@
+Feature: Aggregating Failures
+
+  RSpec::Expectations provides [`aggregate_failures`](../../../rspec-expectations/docs/aggregating-failures), an API that allows you to group a set of expectations and see all the failures at once, rather than it aborting on the first failure. RSpec::Core improves on this feature in a couple of ways:
+
+    * RSpec::Core provides much better failure output, adding code snippets and backtraces to the sub-failures, just like it does for any normal failure.
+    * RSpec::Core provides [metadata](../metadata/user-defined-metadata) integration for this feature. Each example that is tagged with `:aggregate_failures` will be wrapped in an `aggregate_failures` block. You can also use `config.define_derived_metadata` to apply this to every example automatically.
+
+  The metadata form is quite convenient, but may not work well for end-to-end tests that have multiple distinct steps. For example, consider a spec for an HTTP client workflow that (1) makes a request, (2) expects a redirect, (3) follows the redirect, and (4) expects a particular response.  You probably want the `expect(response.status).to be_between(300, 399)` expectation to immediately abort if it fails, because you can't perform the next step (following the redirect) if that is not satisfied. For these situations, we encourage you to use the `aggregate_failures` block form to wrap each set of expectations that represents a distinct step in the test workflow.
+
+  Background:
+    Given a file named "lib/client.rb" with:
+      """ruby
+      Response = Struct.new(:status, :headers, :body)
+
+      class Client
+        def self.make_request
+          Response.new(404, { "Content-Type" => "text/plain" }, "Not Found")
+        end
+      end
+      """
+
+  Scenario: Use `aggregate_failures` block form
+    Given a file named "spec/use_block_form_spec.rb" with:
+      """ruby
+      require 'client'
+
+      RSpec.describe Client do
+        it "returns a successful response" do
+          response = Client.make_request
+
+          aggregate_failures "testing reponse" do
+            expect(response.status).to eq(200)
+            expect(response.headers).to include("Content-Type" => "application/json")
+            expect(response.body).to eq('{"message":"Success"}')
+          end
+        end
+      end
+      """
+    When I run `rspec spec/use_block_form_spec.rb`
+    Then it should fail listing all the failures:
+      """
+      Failures:
+
+        1) Client returns a successful response
+           Got 3 failures from failure aggregation block "testing reponse".
+           # ./spec/use_block_form_spec.rb:7:in `block (2 levels) in <top (required)>'
+
+           1.1) Failure/Error: expect(response.status).to eq(200)
+
+                  expected: 200
+                       got: 404
+
+                  (compared using ==)
+                # ./spec/use_block_form_spec.rb:8:in `block (3 levels) in <top (required)>'
+
+           1.2) Failure/Error: expect(response.headers).to include("Content-Type" => "application/json")
+                  expected {"Content-Type" => "text/plain"} to include {"Content-Type" => "application/json"}
+                  Diff:
+                  @@ -1,2 +1,2 @@
+                  -[{"Content-Type"=>"application/json"}]
+                  +"Content-Type" => "text/plain",
+                # ./spec/use_block_form_spec.rb:9:in `block (3 levels) in <top (required)>'
+
+           1.3) Failure/Error: expect(response.body).to eq('{"message":"Success"}')
+
+                  expected: "{\"message\":\"Success\"}"
+                       got: "Not Found"
+
+                  (compared using ==)
+                # ./spec/use_block_form_spec.rb:10:in `block (3 levels) in <top (required)>'
+      """
+
+  Scenario: Use `:aggregate_failures` metadata
+    Given a file named "spec/use_metadata_spec.rb" with:
+      """ruby
+      require 'client'
+
+      RSpec.describe Client do
+        it "returns a successful response", :aggregate_failures do
+          response = Client.make_request
+
+          expect(response.status).to eq(200)
+          expect(response.headers).to include("Content-Type" => "application/json")
+          expect(response.body).to eq('{"message":"Success"}')
+        end
+      end
+      """
+    When I run `rspec spec/use_metadata_spec.rb`
+    Then it should fail listing all the failures:
+      """
+      Failures:
+
+        1) Client returns a successful response
+           Got 3 failures:
+
+           1.1) Failure/Error: expect(response.status).to eq(200)
+
+                  expected: 200
+                       got: 404
+
+                  (compared using ==)
+                # ./spec/use_metadata_spec.rb:7:in `block (2 levels) in <top (required)>'
+
+           1.2) Failure/Error: expect(response.headers).to include("Content-Type" => "application/json")
+                  expected {"Content-Type" => "text/plain"} to include {"Content-Type" => "application/json"}
+                  Diff:
+                  @@ -1,2 +1,2 @@
+                  -[{"Content-Type"=>"application/json"}]
+                  +"Content-Type" => "text/plain",
+                # ./spec/use_metadata_spec.rb:8:in `block (2 levels) in <top (required)>'
+
+           1.3) Failure/Error: expect(response.body).to eq('{"message":"Success"}')
+
+                  expected: "{\"message\":\"Success\"}"
+                       got: "Not Found"
+
+                  (compared using ==)
+                # ./spec/use_metadata_spec.rb:9:in `block (2 levels) in <top (required)>'
+      """
+
+  Scenario: Enable failure aggregation globally using `define_derived_metadata`
+    Given a file named "spec/enable_globally_spec.rb" with:
+      """ruby
+      require 'client'
+
+      RSpec.configure do |c|
+        c.define_derived_metadata do |meta|
+          meta[:aggregate_failures] = true
+        end
+      end
+
+      RSpec.describe Client do
+        it "returns a successful response" do
+          response = Client.make_request
+
+          expect(response.status).to eq(200)
+          expect(response.headers).to include("Content-Type" => "application/json")
+          expect(response.body).to eq('{"message":"Success"}')
+        end
+      end
+      """
+    When I run `rspec spec/enable_globally_spec.rb`
+    Then it should fail listing all the failures:
+      """
+      Failures:
+
+        1) Client returns a successful response
+           Got 3 failures:
+
+           1.1) Failure/Error: expect(response.status).to eq(200)
+
+                  expected: 200
+                       got: 404
+
+                  (compared using ==)
+                # ./spec/enable_globally_spec.rb:13:in `block (2 levels) in <top (required)>'
+
+           1.2) Failure/Error: expect(response.headers).to include("Content-Type" => "application/json")
+                  expected {"Content-Type" => "text/plain"} to include {"Content-Type" => "application/json"}
+                  Diff:
+                  @@ -1,2 +1,2 @@
+                  -[{"Content-Type"=>"application/json"}]
+                  +"Content-Type" => "text/plain",
+                # ./spec/enable_globally_spec.rb:14:in `block (2 levels) in <top (required)>'
+
+           1.3) Failure/Error: expect(response.body).to eq('{"message":"Success"}')
+
+                  expected: "{\"message\":\"Success\"}"
+                       got: "Not Found"
+
+                  (compared using ==)
+                # ./spec/enable_globally_spec.rb:15:in `block (2 levels) in <top (required)>'
+      """

--- a/features/expectation_framework_integration/aggregating_failures.feature
+++ b/features/expectation_framework_integration/aggregating_failures.feature
@@ -37,7 +37,7 @@ Feature: Aggregating Failures
       end
       """
     When I run `rspec spec/use_block_form_spec.rb`
-    Then it should fail listing all the failures:
+    Then it should fail and list all the failures:
       """
       Failures:
 
@@ -86,7 +86,7 @@ Feature: Aggregating Failures
       end
       """
     When I run `rspec spec/use_metadata_spec.rb`
-    Then it should fail listing all the failures:
+    Then it should fail and list all the failures:
       """
       Failures:
 
@@ -140,7 +140,7 @@ Feature: Aggregating Failures
       end
       """
     When I run `rspec spec/enable_globally_spec.rb`
-    Then it should fail listing all the failures:
+    Then it should fail and list all the failures:
       """
       Failures:
 
@@ -193,7 +193,7 @@ Feature: Aggregating Failures
       end
       """
     When I run `rspec spec/nested_failure_aggregation_spec.rb`
-    Then it should fail listing all the failures:
+    Then it should fail and list all the failures:
       """
       Failures:
 
@@ -253,7 +253,7 @@ Feature: Aggregating Failures
       end
       """
     When I run `rspec spec/mock_expectation_failure_spec.rb`
-    Then it should fail listing all the failures:
+    Then it should fail and list all the failures:
       """
       Failures:
 

--- a/features/expectation_framework_integration/aggregating_failures.feature
+++ b/features/expectation_framework_integration/aggregating_failures.feature
@@ -43,7 +43,7 @@ Feature: Aggregating Failures
 
         1) Client returns a successful response
            Got 3 failures from failure aggregation block "testing reponse".
-           # ./spec/use_block_form_spec.rb:7:in `block (2 levels) in <top (required)>'
+           # ./spec/use_block_form_spec.rb:7
 
            1.1) Failure/Error: expect(response.status).to eq(200)
 
@@ -51,7 +51,7 @@ Feature: Aggregating Failures
                        got: 404
 
                   (compared using ==)
-                # ./spec/use_block_form_spec.rb:8:in `block (3 levels) in <top (required)>'
+                # ./spec/use_block_form_spec.rb:8
 
            1.2) Failure/Error: expect(response.headers).to include("Content-Type" => "application/json")
                   expected {"Content-Type" => "text/plain"} to include {"Content-Type" => "application/json"}
@@ -59,7 +59,7 @@ Feature: Aggregating Failures
                   @@ -1,2 +1,2 @@
                   -[{"Content-Type"=>"application/json"}]
                   +"Content-Type" => "text/plain",
-                # ./spec/use_block_form_spec.rb:9:in `block (3 levels) in <top (required)>'
+                # ./spec/use_block_form_spec.rb:9
 
            1.3) Failure/Error: expect(response.body).to eq('{"message":"Success"}')
 
@@ -67,7 +67,7 @@ Feature: Aggregating Failures
                        got: "Not Found"
 
                   (compared using ==)
-                # ./spec/use_block_form_spec.rb:10:in `block (3 levels) in <top (required)>'
+                # ./spec/use_block_form_spec.rb:10
       """
 
   Scenario: Use `:aggregate_failures` metadata
@@ -99,7 +99,7 @@ Feature: Aggregating Failures
                        got: 404
 
                   (compared using ==)
-                # ./spec/use_metadata_spec.rb:7:in `block (2 levels) in <top (required)>'
+                # ./spec/use_metadata_spec.rb:7
 
            1.2) Failure/Error: expect(response.headers).to include("Content-Type" => "application/json")
                   expected {"Content-Type" => "text/plain"} to include {"Content-Type" => "application/json"}
@@ -107,7 +107,7 @@ Feature: Aggregating Failures
                   @@ -1,2 +1,2 @@
                   -[{"Content-Type"=>"application/json"}]
                   +"Content-Type" => "text/plain",
-                # ./spec/use_metadata_spec.rb:8:in `block (2 levels) in <top (required)>'
+                # ./spec/use_metadata_spec.rb:8
 
            1.3) Failure/Error: expect(response.body).to eq('{"message":"Success"}')
 
@@ -115,7 +115,7 @@ Feature: Aggregating Failures
                        got: "Not Found"
 
                   (compared using ==)
-                # ./spec/use_metadata_spec.rb:9:in `block (2 levels) in <top (required)>'
+                # ./spec/use_metadata_spec.rb:9
       """
 
   Scenario: Enable failure aggregation globally using `define_derived_metadata`
@@ -153,7 +153,7 @@ Feature: Aggregating Failures
                        got: 404
 
                   (compared using ==)
-                # ./spec/enable_globally_spec.rb:13:in `block (2 levels) in <top (required)>'
+                # ./spec/enable_globally_spec.rb:13
 
            1.2) Failure/Error: expect(response.headers).to include("Content-Type" => "application/json")
                   expected {"Content-Type" => "text/plain"} to include {"Content-Type" => "application/json"}
@@ -161,7 +161,7 @@ Feature: Aggregating Failures
                   @@ -1,2 +1,2 @@
                   -[{"Content-Type"=>"application/json"}]
                   +"Content-Type" => "text/plain",
-                # ./spec/enable_globally_spec.rb:14:in `block (2 levels) in <top (required)>'
+                # ./spec/enable_globally_spec.rb:14
 
            1.3) Failure/Error: expect(response.body).to eq('{"message":"Success"}')
 
@@ -169,5 +169,5 @@ Feature: Aggregating Failures
                        got: "Not Found"
 
                   (compared using ==)
-                # ./spec/enable_globally_spec.rb:15:in `block (2 levels) in <top (required)>'
+                # ./spec/enable_globally_spec.rb:15
       """

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -187,7 +187,7 @@ When(/^I run `([^`]+)` and abort in the middle with ctrl\-c$/) do |cmd|
   step "I run `#{cmd}`"
 end
 
-Then(/^it should fail listing all the failures:$/) do |string|
+Then(/^it should fail and list all the failures:$/) do |string|
   step %q{the exit status should not be 0}
   expect(normalize_whitespace_and_backtraces(all_output)).to include(normalize_whitespace_and_backtraces(string))
 end

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -187,4 +187,16 @@ When(/^I run `([^`]+)` and abort in the middle with ctrl\-c$/) do |cmd|
   step "I run `#{cmd}`"
 end
 
+Then(/^it should fail listing all the failures:$/) do |string|
+  step %q{the exit status should not be 0}
+  expect(normalize_whitespace_and_backtraces(all_output)).to include(normalize_whitespace_and_backtraces(string))
+end
+
+module WhitespaceNormalization
+  def normalize_whitespace_and_backtraces(text)
+    text.lines.map { |line| line.sub(/\s+$/, '').sub(/:in .*$/, '') }.join
+  end
+end
+
+World(WhitespaceNormalization)
 World(FormatterSupport)

--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -119,20 +119,13 @@ module RSpec
   #     end
   #
   def self.current_example
-    thread_local_metadata[:current_example]
+    RSpec::Support.thread_local_data[:current_example]
   end
 
   # Set the current example being executed.
   # @api private
   def self.current_example=(example)
-    thread_local_metadata[:current_example] = example
-  end
-
-  # @private
-  # A single thread local variable so we don't excessively pollute that
-  # namespace.
-  def self.thread_local_metadata
-    Thread.current[:_rspec] ||= { :shared_example_group_inclusions => [] }
+    RSpec::Support.thread_local_data[:current_example] = example
   end
 
   # @private

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -367,6 +367,8 @@ module RSpec
         @libs = []
         @derived_metadata_blocks = FilterableItemRepository::QueryOptimized.new(:any?)
         @threadsafe = true
+
+        define_built_in_hooks
       end
 
       # @private
@@ -1730,6 +1732,12 @@ module RSpec
 
       def value_for(key)
         @preferred_options.fetch(key) { yield }
+      end
+
+      def define_built_in_hooks
+        around(:example, :aggregate_failures => true) do |ex|
+          aggregate_failures(nil, :from_around_hook => true, &ex)
+        end
       end
 
       def assert_no_example_groups_defined(config_option)

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -231,7 +231,7 @@ module RSpec
       # @see DSL#describe
       def self.define_example_group_method(name, metadata={})
         idempotently_define_singleton_method(name) do |*args, &example_group_block|
-          thread_data = RSpec.thread_local_metadata
+          thread_data = RSpec::Support.thread_local_data
           top_level   = self == ExampleGroup
 
           if top_level
@@ -705,16 +705,21 @@ module RSpec
 
       # @private
       def self.current_backtrace
-        RSpec.thread_local_metadata[:shared_example_group_inclusions].reverse
+        shared_example_group_inclusions.reverse
       end
 
       # @private
       def self.with_frame(name, location)
-        current_stack = RSpec.thread_local_metadata[:shared_example_group_inclusions]
+        current_stack = shared_example_group_inclusions
         current_stack << new(name, location)
         yield
       ensure
         current_stack.pop
+      end
+
+      # @private
+      def self.shared_example_group_inclusions
+        RSpec::Support.thread_local_data[:shared_example_group_inclusions] ||= []
       end
     end
   end

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -44,7 +44,7 @@ module RSpec
           alignment_basis = "#{' ' * @indentation}#{failure_number}) "
           indentation = ' ' * alignment_basis.length
 
-          "\n#{alignment_basis}#{description}#{detail_formatter.call(example, colorizer, indentation)}" \
+          "\n#{alignment_basis}#{description_and_detail(colorizer, indentation)}" \
           "\n#{formatted_message_and_backtrace(colorizer, indentation)}" \
           "#{extra_detail_formatter.call(failure_number, colorizer, indentation)}"
         end
@@ -54,6 +54,12 @@ module RSpec
         end
 
       private
+
+        def description_and_detail(colorizer, indentation)
+          detail = detail_formatter.call(example, colorizer, indentation)
+          return (description || detail) unless description && detail
+          "#{description}\n#{indentation}#{detail}"
+        end
 
         if String.method_defined?(:encoding)
           def encoding_of(string)

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -7,14 +7,15 @@ module RSpec
         private :message_color, :detail_formatter, :extra_detail_formatter
 
         def initialize(exception, example, options={})
-          @exception              = exception
-          @example                = example
-          @message_color          = options.fetch(:message_color)          { RSpec.configuration.failure_color }
-          @description            = options.fetch(:description_formatter)  { Proc.new { example.full_description } }.call(self)
-          @detail_formatter       = options.fetch(:detail_formatter)       { Proc.new {} }
-          @extra_detail_formatter = options.fetch(:extra_detail_formatter) { Proc.new {} }
-          @indentation            = options.fetch(:indentation, 2)
-          @failure_lines          = options[:failure_lines]
+          @exception               = exception
+          @example                 = example
+          @message_color           = options.fetch(:message_color)          { RSpec.configuration.failure_color }
+          @description             = options.fetch(:description_formatter)  { Proc.new { example.full_description } }.call(self)
+          @detail_formatter        = options.fetch(:detail_formatter)       { Proc.new {} }
+          @extra_detail_formatter  = options.fetch(:extra_detail_formatter) { Proc.new {} }
+          @indentation             = options.fetch(:indentation, 2)
+          @skip_shared_group_trace = options.fetch(:skip_shared_group_trace, false)
+          @failure_lines           = options[:failure_lines]
         end
 
         def message_lines
@@ -95,6 +96,8 @@ module RSpec
         end
 
         def add_shared_group_lines(lines, colorizer)
+          return lines if @skip_shared_group_trace
+
           example.metadata[:shared_group_inclusion_backtrace].each do |frame|
             lines << colorizer.wrap(frame.description, RSpec.configuration.default_color)
           end

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -3,8 +3,9 @@ module RSpec
     module Formatters
       # @private
       class ExceptionPresenter
-        attr_reader :exception, :example, :description, :message_color, :detail_formatter, :extra_detail_formatter
-        private :message_color, :detail_formatter, :extra_detail_formatter
+        attr_reader :exception, :example, :description, :message_color,
+                    :detail_formatter, :extra_detail_formatter, :backtrace_formatter
+        private :message_color, :detail_formatter, :extra_detail_formatter, :backtrace_formatter
 
         def initialize(exception, example, options={})
           @exception               = exception
@@ -13,6 +14,7 @@ module RSpec
           @description             = options.fetch(:description_formatter)  { Proc.new { example.full_description } }.call(self)
           @detail_formatter        = options.fetch(:detail_formatter)       { Proc.new {} }
           @extra_detail_formatter  = options.fetch(:extra_detail_formatter) { Proc.new {} }
+          @backtrace_formatter     = options.fetch(:backtrace_formatter)    { RSpec.configuration.backtrace_formatter }
           @indentation             = options.fetch(:indentation, 2)
           @skip_shared_group_trace = options.fetch(:skip_shared_group_trace, false)
           @failure_lines           = options[:failure_lines]
@@ -70,10 +72,6 @@ module RSpec
             RSpec::Support::EncodedString.new(string)
           end
           # :nocov:
-        end
-
-        def backtrace_formatter
-          RSpec.configuration.backtrace_formatter
         end
 
         def exception_class_name

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -1,0 +1,136 @@
+module RSpec
+  module Core
+    module Formatters
+      # @private
+      class ExceptionPresenter
+        attr_reader :exception, :example, :description, :message_color, :detail_formatter
+        private :message_color, :detail_formatter
+
+        def initialize(exception, example, options={})
+          @exception        = exception
+          @example          = example
+          @message_color    = options.fetch(:message_color)    { RSpec.configuration.failure_color }
+          @description      = options.fetch(:description)      { example.full_description }
+          @detail_formatter = options.fetch(:detail_formatter) { lambda { |*| } }
+          @failure_lines    = options[:failure_lines]
+        end
+
+        def message_lines
+          add_shared_group_lines(failure_lines, Notifications::NullColorizer)
+        end
+
+        def colorized_message_lines(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+          add_shared_group_lines(failure_lines, colorizer).map do |line|
+            colorizer.wrap line, message_color
+          end
+        end
+
+        def formatted_backtrace
+          backtrace_formatter.format_backtrace(exception.backtrace, example.metadata)
+        end
+
+        def colorized_formatted_backtrace(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+          formatted_backtrace.map do |backtrace_info|
+            colorizer.wrap "# #{backtrace_info}", RSpec.configuration.detail_color
+          end
+        end
+
+        def fully_formatted(failure_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+          "\n  #{failure_number}) #{description}#{detail_formatter.call(example, colorizer)}" \
+          "\n#{formatted_message_and_backtrace(colorizer)}"
+        end
+
+      private
+
+        if String.method_defined?(:encoding)
+          def encoding_of(string)
+            string.encoding
+          end
+
+          def encoded_string(string)
+            RSpec::Support::EncodedString.new(string, Encoding.default_external)
+          end
+        else # for 1.8.7
+          # :nocov:
+          def encoding_of(_string)
+          end
+
+          def encoded_string(string)
+            RSpec::Support::EncodedString.new(string)
+          end
+          # :nocov:
+        end
+
+        def backtrace_formatter
+          RSpec.configuration.backtrace_formatter
+        end
+
+        def exception_class_name
+          name = exception.class.name.to_s
+          name = "(anonymous error class)" if name == ''
+          name
+        end
+
+        def failure_lines
+          @failure_lines ||=
+            begin
+              lines = ["Failure/Error: #{read_failed_line.strip}"]
+              lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
+              encoded_string(exception.message.to_s).split("\n").each do |line|
+                lines << "  #{line}"
+              end
+              lines
+            end
+        end
+
+        def add_shared_group_lines(lines, colorizer)
+          example.metadata[:shared_group_inclusion_backtrace].each do |frame|
+            lines << colorizer.wrap(frame.description, RSpec.configuration.default_color)
+          end
+
+          lines
+        end
+
+        def read_failed_line
+          matching_line = find_failed_line
+          unless matching_line
+            return "Unable to find matching line from backtrace"
+          end
+
+          file_path, line_number = matching_line.match(/(.+?):(\d+)(|:\d+)/)[1..2]
+
+          if File.exist?(file_path)
+            File.readlines(file_path)[line_number.to_i - 1] ||
+              "Unable to find matching line in #{file_path}"
+          else
+            "Unable to find #{file_path} to read failed line"
+          end
+        rescue SecurityError
+          "Unable to read failed line"
+        end
+
+        def find_failed_line
+          example_path = example.metadata[:absolute_file_path].downcase
+          exception.backtrace.find do |line|
+            next unless (line_path = line[/(.+?):(\d+)(|:\d+)/, 1])
+            File.expand_path(line_path).downcase == example_path
+          end
+        end
+
+        def formatted_message_and_backtrace(colorizer)
+          formatted = ""
+
+          colorized_message_lines(colorizer).each do |line|
+            formatted << RSpec::Support::EncodedString.new("     #{line}\n", encoding_of(formatted))
+          end
+
+          colorized_formatted_backtrace(colorizer).each do |line|
+            formatted << RSpec::Support::EncodedString.new("     #{line}\n", encoding_of(formatted))
+          end
+
+          formatted
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -140,53 +140,6 @@ module RSpec
           formatted
         end
       end
-
-      # @private
-      class MultipleExpectationsNotMetPresenterOptions
-        def self.for(exception, example, options={})
-          new(exception, example, options).presenter_options
-        end
-
-        attr_reader :exception, :example, :options
-
-        def initialize(exception, example, options={})
-          @exception = exception
-          @example   = example
-          @options   = options
-        end
-
-        def presenter_options
-          options.merge(
-            :failure_lines          => [],
-            :detail_formatter       => method(:failure_summary),
-            :extra_detail_formatter => method(:formatted_sub_failure_list)
-          )
-        end
-
-      private
-
-        def failure_summary(_example, colorizer, indentation)
-          # TODO: ensure this is printed in pending color when appropriate
-          colorizer.wrap("\n#{indentation}#{exception.summary}.", RSpec.configuration.failure_color)
-        end
-
-        def formatted_sub_failure_list(failure_number, colorizer, indentation)
-          # TODO: message_color
-          exception.all_exceptions.each_with_index.map do |failure, index|
-            ExceptionPresenter.new(
-              convert_to_relative_backtrace(failure), example,
-              :description_formatter => :failure_slash_error_line.to_proc,
-              :indentation           => indentation.length
-            ).fully_formatted("#{failure_number}.#{index + 1}", colorizer)
-          end.join
-        end
-
-        def convert_to_relative_backtrace(failure)
-          failure = failure.dup
-          failure.set_backtrace(failure.backtrace[0..-exception.backtrace.size])
-          failure
-        end
-      end
     end
   end
 end

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -12,6 +12,7 @@ module RSpec
           @message_color    = options.fetch(:message_color)    { RSpec.configuration.failure_color }
           @description      = options.fetch(:description)      { example.full_description }
           @detail_formatter = options.fetch(:detail_formatter) { lambda { |*| } }
+          @indentation      = options.fetch(:indentation, 2)
           @failure_lines    = options[:failure_lines]
         end
 
@@ -36,8 +37,9 @@ module RSpec
         end
 
         def fully_formatted(failure_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
-          "\n  #{failure_number}) #{description}#{detail_formatter.call(example, colorizer)}" \
-          "\n#{formatted_message_and_backtrace(colorizer)}"
+          alignment_basis = "#{' ' * @indentation}#{failure_number}) "
+          "\n#{alignment_basis}#{description}#{detail_formatter.call(example, colorizer)}" \
+          "\n#{formatted_message_and_backtrace(colorizer, alignment_basis.length)}"
         end
 
       private
@@ -117,15 +119,13 @@ module RSpec
           end
         end
 
-        def formatted_message_and_backtrace(colorizer)
+        def formatted_message_and_backtrace(colorizer, indentation)
+          lines = colorized_message_lines(colorizer) + colorized_formatted_backtrace(colorizer)
+
           formatted = ""
 
-          colorized_message_lines(colorizer).each do |line|
-            formatted << RSpec::Support::EncodedString.new("     #{line}\n", encoding_of(formatted))
-          end
-
-          colorized_formatted_backtrace(colorizer).each do |line|
-            formatted << RSpec::Support::EncodedString.new("     #{line}\n", encoding_of(formatted))
+          lines.each do |line|
+            formatted << RSpec::Support::EncodedString.new("#{' ' * indentation}#{line}\n", encoding_of(formatted))
           end
 
           formatted

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -270,7 +270,7 @@ module RSpec
               # that take a metadata hash, and MetadataFilter sets this thread
               # local to silence the warning here since it would be so
               # confusing.
-              unless RSpec.thread_local_metadata[:silence_metadata_example_group_deprecations]
+              unless RSpec::Support.thread_local_data[:silence_metadata_example_group_deprecations]
                 RSpec.deprecate("The `:example_group` key in an example group's metadata hash",
                                 :replacement => "the example group's hash directly for the " \
                                 "computed keys and `:parent_example_group` to access the parent " \

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -78,10 +78,10 @@ module RSpec
         end
 
         def silence_metadata_example_group_deprecations
-          RSpec.thread_local_metadata[:silence_metadata_example_group_deprecations] = true
+          RSpec::Support.thread_local_data[:silence_metadata_example_group_deprecations] = true
           yield
         ensure
-          RSpec.thread_local_metadata.delete(:silence_metadata_example_group_deprecations)
+          RSpec::Support.thread_local_data.delete(:silence_metadata_example_group_deprecations)
         end
       end
     end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -315,7 +315,7 @@ module RSpec::Core
       #
       # @return [Array<String>] The example failure message
       def message_lines
-        ["Expected pending '#{example.execution_result.pending_message}' to fail. No Error was raised."]
+        add_shared_group_lines(raw_message_lines, NullColorizer)
       end
 
       # Returns the message generated for this failure colorized line by line.
@@ -323,7 +323,15 @@ module RSpec::Core
       # @param colorizer [#wrap] An object to colorize the message_lines by
       # @return [Array<String>] The example failure message colorized
       def colorized_message_lines(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
-        message_lines.map { |line| colorizer.wrap(line, RSpec.configuration.fixed_color) }
+        add_shared_group_lines(raw_message_lines, colorizer).map do |line|
+          colorizer.wrap line, RSpec.configuration.fixed_color
+        end
+      end
+
+    private
+
+      def raw_message_lines
+        ["Expected pending '#{example.execution_result.pending_message}' to fail. No Error was raised."]
       end
     end
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -228,8 +228,8 @@ module RSpec::Core
     end
 
     # @private
-    PENDING_DETAIL_FORMATTER = lambda do |example, colorizer|
-      colorizer.wrap("\n     # #{example.execution_result.pending_message}", :detail)
+    PENDING_DETAIL_FORMATTER = lambda do |example, colorizer, indentation|
+      colorizer.wrap("\n#{indentation}# #{example.execution_result.pending_message}", :detail)
     end
 
     # The `PendingExampleFailedAsExpectedNotification` extends `FailedExampleNotification` with
@@ -264,7 +264,7 @@ module RSpec::Core
       def fully_formatted(pending_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted_caller = RSpec.configuration.backtrace_formatter.backtrace_line(example.location)
         colorizer.wrap("\n  #{pending_number}) #{example.full_description}", :pending) <<
-          PENDING_DETAIL_FORMATTER.call(example, colorizer) << "\n" <<
+          PENDING_DETAIL_FORMATTER.call(example, colorizer, "     ") << "\n" <<
           colorizer.wrap("     # #{formatted_caller}\n", :detail)
       end
     end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -99,9 +99,10 @@ module RSpec::Core
 
             Formatters::ExceptionPresenter.new(
               failure, example,
-              :description_formatter => :failure_slash_error_line.to_proc,
-              :indentation           => indentation.length,
-              :message_color         => message_color || RSpec.configuration.failure_color
+              :description_formatter   => :failure_slash_error_line.to_proc,
+              :indentation             => indentation.length,
+              :message_color           => message_color || RSpec.configuration.failure_color,
+              :skip_shared_group_trace => true
             ).fully_formatted("#{failure_number}.#{index + 1}", colorizer)
           end.join
         end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -216,11 +216,13 @@ module RSpec::Core
     private
 
       def initialize(example)
+        execution_result = example.execution_result
+
         super(example, Formatters::ExceptionPresenter.new(
           example.execution_result.exception, example,
-          :description   => "#{example.full_description} FIXED",
-          :message_color => RSpec.configuration.fixed_color,
-          :failure_lines => ["Expected pending '#{example.execution_result.pending_message}' to fail. No Error was raised."]
+          :description_formatter => Proc.new { "#{example.full_description} FIXED" },
+          :message_color         => RSpec.configuration.fixed_color,
+          :failure_lines         => ["Expected pending '#{execution_result.pending_message}' to fail. No Error was raised."]
         ))
       end
     end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -104,9 +104,9 @@ module RSpec::Core
                       "#{exception.summary}."
                     end
 
-          summary = "\n#{indentation}#{colorizer.wrap(summary, color || RSpec.configuration.failure_color)}"
+          summary = colorizer.wrap(summary, color || RSpec.configuration.failure_color)
           return summary unless prior_detail_formatter
-          "#{prior_detail_formatter.call(example, colorizer, indentation)}#{summary}"
+          "#{prior_detail_formatter.call(example, colorizer, indentation)}\n#{indentation}#{summary}"
         end
       end
 
@@ -287,8 +287,8 @@ module RSpec::Core
     class PendingExampleFailedAsExpectedNotification < FailedExampleNotification; end
 
     # @private
-    PENDING_DETAIL_FORMATTER = lambda do |example, colorizer, indentation|
-      colorizer.wrap("\n#{indentation}# #{example.execution_result.pending_message}", :detail)
+    PENDING_DETAIL_FORMATTER = Proc.new do |example, colorizer|
+      colorizer.wrap("# #{example.execution_result.pending_message}", :detail)
     end
 
     # The `SkippedExampleNotification` extends `ExampleNotification` with
@@ -304,7 +304,7 @@ module RSpec::Core
       def fully_formatted(pending_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted_caller = RSpec.configuration.backtrace_formatter.backtrace_line(example.location)
         colorizer.wrap("\n  #{pending_number}) #{example.full_description}", :pending) <<
-          PENDING_DETAIL_FORMATTER.call(example, colorizer, "     ") << "\n" <<
+          "\n     " << PENDING_DETAIL_FORMATTER.call(example, colorizer) << "\n" <<
           colorizer.wrap("     # #{formatted_caller}\n", :detail)
       end
     end

--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -80,7 +80,7 @@ module RSpec
       # @see ExampleGroup.include_context
       def shared_examples(name, *args, &block)
         top_level = self == ExampleGroup
-        if top_level && RSpec.thread_local_metadata[:in_example_group]
+        if top_level && RSpec::Support.thread_local_data[:in_example_group]
           raise "Creating isolated shared examples from within a context is " \
                 "not allowed. Remove `RSpec.` prefix or move this to a " \
                 "top-level scope."

--- a/spec/rspec/core/aggregate_failures_spec.rb
+++ b/spec/rspec/core/aggregate_failures_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "Using `:aggregate_failures` metadata" do
+  it 'applies `aggregate_failures` to examples or groups tagged with `:aggregate_failures`' do
+    ex = nil
+
+    RSpec.describe "Aggregate failures", :aggregate_failures do
+      ex = it "has multiple failures" do
+        expect(1).to be_even
+        expect(2).to be_odd
+      end
+    end.run
+
+    expect(ex.execution_result.exception).to have_attributes(
+      :failures => [
+        an_object_having_attributes(:message => 'expected `1.even?` to return true, got false'),
+        an_object_having_attributes(:message => 'expected `2.odd?` to return true, got false')
+      ]
+    )
+  end
+
+  it 'does not interfere with other `around` hooks' do
+    events = []
+
+    RSpec.describe "Outer" do
+      around do |ex|
+        events << :outer_before
+        ex.run
+        events << :outer_after
+      end
+
+      context "aggregating failures", :aggregate_failures do
+        context "inner" do
+          around do |ex|
+            events << :inner_before
+            ex.run
+            events << :inner_after
+          end
+
+          it "has multiple failures" do
+            events << :example_before
+            expect(1).to be_even
+            expect(2).to be_odd
+            events << :example_after
+          end
+        end
+      end
+    end.run
+
+    expect(events).to eq([:outer_before, :inner_before, :example_before,
+                          :example_after, :inner_after, :outer_after])
+  end
+end

--- a/spec/rspec/core/bisect/server_spec.rb
+++ b/spec/rspec/core/bisect/server_spec.rb
@@ -14,6 +14,8 @@ module RSpec::Core
     end
 
     it 'always stops the server, even if an error occurs while yielding' do
+      skip "This test flaps on JRuby 1.8 mode for some reason" if RSpec::Support::Ruby.jruby? && RUBY_VERSION.to_f < 1.9
+
       expect(DRb).not_to have_running_server
 
       expect {

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1460,7 +1460,7 @@ module RSpec::Core
         it "leaves RSpec's thread metadata unchanged" do
           expect {
             self.group.send(name, "named this")
-          }.to avoid_changing(RSpec, :thread_local_metadata)
+          }.to avoid_changing(RSpec::Support, :thread_local_data)
         end
 
         it "leaves RSpec's thread metadata unchanged, even when an error occurs during evaluation" do
@@ -1468,7 +1468,7 @@ module RSpec::Core
             self.group.send(name, "named this") do
               raise "boom"
             end
-          }.to raise_error("boom").and avoid_changing(RSpec, :thread_local_metadata)
+          }.to raise_error("boom").and avoid_changing(RSpec::Support, :thread_local_data)
         end
 
         it "passes parameters to the shared content" do
@@ -1637,7 +1637,7 @@ module RSpec::Core
             shared_examples_for("stuff") { }
             it_should_behave_like "stuff"
           end
-        }.to avoid_changing(RSpec, :thread_local_metadata)
+        }.to avoid_changing(RSpec::Support, :thread_local_data)
       end
 
       it "leaves RSpec's thread metadata unchanged, even when an error occurs during evaluation" do
@@ -1648,7 +1648,7 @@ module RSpec::Core
               raise "boom"
             end
           end
-        }.to raise_error("boom").and avoid_changing(RSpec, :thread_local_metadata)
+        }.to raise_error("boom").and avoid_changing(RSpec::Support, :thread_local_data)
       end
     end
 

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -90,8 +90,8 @@ root
         |pending command with block format
         |  with content that would fail
         |    is pending (PENDING: No reason given)
-        |  with content that would pass
-        |    fails (FAILED - 1)
+        |  behaves like shared
+        |    is marked as pending but passes (FAILED - 1)
         |
         |passing spec
         |  passes

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -18,10 +18,12 @@ module RSpec::Core::Formatters
     it "numbers the failures" do
       send_notification :example_failed, example_notification( double("example 1",
                :description => "first example",
+               :full_description => "group first example",
                :execution_result => execution_result(:status => :failed, :exception => Exception.new)
               ))
       send_notification :example_failed, example_notification( double("example 2",
                :description => "second example",
+               :full_description => "group second example",
                :execution_result => execution_result(:status => :failed, :exception => Exception.new)
               ))
 

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -1,0 +1,95 @@
+require 'pathname'
+
+module RSpec::Core
+  RSpec.describe Formatters::ExceptionPresenter do
+    include FormatterSupport
+
+    let(:example) { new_example }
+    let(:presenter) { Formatters::ExceptionPresenter.new(exception, example) }
+
+    before do
+      allow(example.execution_result).to receive(:exception) { exception }
+      example.metadata[:absolute_file_path] = __FILE__
+    end
+
+    describe "#read_failed_line" do
+      def read_failed_line
+        presenter.send(:read_failed_line)
+      end
+
+      context "when backtrace is a heterogeneous language stack trace" do
+        let(:exception) do
+          instance_double(Exception, :backtrace => [
+            "at Object.prototypeMethod (foo:331:18)",
+            "at Array.forEach (native)",
+            "at a_named_javascript_function (/some/javascript/file.js:39:5)",
+            "/some/line/of/ruby.rb:14"
+          ])
+        end
+
+        it "is handled gracefully" do
+          expect { read_failed_line }.not_to raise_error
+        end
+      end
+
+      context "when backtrace will generate a security error" do
+        let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"]) }
+
+        it "is handled gracefully" do
+          with_safe_set_to_level_that_triggers_security_errors do
+            expect { read_failed_line }.not_to raise_error
+          end
+        end
+      end
+
+      context "when ruby reports a bogus line number in the stack trace" do
+        let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:10000000"]) }
+
+        it "reports the filename and that it was unable to find the matching line" do
+          expect(read_failed_line).to include("Unable to find matching line")
+        end
+      end
+
+      context "when ruby reports a file that does not exist" do
+        let(:file) { "#{__FILE__}/blah.rb" }
+        let(:exception) { instance_double(Exception, :backtrace => [ "#{file}:1"]) }
+
+        it "reports the filename and that it was unable to find the matching line" do
+          example.metadata[:absolute_file_path] = file
+          expect(read_failed_line).to include("Unable to find #{file} to read failed line")
+        end
+      end
+
+      context "when the stacktrace includes relative paths (which can happen when using `rspec/autorun` and running files through `ruby`)" do
+        let(:relative_file) { Pathname(__FILE__).relative_path_from(Pathname(Dir.pwd)) }
+        line = __LINE__
+        let(:exception) { instance_double(Exception, :backtrace => ["#{relative_file}:#{line}"]) }
+
+        it 'still finds the backtrace line' do
+          expect(read_failed_line).to include("line = __LINE__")
+        end
+      end
+
+      context "when String alias to_int to_i" do
+        before do
+          String.class_exec do
+            alias :to_int :to_i
+          end
+        end
+
+        after do
+          String.class_exec do
+            undef to_int
+          end
+        end
+
+        let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"]) }
+
+        it "doesn't hang when file exists" do
+          expect(read_failed_line.strip).to eql(
+            %Q[let(:exception) { instance_double(Exception, :backtrace => [ "\#{__FILE__}:\#{__LINE__}"]) }])
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -52,6 +52,18 @@ module RSpec::Core
         EOS
       end
 
+      it 'allows the failure/error line to be used as the description' do
+        presenter = Formatters::ExceptionPresenter.new(exception, example, :description_formatter => lambda { |p| p.failure_slash_error_line })
+
+        expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |  1) Failure/Error: # The failure happened here!
+          |       Boom
+          |       Bam
+          |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
+
     end
 
     describe "#read_failed_line" do

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -53,9 +53,7 @@ module RSpec::Core
       end
 
       it 'passes the indentation on to the `:detail_formatter` lambda so it can align things' do
-        detail_formatter = lambda do |ex, colorizer, indentation|
-          "\n#{indentation}Some Detail"
-        end
+        detail_formatter = Proc.new { "Some Detail" }
 
         presenter = Formatters::ExceptionPresenter.new(exception, example, :indentation => 4,
                                                        :detail_formatter => detail_formatter)
@@ -67,6 +65,21 @@ module RSpec::Core
           |         Boom
           |         Bam
           |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
+
+      it 'allows the caller to omit the description' do
+        presenter = Formatters::ExceptionPresenter.new(exception, example,
+                                                       :detail_formatter => Proc.new { "Detail!" },
+                                                       :description_formatter => Proc.new { })
+
+        expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |  1) Detail!
+          |     Failure/Error: # The failure happened here!
+          |       Boom
+          |       Bam
+          |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
         EOS
       end
 

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -12,6 +12,48 @@ module RSpec::Core
       example.metadata[:absolute_file_path] = __FILE__
     end
 
+    describe "#fully_formatted" do
+      line_num = __LINE__ + 2
+      let(:exception) { instance_double(Exception, :message => "Boom\nBam", :backtrace => [ "#{__FILE__}:#{line_num}"]) }
+      # The failure happened here!
+
+      it "formats the exception with all the normal details" do
+        expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |  1) Example
+          |     Failure/Error: # The failure happened here!
+          |       Boom
+          |       Bam
+          |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
+
+      it "indents properly when given a multiple-digit failure index" do
+        expect(presenter.fully_formatted(100)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |  100) Example
+          |       Failure/Error: # The failure happened here!
+          |         Boom
+          |         Bam
+          |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
+
+      it "allows the caller to specify additional indentation" do
+        presenter = Formatters::ExceptionPresenter.new(exception, example, :indentation => 4)
+
+        expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |    1) Example
+          |       Failure/Error: # The failure happened here!
+          |         Boom
+          |         Bam
+          |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
+
+    end
+
     describe "#read_failed_line" do
       def read_failed_line
         presenter.send(:read_failed_line)

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -296,18 +296,18 @@ a {
 </div>
 <div id="div_group_4" class="example_group passed">
   <dl style="margin-left: 15px;">
-<dt id="example_group_4" class="passed">with content that would pass</dt>
+<dt id="example_group_4" class="passed">behaves like shared</dt>
     <script type="text/javascript">makeRed('rspec-header');</script><script type="text/javascript">makeRed('div_group_4');</script><script type="text/javascript">makeRed('example_group_4');</script><script type="text/javascript">moveProgressBar('42.8');</script><dd class="example pending_fixed">
-      <span class="failed_spec_name">fails</span>
+      <span class="failed_spec_name">is marked as pending but passes</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_1">
         <div class="message"><pre>Expected example to fail since it is pending, but it passed.</pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:16</pre></div>
-    <pre class="ruby"><code><span class="linenum">14</span>
-<span class="linenum">15</span>  context <span class="string"><span class="delimiter">"</span><span class="content">with content that would pass</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
-<span class="offending"><span class="linenum">16</span>    it <span class="string"><span class="delimiter">"</span><span class="content">fails</span><span class="delimiter">"</span></span> <span class="keyword">do</span></span>
-<span class="linenum">17</span>      pending
-<span class="linenum">18</span>      expect(<span class="integer">1</span>).to eq(<span class="integer">1</span>)</code></pre>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:4</pre></div>
+    <pre class="ruby"><code><span class="linenum">2</span>
+<span class="linenum">3</span><span class="constant">RSpec</span>.shared_examples_for <span class="string"><span class="delimiter">"</span><span class="content">shared</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
+<span class="offending"><span class="linenum">4</span>  it <span class="string"><span class="delimiter">"</span><span class="content">is marked as pending but passes</span><span class="delimiter">"</span></span> <span class="keyword">do</span></span>
+<span class="linenum">5</span>    pending
+<span class="linenum">6</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">1</span>)</code></pre>
       </div>
     </dd>
   </dl>
@@ -333,12 +333,12 @@ expected: 2
 
 (compared using ==)
 </pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:31</pre></div>
-    <pre class="ruby"><code><span class="linenum">29</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">"</span><span class="content">failing spec</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
-<span class="linenum">30</span>  it <span class="string"><span class="delimiter">"</span><span class="content">fails</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
-<span class="offending"><span class="linenum">31</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
-<span class="linenum">32</span>  <span class="keyword">end</span>
-<span class="linenum">33</span><span class="keyword">end</span></code></pre>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:33</pre></div>
+    <pre class="ruby"><code><span class="linenum">31</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">"</span><span class="content">failing spec</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
+<span class="linenum">32</span>  it <span class="string"><span class="delimiter">"</span><span class="content">fails</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
+<span class="offending"><span class="linenum">33</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
+<span class="linenum">34</span>  <span class="keyword">end</span>
+<span class="linenum">35</span><span class="keyword">end</span></code></pre>
       </div>
     </dd>
   </dl>
@@ -351,7 +351,7 @@ expected: 2
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_3">
         <div class="message"><pre>foo</pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:39</pre></div>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:41</pre></div>
     <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for (erb)</span></code></pre>
       </div>
     </dd>

--- a/spec/rspec/core/notifications_spec.rb
+++ b/spec/rspec/core/notifications_spec.rb
@@ -1,10 +1,11 @@
 require 'rspec/core/notifications'
-require 'pathname'
 
 RSpec.describe "FailedExampleNotification" do
   include FormatterSupport
 
   let(:example) { new_example }
+  exception_line = __LINE__ + 1
+  let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{exception_line}"], :message => 'Test exception') }
   let(:notification) { ::RSpec::Core::Notifications::FailedExampleNotification.new(example) }
 
   before do
@@ -12,86 +13,16 @@ RSpec.describe "FailedExampleNotification" do
     example.metadata[:absolute_file_path] = __FILE__
   end
 
-  # ported from `base_formatter_spec` should be refactored by final
-  describe "#read_failed_line" do
-    context "when backtrace is a heterogeneous language stack trace" do
-      let(:exception) do
-        instance_double(Exception, :backtrace => [
-          "at Object.prototypeMethod (foo:331:18)",
-          "at Array.forEach (native)",
-          "at a_named_javascript_function (/some/javascript/file.js:39:5)",
-          "/some/line/of/ruby.rb:14"
-        ])
-      end
+  it 'provides a description' do
+    expect(notification.description).to eq(example.full_description)
+  end
 
-      it "is handled gracefully" do
-        expect { notification.send(:read_failed_line) }.not_to raise_error
-      end
-    end
-
-    context "when backtrace will generate a security error" do
-      let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"]) }
-
-      it "is handled gracefully" do
-        with_safe_set_to_level_that_triggers_security_errors do
-          expect { notification.send(:read_failed_line) }.not_to raise_error
-        end
-      end
-    end
-
-    context "when ruby reports a bogus line number in the stack trace" do
-      let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:10000000"]) }
-
-      it "reports the filename and that it was unable to find the matching line" do
-        expect(notification.send(:read_failed_line)).to include("Unable to find matching line")
-      end
-    end
-
-    context "when ruby reports a file that does not exist" do
-      let(:file) { "#{__FILE__}/blah.rb" }
-      let(:exception) { instance_double(Exception, :backtrace => [ "#{file}:1"]) }
-
-      it "reports the filename and that it was unable to find the matching line" do
-        example.metadata[:absolute_file_path] = file
-        expect(notification.send(:read_failed_line)).to include("Unable to find #{file} to read failed line")
-      end
-    end
-
-    context "when the stacktrace includes relative paths (which can happen when using `rspec/autorun` and running files through `ruby`)" do
-      let(:relative_file) { Pathname(__FILE__).relative_path_from(Pathname(Dir.pwd)) }
-      line = __LINE__
-      let(:exception) { instance_double(Exception, :backtrace => ["#{relative_file}:#{line}"]) }
-
-      it 'still finds the backtrace line' do
-        expect(notification.send(:read_failed_line)).to include("line = __LINE__")
-      end
-    end
-
-    context "when String alias to_int to_i" do
-      before do
-        String.class_exec do
-          alias :to_int :to_i
-        end
-      end
-
-      after do
-        String.class_exec do
-          undef to_int
-        end
-      end
-
-      let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"]) }
-
-      it "doesn't hang when file exists" do
-        expect(notification.send(:read_failed_line).strip).to eql(
-          %Q[let(:exception) { instance_double(Exception, :backtrace => [ "\#{__FILE__}:\#{__LINE__}"]) }])
-      end
-
-    end
+  it 'provides `colorized_formatted_backtrace`, which formats the backtrace and colorizes it' do
+    allow(RSpec.configuration).to receive(:color_enabled?).and_return(true)
+    expect(notification.colorized_formatted_backtrace).to eq(["\e[36m# #{RSpec::Core::Metadata.relative_path(__FILE__)}:#{exception_line}\e[0m"])
   end
 
   describe '#message_lines' do
-    let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"], :message => 'Test exception') }
     let(:example_group) { class_double(RSpec::Core::ExampleGroup, :metadata => {}, :parent_groups => [], :location => "#{__FILE__}:#{__LINE__}") }
 
     before do

--- a/spec/rspec/core/notifications_spec.rb
+++ b/spec/rspec/core/notifications_spec.rb
@@ -3,10 +3,10 @@ require 'rspec/core/notifications'
 RSpec.describe "FailedExampleNotification" do
   include FormatterSupport
 
-  let(:example) { new_example }
+  let(:example) { new_example(:status => :failed) }
   exception_line = __LINE__ + 1
   let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{exception_line}"], :message => 'Test exception') }
-  let(:notification) { ::RSpec::Core::Notifications::FailedExampleNotification.new(example) }
+  let(:notification) { ::RSpec::Core::Notifications::ExampleNotification.for(example) }
 
   before do
     allow(example.execution_result).to receive(:exception) { exception }
@@ -20,6 +20,99 @@ RSpec.describe "FailedExampleNotification" do
   it 'provides `colorized_formatted_backtrace`, which formats the backtrace and colorizes it' do
     allow(RSpec.configuration).to receive(:color_enabled?).and_return(true)
     expect(notification.colorized_formatted_backtrace).to eq(["\e[36m# #{RSpec::Core::Metadata.relative_path(__FILE__)}:#{exception_line}\e[0m"])
+  end
+
+  describe "fully formatted failure output" do
+    def fully_formatted
+      notification.fully_formatted(1)
+    end
+
+    def dedent(string)
+      string.gsub(/^ +\|/, '')
+    end
+
+    context "when the exception is a MultipleExpectationsNotMetError" do
+      RSpec::Matchers.define :fail_with_description do |desc|
+        match { false }
+        description { desc }
+        failure_message { "expected pass, but #{desc}" }
+      end
+
+      def capture_and_normalize_aggregation_error
+        backtrace_truncation_frames = caller.length + 2
+
+        begin
+          yield
+        rescue RSpec::Expectations::MultipleExpectationsNotMetError => failure
+          # To keep the output manageable, truncate the backtraces...
+          ([failure] + failure.all_exceptions).each do |exception|
+            exception.set_backtrace(exception.backtrace[0..-backtrace_truncation_frames])
+            exception.backtrace.map! { |line| line.sub(/:in .*$/, '') }
+          end
+
+          failure
+        end
+      end
+
+      let(:aggregate_line) { __LINE__ + 3 }
+      let(:exception) do
+        capture_and_normalize_aggregation_error do
+          aggregate_failures("multiple expectations") do
+            expect(1).to fail_with_description("foo")
+            expect(1).to fail_with_description("bar")
+          end
+        end
+      end
+
+      it 'provides a summary composed of example description, failure count and aggregate backtrace' do
+        expect(fully_formatted.lines.first(5)).to eq(dedent(<<-EOS).lines.to_a)
+          |
+          |  1) Example
+          |     Got 2 failures from failure aggregation block "multiple expectations".
+          |     # #{RSpec::Core::Metadata.relative_path(__FILE__)}:#{aggregate_line}
+          |
+        EOS
+      end
+
+      it 'lists each individual expectation failure, with a backtrace relative to the aggregation block' do
+        expect(fully_formatted.lines.to_a.last(8)).to eq(dedent(<<-EOS).lines.to_a)
+          |
+          |     1.1) Failure/Error: expect(1).to fail_with_description("foo")
+          |            expected pass, but foo
+          |          # #{RSpec::Core::Metadata.relative_path(__FILE__)}:#{aggregate_line + 1}
+          |
+          |     1.2) Failure/Error: expect(1).to fail_with_description("bar")
+          |            expected pass, but bar
+          |          # #{RSpec::Core::Metadata.relative_path(__FILE__)}:#{aggregate_line + 2}
+        EOS
+      end
+
+      context "when there are failures and other errors" do
+        let(:aggregate_line) { __LINE__ + 3 }
+        let(:exception) do
+          capture_and_normalize_aggregation_error do
+            aggregate_failures("multiple expectations") do
+              expect(1).to fail_with_description("foo")
+              raise "boom"
+            end
+          end
+        end
+
+        it 'lists both types in the exception listing' do
+          expect(fully_formatted.lines.to_a.last(9)).to eq(dedent(<<-EOS).lines.to_a)
+            |
+            |     1.1) Failure/Error: expect(1).to fail_with_description("foo")
+            |            expected pass, but foo
+            |          # #{RSpec::Core::Metadata.relative_path(__FILE__)}:#{aggregate_line + 1}
+            |
+            |     1.2) Failure/Error: raise "boom"
+            |          RuntimeError:
+            |            boom
+            |          # #{RSpec::Core::Metadata.relative_path(__FILE__)}:#{aggregate_line + 2}
+           EOS
+        end
+      end
+    end
   end
 
   describe '#message_lines' do

--- a/spec/rspec/core/resources/formatter_specs.rb
+++ b/spec/rspec/core/resources/formatter_specs.rb
@@ -1,5 +1,12 @@
 # Deliberately named _specs.rb to avoid being loaded except when specified
 
+RSpec.shared_examples_for "shared" do
+  it "is marked as pending but passes" do
+    pending
+    expect(1).to eq(1)
+  end
+end
+
 RSpec.describe "pending spec with no implementation" do
   it "is pending"
 end
@@ -12,12 +19,7 @@ RSpec.describe "pending command with block format" do
     end
   end
 
-  context "with content that would pass" do
-    it "fails" do
-      pending
-      expect(1).to eq(1)
-    end
-  end
+  it_behaves_like "shared"
 end
 
 RSpec.describe "passing spec" do

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -218,6 +218,14 @@ RSpec.describe RSpec do
     end
   end
 
+  it 'uses only one thread local variable', :run_last do
+    # Trigger features that use thread locals...
+    aggregate_failures { }
+    RSpec.shared_examples_for("something") { }
+
+    expect(Thread.current.keys.map(&:to_s).grep(/rspec/i).count).to eq(1)
+  end
+
   describe "::Core.path_to_executable" do
     it 'returns the absolute location of the exe/rspec file' do
       expect(File.exist? RSpec::Core.path_to_executable).to be_truthy

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -44,7 +44,7 @@ module FormatterSupport
         |
         |  1) pending spec with no implementation is pending
         |     # Not yet implemented
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:4
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:11
         |
         |  2) pending command with block format with content that would fail is pending
         |     # No reason given
@@ -54,16 +54,17 @@ module FormatterSupport
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:11
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:18
         |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14
         |     # ./spec/support/sandboxing.rb:7
         |
         |Failures:
         |
-        |  1) pending command with block format with content that would pass fails FIXED
+        |  1) pending command with block format behaves like shared is marked as pending but passes FIXED
         |     Expected pending 'No reason given' to fail. No Error was raised.
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:16
+        |     Shared Example Group: "shared" called from ./spec/rspec/core/resources/formatter_specs.rb:22
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:4
         |
         |  2) failing spec fails
         |     Failure/Error: expect(1).to eq(2)
@@ -72,7 +73,7 @@ module FormatterSupport
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:31
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:33
         |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14
         |     # ./spec/support/sandboxing.rb:7
@@ -94,10 +95,10 @@ module FormatterSupport
         |
         |Failed examples:
         |
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:16 # pending command with block format with content that would pass fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:30 # failing spec fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # a failing spec with odd backtraces fails with a backtrace that has no file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:42 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:4 # pending command with block format behaves like shared is marked as pending but passes
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:32 # failing spec fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:38 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:44 # a failing spec with odd backtraces fails with a backtrace containing an erb file
       EOS
     end
   else
@@ -107,7 +108,7 @@ module FormatterSupport
         |
         |  1) pending spec with no implementation is pending
         |     # Not yet implemented
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:4
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:11
         |
         |  2) pending command with block format with content that would fail is pending
         |     # No reason given
@@ -117,16 +118,17 @@ module FormatterSupport
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:11:in `block (3 levels) in <top (required)>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:18:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
         |Failures:
         |
-        |  1) pending command with block format with content that would pass fails FIXED
+        |  1) pending command with block format behaves like shared is marked as pending but passes FIXED
         |     Expected pending 'No reason given' to fail. No Error was raised.
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:16
+        |     Shared Example Group: "shared" called from ./spec/rspec/core/resources/formatter_specs.rb:22
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:4
         |
         |  2) failing spec fails
         |     Failure/Error: expect(1).to eq(2)
@@ -135,7 +137,7 @@ module FormatterSupport
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:31:in `block (2 levels) in <top (required)>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
@@ -145,7 +147,7 @@ module FormatterSupport
         |     RuntimeError:
         |       foo
         |     # (erb):1:in `<main>'
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:39:in `block (2 levels) in <top (required)>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
@@ -161,10 +163,10 @@ module FormatterSupport
         |
         |Failed examples:
         |
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:16 # pending command with block format with content that would pass fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:30 # failing spec fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # a failing spec with odd backtraces fails with a backtrace that has no file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:42 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:4 # pending command with block format behaves like shared is marked as pending but passes
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:32 # failing spec fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:38 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:44 # a failing spec with odd backtraces fails with a backtrace containing an erb file
       EOS
     end
   end


### PR DESCRIPTION
This is the start of the rspec-core work for the new `aggregate_failures` feature.  The part I'm working on now is getting the aggregated failure to format how we want.  To facilitate this, I've extracted a new `ExceptionFormatter` class that is able to format exceptions according to how rspec-core typically does it for its built-in formatters.  We'll then be able to apply this to each of the aggregated failures.

More to come, but I wanted to push what I had and get the travis build going.