### PR TITLE
Refactor example creation.

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -142,8 +142,9 @@ module RSpec
           options.update(:skip => RSpec::Core::Pending::NOT_YET_IMPLEMENTED) unless block
           options.update(extra_options)
 
-          examples << RSpec::Core::Example.new(self, desc, options, block)
-          examples.last
+          example = RSpec::Core::Example.new(self, desc, options, block)
+          examples << example
+          example
         end
       end
 


### PR DESCRIPTION
- Remove unnecessary `Array#last` call.
- This version is threadsafe, whereas the prior
  version wasn’t.  Consider what would happen if
  another thread added an example to the `examples`
  array while this was happening: it would have returned
  a different example than the one created here. We don’t
  actually do any multithreading when examples are defined,
  and have no plans to do so, but it’s always nice to make
  things more threadsafe.