### PR TITLE
Allows user code to retain references to memoized helpers

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -225,10 +225,7 @@ module RSpec
         rescue Exception => e
           set_exception(e)
         ensure
-          ExampleGroup.each_instance_variable_for_example(@example_group_instance) do |ivar|
-            @example_group_instance.instance_variable_set(ivar, nil)
-          end
-          @example_group_instance = nil
+          @example_group_instance = nil # if you love something... let it go
         end
 
         finish(reporter)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,15 +31,15 @@ Dir['./spec/support/**/*.rb'].map do |file|
   require file.gsub("./spec/support", "support")
 end
 
-  class RaiseOnFailuresReporter < RSpec::Core::NullReporter
-    def self.example_failed(example)
-      raise example.exception
-    end
+class RaiseOnFailuresReporter < RSpec::Core::NullReporter
+  def self.example_failed(example)
+    raise example.exception
   end
+end
 
 module CommonHelpers
-  def describe_successfully(&describe_body)
-    example_group    = RSpec.describe(&describe_body)
+  def describe_successfully(description="", &describe_body)
+    example_group    = RSpec.describe(description, &describe_body)
     ran_successfully = example_group.run RaiseOnFailuresReporter
     expect(ran_successfully).to eq true
     example_group


### PR DESCRIPTION
Accomplish this by no longer clearing the example's ivars.

Fixes rspec/rspec-core#1921

Context
-------

* Originally clearing ivars due to memory leak:
  https://github.com/rspec/rspec-core/issues/321
* Threadsafe memoized helpers caused `__memoized` to stop lazily initializing:
  https://github.com/rspec/rspec-core/issues/321
* This caused it to be permawiped by by the resetting of the example's ivars:
  https://github.com/rspec/rspec-core/issues/1921

However, this patch tests the behaviour of the memory leak,
rather than its mechanics, which shows that it was fixed at some point.
So we simply remove that code.