### PR TITLE
stop 70 being displayed as 1 minute 1 second

### DIFF
--- a/lib/rspec/core/formatters/helpers.rb
+++ b/lib/rspec/core/formatters/helpers.rb
@@ -67,6 +67,9 @@ module RSpec
         #
         # Remove trailing zeros from a string.
         #
+        # Only remove trailing zeros after a decimal place.
+        # see: http://rubular.com/r/ojtTydOgpn
+        #
         # @param string [String] string with trailing zeros
         # @return [String] string with trailing zeros removed
         def self.strip_trailing_zeroes(string)

--- a/lib/rspec/core/formatters/helpers.rb
+++ b/lib/rspec/core/formatters/helpers.rb
@@ -70,8 +70,7 @@ module RSpec
         # @param string [String] string with trailing zeros
         # @return [String] string with trailing zeros removed
         def self.strip_trailing_zeroes(string)
-          stripped = string.sub(/[^1-9]+$/, '')
-          stripped.empty? ? "0" : stripped
+          string.sub(/(?:(\..*[^0])0+|\.0+)$/, '\1')
         end
         private_class_method :strip_trailing_zeroes
 

--- a/spec/rspec/core/formatters/helpers_spec.rb
+++ b/spec/rspec/core/formatters/helpers_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RSpec::Core::Formatters::Helpers do
         expect(helper.format_duration(1)).to eq("1 second")
       end
     end
-    
+
     context '= 70' do
       it "returns 'x minute, x0 seconds' formatted string" do
         expect(helper.format_duration(70)).to eq("1 minute 10 seconds")
@@ -91,7 +91,7 @@ RSpec.describe RSpec::Core::Formatters::Helpers do
 
       context "70" do
         it "doesn't strip of meaningful trailing zeros" do
-          expect(helper.format_seconds(70)).to eq("70") 
+          expect(helper.format_seconds(70)).to eq("70")
         end
       end
     end

--- a/spec/rspec/core/formatters/helpers_spec.rb
+++ b/spec/rspec/core/formatters/helpers_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe RSpec::Core::Formatters::Helpers do
         expect(helper.format_duration(1)).to eq("1 second")
       end
     end
+    
+    context '= 70' do
+      it "returns 'x minute, x0 seconds' formatted string" do
+        expect(helper.format_duration(70)).to eq("1 minute 10 seconds")
+      end
+    end
 
     context 'with mathn loaded' do
       include MathnIntegrationSupport
@@ -80,6 +86,12 @@ RSpec.describe RSpec::Core::Formatters::Helpers do
       context "> 1" do
         it "strips off trailing zeroes" do
           expect(helper.format_seconds(1.00000000001)).to eq("1")
+        end
+      end
+
+      context "70" do
+        it "doesn't strip of meaningful trailing zeros" do
+          expect(helper.format_seconds(70)).to eq("70") 
         end
       end
     end


### PR DESCRIPTION
70 seconds was having trailing 0's stripped so shown as 1 minute, 1 second. Changed the helper regex, based on this SO answer: http://stackoverflow.com/a/4913031/671422 