### PR TITLE
Use :rerun_file_path when checking location filters

### DIFF
--- a/lib/rspec/core/filter_manager.rb
+++ b/lib/rspec/core/filter_manager.rb
@@ -99,8 +99,10 @@ module RSpec
       # defined in the same file as the location filters. Excluded specs in
       # other files should still be excluded.
       def file_scoped_include?(ex_metadata, ids, locations)
-        no_location_filters = locations[ex_metadata[:absolute_file_path]].empty?
         no_id_filters = ids[ex_metadata[:rerun_file_path]].empty?
+        no_location_filters = locations[
+          File.expand_path(ex_metadata[:rerun_file_path])
+        ].empty?
 
         return yield if no_location_filters && no_id_filters
 


### PR DESCRIPTION
Fixes #1961

The problem with using `:absolute_file_path` is that it doesn't function
correctly for shared examples in an external file. The filter manager thinks
that there are no location filters set, when actually there are.

Since `MetadataFilter` already handles location filtering correctly across multiple
nested examples / files, correcting the path that is checked is sufficient to
fix the line filtering issue.