### PR TITLE
`c.mock_framework = :foo` => `c.mock_with :foo`

### DIFF
--- a/features/mock_framework_integration/use_any_framework.feature
+++ b/features/mock_framework_integration/use_any_framework.feature
@@ -84,7 +84,7 @@ Feature: mock with an alternative framework
       require File.expand_path("../expector", __FILE__)
 
       RSpec.configure do |config|
-        config.mock_framework = Expector::RSpecAdapter
+        config.mock_with Expector::RSpecAdapter
       end
 
       RSpec.describe Expector do

--- a/features/mock_framework_integration/use_flexmock.feature
+++ b/features/mock_framework_integration/use_flexmock.feature
@@ -6,7 +6,7 @@ Feature: mock with flexmock
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :flexmock
+        config.mock_with :flexmock
       end
 
       RSpec.describe "mocking with Flexmock" do
@@ -24,7 +24,7 @@ Feature: mock with flexmock
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :flexmock
+        config.mock_with :flexmock
       end
 
       RSpec.describe "mocking with Flexmock" do
@@ -41,7 +41,7 @@ Feature: mock with flexmock
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :flexmock
+        config.mock_with :flexmock
       end
 
       RSpec.describe "failed message expectation in a pending example" do
@@ -60,7 +60,7 @@ Feature: mock with flexmock
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :flexmock
+        config.mock_with :flexmock
       end
 
       RSpec.describe "passing message expectation in a pending example" do
@@ -81,7 +81,7 @@ Feature: mock with flexmock
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :flexmock
+        config.mock_with :flexmock
       end
 
       RSpec.describe "RSpec.configuration.mock_framework.framework_name" do

--- a/features/mock_framework_integration/use_mocha.feature
+++ b/features/mock_framework_integration/use_mocha.feature
@@ -6,7 +6,7 @@ Feature: mock with mocha
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :mocha
+        config.mock_with :mocha
       end
 
       RSpec.describe "mocking with RSpec" do
@@ -24,7 +24,7 @@ Feature: mock with mocha
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :mocha
+        config.mock_with :mocha
       end
 
       RSpec.describe "mocking with RSpec" do
@@ -41,7 +41,7 @@ Feature: mock with mocha
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :mocha
+        config.mock_with :mocha
       end
 
       RSpec.describe "failed message expectation in a pending example" do
@@ -60,7 +60,7 @@ Feature: mock with mocha
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :mocha
+        config.mock_with :mocha
       end
 
       RSpec.describe "passing message expectation in a pending example" do
@@ -81,7 +81,7 @@ Feature: mock with mocha
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :mocha
+        config.mock_with :mocha
       end
 
       RSpec.describe "RSpec.configuration.mock_framework.framework_name" do

--- a/features/mock_framework_integration/use_rr.feature
+++ b/features/mock_framework_integration/use_rr.feature
@@ -6,7 +6,7 @@ Feature: mock with rr
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rr
+        config.mock_with :rr
       end
 
       RSpec.describe "mocking with RSpec" do
@@ -24,7 +24,7 @@ Feature: mock with rr
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rr
+        config.mock_with :rr
       end
 
       RSpec.describe "mocking with RSpec" do
@@ -41,7 +41,7 @@ Feature: mock with rr
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rr
+        config.mock_with :rr
       end
 
       RSpec.describe "failed message expectation in a pending example" do
@@ -60,7 +60,7 @@ Feature: mock with rr
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rr
+        config.mock_with :rr
       end
 
       RSpec.describe "passing message expectation in a pending example" do
@@ -81,7 +81,7 @@ Feature: mock with rr
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rr
+        config.mock_with :rr
       end
 
       RSpec.describe "RSpec.configuration.mock_framework.framework_name" do

--- a/features/mock_framework_integration/use_rspec.feature
+++ b/features/mock_framework_integration/use_rspec.feature
@@ -7,7 +7,7 @@ Feature: mock with rspec
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rspec
+        config.mock_with :rspec
       end
 
       RSpec.describe "mocking with RSpec" do
@@ -25,7 +25,7 @@ Feature: mock with rspec
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rspec
+        config.mock_with :rspec
       end
 
       RSpec.describe "mocking with RSpec" do
@@ -42,7 +42,7 @@ Feature: mock with rspec
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rspec
+        config.mock_with :rspec
       end
 
       RSpec.describe "failed message expectation in a pending example" do
@@ -61,7 +61,7 @@ Feature: mock with rspec
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rspec
+        config.mock_with :rspec
       end
 
       RSpec.describe "passing message expectation in a pending example" do
@@ -82,7 +82,7 @@ Feature: mock with rspec
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rspec
+        config.mock_with :rspec
       end
 
       RSpec.describe "RSpec.configuration.mock_framework.framework_name" do
@@ -98,7 +98,7 @@ Feature: mock with rspec
     Given a file named "example_spec.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.mock_framework = :rspec
+        config.mock_with :rspec
       end
 
       RSpec.describe "Testing" do


### PR DESCRIPTION
Both work but the latter is the way we document the
config elsewhere, so it's worth standardizing here.