### PR TITLE
Add fallback formatter for #message

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -47,6 +47,8 @@ Enhancements:
   `aggregate_failures` feature to allow multiple failures in an example
   and list them all, rather than aborting on the first failure. (Myron
   Marston, #1946)
+* When no formatter implements #message add a fallback to prevent those
+  messages being lost. (Jon Rowe, #1980)
 
 Bug Fixes:
 

--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -66,13 +66,13 @@ RSpec::Support.require_rspec_support "directory_maker"
 # @see RSpec::Core::Formatters::BaseTextFormatter
 # @see RSpec::Core::Reporter
 module RSpec::Core::Formatters
-  autoload :DocumentationFormatter, 'rspec/core/formatters/documentation_formatter'
-  autoload :HtmlFormatter,          'rspec/core/formatters/html_formatter'
-  autoload :MessageFormatter,       'rspec/core/formatters/message_formatter'
-  autoload :ProgressFormatter,      'rspec/core/formatters/progress_formatter'
-  autoload :ProfileFormatter,       'rspec/core/formatters/profile_formatter'
-  autoload :JsonFormatter,          'rspec/core/formatters/json_formatter'
-  autoload :BisectFormatter,        'rspec/core/formatters/bisect_formatter'
+  autoload :DocumentationFormatter,   'rspec/core/formatters/documentation_formatter'
+  autoload :HtmlFormatter,            'rspec/core/formatters/html_formatter'
+  autoload :FallbackMessageFormatter, 'rspec/core/formatters/fallback_message_formatter'
+  autoload :ProgressFormatter,        'rspec/core/formatters/progress_formatter'
+  autoload :ProfileFormatter,         'rspec/core/formatters/profile_formatter'
+  autoload :JsonFormatter,            'rspec/core/formatters/json_formatter'
+  autoload :BisectFormatter,          'rspec/core/formatters/bisect_formatter'
 
   # Register the formatter class
   # @param formatter_class [Class] formatter class to register
@@ -123,7 +123,7 @@ module RSpec::Core::Formatters
       end
 
       unless existing_formatter_implements?(:message)
-        add MessageFormatter, output_stream
+        add FallbackMessageFormatter, output_stream
       end
 
       return unless RSpec.configuration.profile_examples? && !existing_formatter_implements?(:dump_profile)

--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -68,6 +68,7 @@ RSpec::Support.require_rspec_support "directory_maker"
 module RSpec::Core::Formatters
   autoload :DocumentationFormatter, 'rspec/core/formatters/documentation_formatter'
   autoload :HtmlFormatter,          'rspec/core/formatters/html_formatter'
+  autoload :MessageFormatter,       'rspec/core/formatters/message_formatter'
   autoload :ProgressFormatter,      'rspec/core/formatters/progress_formatter'
   autoload :ProfileFormatter,       'rspec/core/formatters/profile_formatter'
   autoload :JsonFormatter,          'rspec/core/formatters/json_formatter'
@@ -119,6 +120,10 @@ module RSpec::Core::Formatters
 
       unless @formatters.any? { |formatter| DeprecationFormatter === formatter }
         add DeprecationFormatter, deprecation_stream, output_stream
+      end
+
+      unless existing_formatter_implements?(:message)
+        add MessageFormatter, output_stream
       end
 
       return unless RSpec.configuration.profile_examples? && !existing_formatter_implements?(:dump_profile)

--- a/lib/rspec/core/formatters/fallback_message_formatter.rb
+++ b/lib/rspec/core/formatters/fallback_message_formatter.rb
@@ -4,7 +4,7 @@ module RSpec
       # @api private
       # Formatter for providing message output as a fallback when no other
       # profiler implements #message
-      class MessageFormatter
+      class FallbackMessageFormatter
         Formatters.register self, :message
 
         def initialize(output)

--- a/lib/rspec/core/formatters/message_formatter.rb
+++ b/lib/rspec/core/formatters/message_formatter.rb
@@ -1,0 +1,28 @@
+module RSpec
+  module Core
+    module Formatters
+      # @api private
+      # Formatter for providing message output as a fallback when no other
+      # profiler implements #message
+      class MessageFormatter
+        Formatters.register self, :message
+
+        def initialize(output)
+          @output = output
+        end
+
+        # @private
+        attr_reader :output
+
+        # @api public
+        #
+        # Used by the reporter to send messages to the output stream.
+        #
+        # @param notification [MessageNotification] containing message
+        def message(notification)
+          output.puts notification.message
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/core/formatters/fallback_message_formatter_spec.rb
+++ b/spec/rspec/core/formatters/fallback_message_formatter_spec.rb
@@ -1,0 +1,18 @@
+require 'rspec/core/reporter'
+require 'rspec/core/formatters/fallback_message_formatter'
+
+module RSpec::Core::Formatters
+  RSpec.describe FallbackMessageFormatter do
+    include FormatterSupport
+
+    describe "#message" do
+      it 'writes the message to the output' do
+        expect {
+          send_notification :message, message_notification('Custom Message')
+        }.to change { formatter_output.string }.
+          from(excluding 'Custom Message').
+          to(including 'Custom Message')
+      end
+    end
+  end
+end

--- a/spec/rspec/core/formatters_spec.rb
+++ b/spec/rspec/core/formatters_spec.rb
@@ -138,7 +138,7 @@ module RSpec::Core::Formatters
           allow(reporter).to receive(:registered_listeners).with(:message) { [:json] }
           setup_default
           expect(loader.formatters).to exclude(
-            an_instance_of ::RSpec::Core::Formatters::MessageFormatter
+            an_instance_of ::RSpec::Core::Formatters::FallbackMessageFormatter
           )
         end
       end
@@ -149,8 +149,8 @@ module RSpec::Core::Formatters
           expect {
             setup_default
           }.to change { loader.formatters }.
-            from( excluding an_instance_of ::RSpec::Core::Formatters::MessageFormatter ).
-            to( including an_instance_of ::RSpec::Core::Formatters::MessageFormatter )
+            from( excluding an_instance_of ::RSpec::Core::Formatters::FallbackMessageFormatter ).
+            to( including an_instance_of ::RSpec::Core::Formatters::FallbackMessageFormatter )
         end
       end
 

--- a/spec/rspec/core/formatters_spec.rb
+++ b/spec/rspec/core/formatters_spec.rb
@@ -130,28 +130,52 @@ module RSpec::Core::Formatters
       end
     end
 
-    describe "#setup_default", "with profiling enabled" do
+    describe "#setup_default" do
       let(:setup_default) { loader.setup_default output, output }
 
-      before do
-        allow(RSpec.configuration).to receive(:profile_examples?) { true }
-      end
-
-      context "without an existing profile formatter" do
-        it "will add the profile formatter" do
-          allow(reporter).to receive(:registered_listeners).with(:dump_profile) { [] }
+      context "with a formatter that implements #message" do
+        it 'doesnt add a fallback formatter' do
+          allow(reporter).to receive(:registered_listeners).with(:message) { [:json] }
           setup_default
-          expect(loader.formatters.last).to be_a ::RSpec::Core::Formatters::ProfileFormatter
+          expect(loader.formatters).to exclude(
+            an_instance_of ::RSpec::Core::Formatters::MessageFormatter
+          )
         end
       end
 
-      context "when a formatter that implement #dump_profile is added" do
-        it "wont add the profile formatter" do
-          allow(reporter).to receive(:registered_listeners).with(:dump_profile) { [:json] }
-          setup_default
-          expect(
-            loader.formatters.map(&:class)
-          ).to_not include ::RSpec::Core::Formatters::ProfileFormatter
+      context "without a formatter that implements #message" do
+        it 'adds a fallback for message output' do
+          allow(reporter).to receive(:registered_listeners).with(:message) { [] }
+          expect {
+            setup_default
+          }.to change { loader.formatters }.
+            from( excluding an_instance_of ::RSpec::Core::Formatters::MessageFormatter ).
+            to( including an_instance_of ::RSpec::Core::Formatters::MessageFormatter )
+        end
+      end
+
+      context "with profiling enabled" do
+        before do
+          allow(reporter).to receive(:registered_listeners).with(:message) { [:json] }
+          allow(RSpec.configuration).to receive(:profile_examples?) { true }
+        end
+
+        context "without an existing profile formatter" do
+          it "will add the profile formatter" do
+            allow(reporter).to receive(:registered_listeners).with(:dump_profile) { [] }
+            setup_default
+            expect(loader.formatters.last).to be_a ::RSpec::Core::Formatters::ProfileFormatter
+          end
+        end
+
+        context "when a formatter that implement #dump_profile is added" do
+          it "wont add the profile formatter" do
+            allow(reporter).to receive(:registered_listeners).with(:dump_profile) { [:json] }
+            setup_default
+            expect(
+              loader.formatters.map(&:class)
+            ).to_not include ::RSpec::Core::Formatters::ProfileFormatter
+          end
         end
       end
     end

--- a/spec/rspec/core/formatters_spec.rb
+++ b/spec/rspec/core/formatters_spec.rb
@@ -163,8 +163,11 @@ module RSpec::Core::Formatters
         context "without an existing profile formatter" do
           it "will add the profile formatter" do
             allow(reporter).to receive(:registered_listeners).with(:dump_profile) { [] }
-            setup_default
-            expect(loader.formatters.last).to be_a ::RSpec::Core::Formatters::ProfileFormatter
+            expect {
+              setup_default
+            }.to change { loader.formatters }.
+              from( excluding an_instance_of ::RSpec::Core::Formatters::ProfileFormatter ).
+              to( including an_instance_of ::RSpec::Core::Formatters::ProfileFormatter )
           end
         end
 

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -121,4 +121,5 @@ RSpec::Matchers.alias_matcher :a_file_collection, :contain_files
 
 RSpec::Matchers.define_negated_matcher :avoid_outputting, :output
 RSpec::Matchers.define_negated_matcher :exclude, :include
+RSpec::Matchers.define_negated_matcher :excluding, :include
 RSpec::Matchers.define_negated_matcher :avoid_changing,   :change


### PR DESCRIPTION
Add a new  `MessageFormatter` as a fallback when no other formatter in use implements `#message`

Fixes #1978