### PR TITLE
More helpful assertions on memory leak test

### DIFF
--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -369,7 +369,13 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
         expect {
           GC.enable
           GC.start :full_mark => true, :immediate_sweep => true
-        }.to change { ObjectSpace.each_object(garbage).count }.from(8).to(0)
+        }.to change {
+          ObjectSpace.each_object(garbage).map(&:defined_in).map(&:to_s).sort
+        }.from(%w[
+          after_all  after_each  after_each
+          before_all before_each before_each
+          failing_example passing_example
+        ]).to([])
       end
 
       it 'can still be referenced by user code afterwards' do


### PR DESCRIPTION
The test for a memory leak failed on CI https://travis-ci.org/rspec/rspec-core/jobs/61159415, saying "expected result to have changed to 0, but is now 1"

This updates it so that future failures will tell us which one was not garbage collected.

See https://github.com/rspec/rspec-core/pull/1950#issuecomment-98784821 for more details.

I'll look into the issue in more detail soonish (its assessment week, so students are super stressed right now, and I'm doing a lot of [mindless coding](https://github.com/JoshCheek/animated-gif-in-the-terminal) to keep from catching it).