### PR TITLE
Add `RSpec::Core::MemoizedHelpers.will_be_expected`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,8 @@ Enhancements:
 * When invalid options are parsed, notify users where they came from
   (e.g. `.rspec` or `~/.rspec` or `ENV['SPEC_OPTS']`) so they can
   easily find the source of the problem. (Myron Marston, #1940)
+* Add `RSpec::Core::MemoizedHelpers.will_be_expected` for wrapping subject
+  to `expect { subject }` (Dmitry Gritsay)
 
 Bug Fixes:
 

--- a/features/subject/one_liner_syntax.feature
+++ b/features/subject/one_liner_syntax.feature
@@ -13,6 +13,8 @@ Feature: One-liner syntax
 
     * `is_expected` is defined simply as `expect(subject)` and is designed for
       when you are using rspec-expectations with its newer expect-based syntax.
+    * `will_be_expected` is similar to `is_expected` and defined
+       as `expect { subject }`
     * `should` was designed back when rspec-expectations only had a should-based
       syntax. However, it continues to be available and work even if the
       `:should` syntax is disabled (since that merely removes `Object#should`
@@ -70,3 +72,24 @@ Feature: One-liner syntax
            should not be empty
            should not be empty
        """
+
+  Scenario: Explicit subject
+   Given a file named "example_spec.rb" with:
+     """ruby
+     class SimplePrinter
+       def initialize
+         print "Printer is ready"
+       end
+     end
+
+     RSpec.describe SimplePrinter do
+       it { will_be_expected.to output("Printer is ready").to_stdout }
+     end
+     """
+   When I run `rspec example_spec.rb --format doc`
+   Then the examples should all pass
+    And the output should contain:
+      """
+      SimplePrinter
+        should output "Printer is ready" to stdout
+      """

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -119,6 +119,33 @@ module RSpec
         expect(subject)
       end
 
+      # Wraps the `subject` in `expect` with block to make it the target
+      # of an expectation.
+      # Designed to easily use expectations with blocks for one-liners.
+      #
+      # @example
+
+      #   describe UserFactory do
+      #     subject { UserFactory.create_user }
+      #
+      #     it { will_be_expected.to change(User.count).by(1) }
+      #     it { will_be_expected.to output.to_stdout }
+      #
+      #     context 'with database issues' do
+      #       it { will_be_expected.to output.to_stderr }
+      #       it { will_be_expected.to raise_error }
+      #     end
+      #   end
+      #
+      # @see #subject
+      # @see #should
+      # @see #is_expected
+      #
+      # @note This only works if you are using rspec-expectations.
+      def will_be_expected
+        expect { subject }
+      end
+
       # @private
       # should just be placed in private section,
       # but Ruby issues warnings on private attributes.

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1663,7 +1663,7 @@ module RSpec::Core
       # for users. RSpec internals should not add methods here, though.
       expect(rspec_core_methods.map(&:to_sym)).to contain_exactly(
         :described_class, :subject,
-        :is_expected, :should, :should_not,
+        :is_expected, :will_be_expected, :should, :should_not,
         :pending, :skip,
         :setup_mocks_for_rspec, :teardown_mocks_for_rspec, :verify_mocks_for_rspec
       )


### PR DESCRIPTION
Create an alias `RSpec::Core::MemoizedHelpers.will_be_expected` to `expect { subject }`

Designed to prettify one-liners when you have block expectations for subject, e.g.

```ruby
class SimplePrinter
  def initialize
    print "Printer is ready"
  end
end
```

This goes to

```ruby
it { will_be_expected.to output("Printer is ready").to_stdout }
```

instead of

```ruby
specify { expect { subject }.to output("Printer is ready").to_stdout }
```

For more complicated cases:

```ruby
describe UserFactory do
  subject { UserFactory.create_user }

  it { will_be_expected.to change(User.count).by(1) }
  it { will_be_expected.to output.to_stdout }

  context 'with database issues' do
    it { will_be_expected.to output.to_stderr }
    it { will_be_expected.to raise_error }
  end
end
```

So this change allows to DRY up, prettify and make specs even more readable.

Do you have any suggestions?