### PR TITLE
Failure aggregation fixes

### DIFF
--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -43,110 +43,19 @@ module RSpec::Core
         return SkippedExampleNotification.new(example) if execution_result.example_skipped?
         return new(example) unless execution_result.status == :pending || execution_result.status == :failed
 
-        klass = FailedExampleNotification
-        exception = execution_result.exception
-        ex_presenter_options = {}
+        klass = if execution_result.pending_fixed?
+                  PendingExampleFixedNotification
+                elsif execution_result.status == :pending
+                  PendingExampleFailedAsExpectedNotification
+                else
+                  FailedExampleNotification
+                end
 
-        if execution_result.pending_fixed?
-          klass = PendingExampleFixedNotification
-          ex_presenter_options = {
-            :description_formatter => Proc.new { "#{example.full_description} FIXED" },
-            :message_color         => RSpec.configuration.fixed_color,
-            :failure_lines         => ["Expected pending '#{execution_result.pending_message}' to fail. No Error was raised."]
-          }
-        elsif execution_result.status == :pending
-          klass = PendingExampleFailedAsExpectedNotification
-          exception = example.execution_result.pending_exception
-          ex_presenter_options = {
-            :message_color    => RSpec.configuration.pending_color,
-            :detail_formatter => PENDING_DETAIL_FORMATTER
-          }
-        end
-
-        if multiple_exceptions_not_met_error?(exception)
-          ex_presenter_options = exception_presenter_opts_for_multiple_error(
-            exception, example, ex_presenter_options
-          )
-        end
-
-        ex_presenter = Formatters::ExceptionPresenter.new(exception, example, ex_presenter_options)
-        klass.new(example, ex_presenter)
+        exception_presenter = Formatters::ExceptionPresenter::Factory.new(example).build
+        klass.new(example, exception_presenter)
       end
 
-      def self.exception_presenter_opts_for_multiple_error(exception, example, options)
-        ex_presenter_options = options.merge(
-          :failure_lines          => [],
-          :extra_detail_formatter => sub_failure_list_formatter(exception, example,
-                                                                options[:message_color]),
-          :detail_formatter       => multiple_failure_sumarizer(exception,
-                                                                options[:detail_formatter],
-                                                                options[:message_color])
-        )
-
-        ex_presenter_options[:description_formatter] &&= Proc.new {}
-
-        if exception.aggregation_metadata[:from_around_hook]
-          ex_presenter_options[:backtrace_formatter] = EmptyBacktraceFormatter
-        end
-
-        ex_presenter_options
-      end
-
-      # @private
-      # Used to prevent a confusing backtrace from showing up from the `aggregate_failures`
-      # block declared for `:aggregate_failures` metadata.
-      module EmptyBacktraceFormatter
-        def self.format_backtrace(*)
-          []
-        end
-      end
-
-      def self.multiple_exceptions_not_met_error?(exception)
-        return false unless defined?(RSpec::Expectations::MultipleExpectationsNotMetError)
-        RSpec::Expectations::MultipleExpectationsNotMetError === exception
-      end
-
-      def self.multiple_failure_sumarizer(exception, prior_detail_formatter, color)
-        lambda do |example, colorizer, indentation|
-          summary = if exception.aggregation_metadata[:from_around_hook]
-                      "Got #{exception.exception_count_description}:"
-                    else
-                      "#{exception.summary}."
-                    end
-
-          summary = colorizer.wrap(summary, color || RSpec.configuration.failure_color)
-          return summary unless prior_detail_formatter
-          "#{prior_detail_formatter.call(example, colorizer, indentation)}\n#{indentation}#{summary}"
-        end
-      end
-
-      def self.sub_failure_list_formatter(exception, example, message_color)
-        lambda do |failure_number, colorizer, indentation|
-          exception.all_exceptions.each_with_index.map do |failure, index|
-            options = {
-              :description_formatter   => :failure_slash_error_line.to_proc,
-              :indentation             => indentation.length,
-              :message_color           => message_color || RSpec.configuration.failure_color,
-              :skip_shared_group_trace => true
-            }
-
-            if multiple_exceptions_not_met_error?(failure)
-              options = exception_presenter_opts_for_multiple_error(failure, example, options)
-            end
-
-            failure = failure.dup
-            failure.set_backtrace(failure.backtrace[0..-exception.backtrace.size])
-
-            Formatters::ExceptionPresenter.new(
-              failure, example, options
-            ).fully_formatted("#{failure_number}.#{index + 1}", colorizer)
-          end.join
-        end
-      end
-
-      private_class_method :new, :multiple_exceptions_not_met_error?,
-                           :multiple_failure_sumarizer, :sub_failure_list_formatter,
-                           :exception_presenter_opts_for_multiple_error
+      private_class_method :new
     end
 
     # The `ExamplesNotification` represents notifications sent by the reporter
@@ -305,11 +214,6 @@ module RSpec::Core
     # @deprecated Use {FailedExampleNotification} instead.
     class PendingExampleFailedAsExpectedNotification < FailedExampleNotification; end
 
-    # @private
-    PENDING_DETAIL_FORMATTER = Proc.new do |example, colorizer|
-      colorizer.wrap("# #{example.execution_result.pending_message}", :detail)
-    end
-
     # The `SkippedExampleNotification` extends `ExampleNotification` with
     # things useful for specs that are skipped.
     #
@@ -322,9 +226,9 @@ module RSpec::Core
       #   RSpec's built-in formatters emit.
       def fully_formatted(pending_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted_caller = RSpec.configuration.backtrace_formatter.backtrace_line(example.location)
-        colorizer.wrap("\n  #{pending_number}) #{example.full_description}", :pending) <<
-          "\n     " << PENDING_DETAIL_FORMATTER.call(example, colorizer) << "\n" <<
-          colorizer.wrap("     # #{formatted_caller}\n", :detail)
+        colorizer.wrap("\n  #{pending_number}) #{example.full_description}", :pending) << "\n     " <<
+          Formatters::ExceptionPresenter::PENDING_DETAIL_FORMATTER.call(example, colorizer) <<
+          "\n" << colorizer.wrap("     # #{formatted_caller}\n", :detail)
       end
     end
 


### PR DESCRIPTION
These are some fixes necessary for rspec/rspec-support#210 in order to support rspec/rspec-mocks#956.

I also heavily refactored the exception presenter creation; it was very messy before.  Still a bit messy but much improved.