### PR TITLE
More multi failures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -51,6 +51,8 @@ Enhancements:
   messages being lost. (Jon Rowe, #1980)
 * Profiling examples now takes into account time spent in `before(:context)`
   hooks. (Denis Laliberté, Jon Rowe, #1971)
+* Improve failure output when an example has multiple exceptions, such
+  as one from an `it` block and one from an `after` block. (Myron Marston, #1985)
 
 Bug Fixes:
 

--- a/features/expectation_framework_integration/aggregating_failures.feature
+++ b/features/expectation_framework_integration/aggregating_failures.feature
@@ -13,7 +13,7 @@ Feature: Aggregating Failures
       Response = Struct.new(:status, :headers, :body)
 
       class Client
-        def self.make_request
+        def self.make_request(url='/')
           Response.new(404, { "Content-Type" => "text/plain" }, "Not Found")
         end
       end
@@ -25,6 +25,17 @@ Feature: Aggregating Failures
       require 'client'
 
       RSpec.describe Client do
+        after do
+          # this should be appended to failure list
+          expect(false).to be(true), "after hook failure"
+        end
+
+        around do |ex|
+          ex.run
+          # this should also be appended to failure list
+          expect(false).to be(true), "around hook failure"
+        end
+
         it "returns a successful response" do
           response = Client.make_request
 
@@ -42,32 +53,44 @@ Feature: Aggregating Failures
       Failures:
 
         1) Client returns a successful response
-           Got 3 failures from failure aggregation block "testing reponse".
-           # ./spec/use_block_form_spec.rb:7
+           Got 3 failures:
 
-           1.1) Failure/Error: expect(response.status).to eq(200)
+           1.1) Got 3 failures from failure aggregation block "testing reponse".
+                # ./spec/use_block_form_spec.rb:18:in `block (2 levels) in <top (required)>'
+                # ./spec/use_block_form_spec.rb:10:in `block (2 levels) in <top (required)>'
 
-                  expected: 200
-                       got: 404
+                1.1.1) Failure/Error: expect(response.status).to eq(200)
 
-                  (compared using ==)
-                # ./spec/use_block_form_spec.rb:8
+                         expected: 200
+                              got: 404
 
-           1.2) Failure/Error: expect(response.headers).to include("Content-Type" => "application/json")
-                  expected {"Content-Type" => "text/plain"} to include {"Content-Type" => "application/json"}
-                  Diff:
-                  @@ -1,2 +1,2 @@
-                  -[{"Content-Type"=>"application/json"}]
-                  +"Content-Type" => "text/plain",
-                # ./spec/use_block_form_spec.rb:9
+                         (compared using ==)
+                       # ./spec/use_block_form_spec.rb:19:in `block (3 levels) in <top (required)>'
 
-           1.3) Failure/Error: expect(response.body).to eq('{"message":"Success"}')
+                1.1.2) Failure/Error: expect(response.headers).to include("Content-Type" => "application/json")
+                         expected {"Content-Type" => "text/plain"} to include {"Content-Type" => "application/json"}
+                         Diff:
+                         @@ -1,2 +1,2 @@
+                         -[{"Content-Type"=>"application/json"}]
+                         +"Content-Type" => "text/plain",
+                       # ./spec/use_block_form_spec.rb:20:in `block (3 levels) in <top (required)>'
 
-                  expected: "{\"message\":\"Success\"}"
-                       got: "Not Found"
+                1.1.3) Failure/Error: expect(response.body).to eq('{"message":"Success"}')
 
-                  (compared using ==)
-                # ./spec/use_block_form_spec.rb:10
+                         expected: "{\"message\":\"Success\"}"
+                              got: "Not Found"
+
+                         (compared using ==)
+                       # ./spec/use_block_form_spec.rb:21:in `block (3 levels) in <top (required)>'
+
+           1.2) Failure/Error: expect(false).to be(true), "after hook failure"
+                  after hook failure
+                # ./spec/use_block_form_spec.rb:6:in `block (2 levels) in <top (required)>'
+                # ./spec/use_block_form_spec.rb:10:in `block (2 levels) in <top (required)>'
+
+           1.3) Failure/Error: expect(false).to be(true), "around hook failure"
+                  around hook failure
+                # ./spec/use_block_form_spec.rb:12:in `block (2 levels) in <top (required)>'
       """
 
   Scenario: Use `:aggregate_failures` metadata

--- a/features/expectation_framework_integration/aggregating_failures.feature
+++ b/features/expectation_framework_integration/aggregating_failures.feature
@@ -300,3 +300,53 @@ Feature: Aggregating Failures
                 # ./spec/mock_expectation_failure_spec.rb:6
 
       """
+
+  Scenario: Pending integrates properly with aggregated failures
+    Given a file named "spec/pending_spec.rb" with:
+      """ruby
+      require 'client'
+
+      RSpec.describe Client do
+        it "returns a successful response", :aggregate_failures do
+          pending "Not yet ready"
+          response = Client.make_request
+
+          expect(response.status).to eq(200)
+          expect(response.headers).to include("Content-Type" => "application/json")
+          expect(response.body).to eq('{"message":"Success"}')
+        end
+      end
+      """
+    When I run `rspec spec/pending_spec.rb`
+    Then it should pass and list all the pending examples:
+      """
+      Pending: (Failures listed here are expected and do not affect your suite's status)
+
+        1) Client returns a successful response
+           # Not yet ready
+           Got 3 failures:
+
+           1.1) Failure/Error: expect(response.status).to eq(200)
+
+                  expected: 200
+                       got: 404
+
+                  (compared using ==)
+                # ./spec/pending_spec.rb:8:in `block (2 levels) in <top (required)>'
+
+           1.2) Failure/Error: expect(response.headers).to include("Content-Type" => "application/json")
+                  expected {"Content-Type" => "text/plain"} to include {"Content-Type" => "application/json"}
+                  Diff:
+                  @@ -1,2 +1,2 @@
+                  -[{"Content-Type"=>"application/json"}]
+                  +"Content-Type" => "text/plain",
+                # ./spec/pending_spec.rb:9:in `block (2 levels) in <top (required)>'
+
+           1.3) Failure/Error: expect(response.body).to eq('{"message":"Success"}')
+
+                  expected: "{\"message\":\"Success\"}"
+                       got: "Not Found"
+
+                  (compared using ==)
+                # ./spec/pending_spec.rb:10:in `block (2 levels) in <top (required)>'
+      """

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -192,6 +192,11 @@ Then(/^it should fail and list all the failures:$/) do |string|
   expect(normalize_whitespace_and_backtraces(all_output)).to include(normalize_whitespace_and_backtraces(string))
 end
 
+Then(/^it should pass and list all the pending examples:$/) do |string|
+  step %q{the exit status should be 0}
+  expect(normalize_whitespace_and_backtraces(all_output)).to include(normalize_whitespace_and_backtraces(string))
+end
+
 module WhitespaceNormalization
   def normalize_whitespace_and_backtraces(text)
     text.lines.map { |line| line.sub(/\s+$/, '').sub(/:in .*$/, '') }.join

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -189,19 +189,25 @@ end
 
 Then(/^it should fail and list all the failures:$/) do |string|
   step %q{the exit status should not be 0}
-  expect(normalize_whitespace_and_backtraces(all_output)).to include(normalize_whitespace_and_backtraces(string))
+  expect(normalize_failure_output(all_output)).to include(normalize_failure_output(string))
 end
 
 Then(/^it should pass and list all the pending examples:$/) do |string|
   step %q{the exit status should be 0}
-  expect(normalize_whitespace_and_backtraces(all_output)).to include(normalize_whitespace_and_backtraces(string))
+  expect(normalize_failure_output(all_output)).to include(normalize_failure_output(string))
 end
 
-module WhitespaceNormalization
-  def normalize_whitespace_and_backtraces(text)
-    text.lines.map { |line| line.sub(/\s+$/, '').sub(/:in .*$/, '') }.join
+module Normalization
+  def normalize_failure_output(text)
+    whitespace_normalized = text.lines.map { |line| line.sub(/\s+$/, '').sub(/:in .*$/, '') }.join
+
+    # 1.8.7 and JRuby produce slightly different output for `Hash#fetch` errors, so we
+    # convert it to the same output here to match our expectation.
+    whitespace_normalized.
+      sub("IndexError", "KeyError").
+      sub(/key not found.*$/, "key not found")
   end
 end
 
-World(WhitespaceNormalization)
+World(Normalization)
 World(FormatterSupport)

--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -31,7 +31,7 @@ module RSpec
       end
 
       def format_backtrace(backtrace, options={})
-        return backtrace if options[:full_backtrace]
+        return backtrace if options[:full_backtrace] || backtrace.empty?
 
         backtrace.map { |l| backtrace_line(l) }.compact.
           tap do |filtered|

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1736,7 +1736,7 @@ module RSpec
 
       def define_built_in_hooks
         around(:example, :aggregate_failures => true) do |ex|
-          aggregate_failures(nil, :from_around_hook => true, &ex)
+          aggregate_failures(nil, :hide_backtrace => true, &ex)
         end
       end
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -638,6 +638,13 @@ module RSpec
             framework
           when :rspec
             require 'rspec/expectations'
+
+            # Tag this exception class so our exception formatting logic knows
+            # that it satisfies the `MultipleExceptionError` interface.
+            ::RSpec::Expectations::MultipleExpectationsNotMetError.__send__(
+              :include, MultipleExceptionError::InterfaceTag
+            )
+
             ::RSpec::Matchers
           when :test_unit
             require 'rspec/core/test_unit_assertions_adapter'

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1742,8 +1742,12 @@ module RSpec
       end
 
       def define_built_in_hooks
-        around(:example, :aggregate_failures => true) do |ex|
-          aggregate_failures(nil, :hide_backtrace => true, &ex)
+        around(:example, :aggregate_failures => true) do |procsy|
+          begin
+            aggregate_failures(nil, :hide_backtrace => true, &procsy)
+          rescue Exception => exception
+            procsy.example.set_aggregate_failures_exception(exception)
+          end
         end
       end
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -341,13 +341,6 @@ module RSpec
       end
 
       # @private
-      def instance_exec_with_rescue(&block)
-        @example_group_instance.instance_exec(self, &block)
-      rescue Exception => e
-        set_exception(e)
-      end
-
-      # @private
       def instance_exec(*args, &block)
         @example_group_instance.instance_exec(*args, &block)
       end

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -316,6 +316,8 @@ module RSpec
       # the example or the `pending_exception` if the example is pending.
       def display_exception=(ex)
         if pending? && !(Pending::PendingExampleFixedError === ex)
+          @exception = nil
+          execution_result.pending_fixed = false
           execution_result.pending_exception = ex
         else
           @exception = ex
@@ -441,13 +443,7 @@ module RSpec
       def verify_mocks
         @example_group_instance.verify_mocks_for_rspec
       rescue Exception => e
-        if pending?
-          execution_result.pending_fixed = false
-          execution_result.pending_exception = e
-          @exception = nil
-        else
-          set_exception(e)
-        end
+        set_exception(e)
       end
 
       def assign_generated_description

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -408,7 +408,7 @@ module RSpec
       end
 
       def verify_mocks
-        @example_group_instance.verify_mocks_for_rspec if mocks_need_verification?
+        @example_group_instance.verify_mocks_for_rspec
       rescue Exception => e
         if pending?
           execution_result.pending_fixed = false
@@ -417,10 +417,6 @@ module RSpec
         else
           set_exception(e)
         end
-      end
-
-      def mocks_need_verification?
-        exception.nil? || execution_result.pending_fixed?
       end
 
       def assign_generated_description

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -305,6 +305,16 @@ module RSpec
         # @param exception [Exception] Exception to append to the list.
         # @private
         def add(exception)
+          # `PendingExampleFixedError` can be assigned to an example that initially has no
+          # failures, but when the `aggregate_failures` around hook completes, it notifies of
+          # a failure. If we do not ignore `PendingExampleFixedError` it would be surfaced to
+          # the user as part of a multiple exception error, which is undesirable. While it's
+          # pretty weird we handle this here, it's the best solution I've been able to come
+          # up with, and `PendingExampleFixedError` always represents the _lack_ of any exception
+          # so clearly when we are transitioning to a `MultipleExceptionError`, it makes sense to
+          # ignore it.
+          return if Pending::PendingExampleFixedError === exception
+
           all_exceptions << exception
 
           if exception.class.name =~ /RSpec/

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -313,6 +313,15 @@ module RSpec
             other_errors << exception
           end
         end
+
+        # Provides a way to force `ex` to be something that satisfies the multiple
+        # exception error interface. If it already satisfies it, it will be returned;
+        # otherwise it will wrap it in a `MultipleExceptionError`.
+        # @private
+        def self.for(ex)
+          return ex if self === ex
+          MultipleExceptionError.new(ex)
+        end
       end
 
       include InterfaceTag

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -196,9 +196,9 @@ module RSpec
             options = options.merge(
               :failure_lines          => [],
               :extra_detail_formatter => sub_failure_list_formatter(exception, options[:message_color]),
-              :detail_formatter       => multiple_exception_sumarizer(exception,
-                                                                      options[:detail_formatter],
-                                                                      options[:message_color])
+              :detail_formatter       => multiple_exception_summarizer(exception,
+                                                                       options[:detail_formatter],
+                                                                       options[:message_color])
             )
 
             options[:description_formatter] &&= Proc.new {}
@@ -212,11 +212,11 @@ module RSpec
             MultipleExceptionError::InterfaceTag === exception
           end
 
-          def multiple_exception_sumarizer(exception, prior_detail_formatter, color)
+          def multiple_exception_summarizer(exception, prior_detail_formatter, color)
             lambda do |example, colorizer, indentation|
               summary = if exception.aggregation_metadata[:hide_backtrace]
                           # Since the backtrace is hidden, the subfailures will come
-                          # immeidately after this, and using `:` will read well.
+                          # immediately after this, and using `:` will read well.
                           "Got #{exception.exception_count_description}:"
                         else
                           # The backtrace comes after this, so using a `:` doesn't make sense

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -203,7 +203,7 @@ module RSpec
 
             options[:description_formatter] &&= Proc.new {}
 
-            return options unless exception.aggregation_metadata[:from_around_hook]
+            return options unless exception.aggregation_metadata[:hide_backtrace]
             options[:backtrace_formatter] = EmptyBacktraceFormatter
             options
           end
@@ -215,9 +215,13 @@ module RSpec
 
           def multiple_failure_sumarizer(exception, prior_detail_formatter, color)
             lambda do |example, colorizer, indentation|
-              summary = if exception.aggregation_metadata[:from_around_hook]
+              summary = if exception.aggregation_metadata[:hide_backtrace]
+                          # Since the backtrace is hidden, the subfailures will come
+                          # immeidately after this, and using `:` will read well.
                           "Got #{exception.exception_count_description}:"
                         else
+                          # The backtrace comes after this, so using a `:` doesn't make sense
+                          # since the failures may be many lines below.
                           "#{exception.summary}."
                         end
 

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -300,7 +300,20 @@ module RSpec
       # and `RSpec::Expectations::MultipleExpectationsNotMetError`, which allows
       # code to detect exceptions that are instances of either, without first
       # checking to see if rspec-expectations is loaded.
-      InterfaceTag = Module.new
+      module InterfaceTag
+        # Appends the provided exception to the list.
+        # @param exception [Exception] Exception to append to the list.
+        # @private
+        def add(exception)
+          all_exceptions << exception
+
+          if exception.class.name =~ /RSpec/
+            failures << exception
+          else
+            other_errors << exception
+          end
+        end
+      end
 
       include InterfaceTag
 
@@ -331,18 +344,6 @@ module RSpec
         @aggregation_block_label = nil
 
         exceptions.each { |e| add e }
-      end
-
-      # Appends the provided exception to the list.
-      # @param exception [Exception] Exception to append to the list.
-      def add(exception)
-        @all_exceptions << exception
-
-        if exception.class.name =~ /RSpec/
-          @failures << exception
-        else
-          @other_errors << exception
-        end
       end
 
       # @return [String] Combines all the exception messages into a single string.

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -361,7 +361,9 @@ module RSpec
       # @private
       class AfterHook < Hook
         def run(example)
-          example.instance_exec_with_rescue(&block)
+          example.instance_exec(example, &block)
+        rescue Exception => ex
+          example.set_exception(ex)
         end
       end
 

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -361,7 +361,7 @@ module RSpec
       # @private
       class AfterHook < Hook
         def run(example)
-          example.instance_exec_with_rescue("in an after hook", &block)
+          example.instance_exec_with_rescue(&block)
         end
       end
 

--- a/spec/rspec/core/aggregate_failures_spec.rb
+++ b/spec/rspec/core/aggregate_failures_spec.rb
@@ -1,51 +1,163 @@
-RSpec.describe "Using `:aggregate_failures` metadata" do
-  it 'applies `aggregate_failures` to examples or groups tagged with `:aggregate_failures`' do
-    ex = nil
+RSpec.describe "Aggregating failures" do
+  shared_examples_for "failure aggregation" do |exception_attribute, example_meta|
+    context "via the `aggregate_failures` method" do
+      context 'when the example has an expectation failure, plus an `after` hook and an `around` hook failure' do
+        it 'presents a flat list of three failures' do
+          ex = nil
 
-    RSpec.describe "Aggregate failures", :aggregate_failures do
-      ex = it "has multiple failures" do
-        expect(1).to be_even
-        expect(2).to be_odd
-      end
-    end.run
+          RSpec.describe do
+            ex = example "ex", example_meta do
+              aggregate_failures { expect(1).to be_even }
+            end
+            after { raise "after" }
+            around { |example| example.run; raise "around" }
+          end.run
 
-    expect(ex.execution_result.exception).to have_attributes(
-      :failures => [
-        an_object_having_attributes(:message => 'expected `1.even?` to return true, got false'),
-        an_object_having_attributes(:message => 'expected `2.odd?` to return true, got false')
-      ]
-    )
-  end
-
-  it 'does not interfere with other `around` hooks' do
-    events = []
-
-    RSpec.describe "Outer" do
-      around do |ex|
-        events << :outer_before
-        ex.run
-        events << :outer_after
-      end
-
-      context "aggregating failures", :aggregate_failures do
-        context "inner" do
-          around do |ex|
-            events << :inner_before
-            ex.run
-            events << :inner_after
-          end
-
-          it "has multiple failures" do
-            events << :example_before
-            expect(1).to be_even
-            expect(2).to be_odd
-            events << :example_after
-          end
+          expect(ex.execution_result.__send__(exception_attribute)).to have_attributes(
+            :all_exceptions => [
+              an_object_having_attributes(:message => 'expected `1.even?` to return true, got false'),
+              an_object_having_attributes(:message => 'after'),
+              an_object_having_attributes(:message => 'around')
+            ]
+          )
         end
       end
-    end.run
 
-    expect(events).to eq([:outer_before, :inner_before, :example_before,
-                          :example_after, :inner_after, :outer_after])
+      context 'when the example has multiple expectation failures, plus an `after` hook and an `around` hook failure' do
+        it 'nests the expectation failures so that they can be labeled with the aggregation block label' do
+          ex = nil
+
+          RSpec.describe do
+            ex = example "ex", example_meta do
+              aggregate_failures do
+                expect(1).to be_even
+                expect(2).to be_odd
+              end
+            end
+            after { raise "after" }
+            around { |example| example.run; raise "around" }
+          end.run
+
+          exception = ex.execution_result.__send__(exception_attribute)
+
+          expect(exception).to have_attributes(
+            :all_exceptions => [
+              an_object_having_attributes(:class   => RSpec::Expectations::MultipleExpectationsNotMetError),
+              an_object_having_attributes(:message => 'after'),
+              an_object_having_attributes(:message => 'around')
+            ]
+          )
+
+          expect(exception.all_exceptions.first.all_exceptions).to match [
+            an_object_having_attributes(:message => 'expected `1.even?` to return true, got false'),
+            an_object_having_attributes(:message => 'expected `2.odd?` to return true, got false')
+          ]
+        end
+      end
+    end
+
+    context "via `:aggregate_failures` metadata" do
+      it 'applies `aggregate_failures` to examples or groups tagged with `:aggregate_failures`' do
+        pending "Not yet working with pending examples" if example_meta.key?(:pending)
+
+        ex = nil
+
+        RSpec.describe "Aggregate failures", :aggregate_failures do
+          ex = it "has multiple failures", example_meta do
+            expect(1).to be_even
+            expect(2).to be_odd
+          end
+        end.run
+
+        expect(ex.execution_result.__send__(exception_attribute)).to have_attributes(
+          :failures => [
+            an_object_having_attributes(:message => 'expected `1.even?` to return true, got false'),
+            an_object_having_attributes(:message => 'expected `2.odd?` to return true, got false')
+          ]
+        )
+      end
+
+      context 'when the example has an exception, plus another error' do
+        it 'reports it as a multiple exception error' do
+          ex = nil
+
+          RSpec.describe "Aggregate failures", :aggregate_failures do
+            ex = example "fail and raise", example_meta do
+              expect(1).to be_even
+              boom
+            end
+          end.run
+
+          expect(ex.execution_result.__send__(exception_attribute)).to have_attributes(
+            :all_exceptions => [
+              an_object_having_attributes(:message => 'expected `1.even?` to return true, got false'),
+              an_object_having_attributes(:class => NameError, :message => /boom/)
+            ]
+          )
+        end
+      end
+
+      context 'when the example has multiple exceptions, plus another error' do
+        it 'reports it as a flat multiple exception error' do
+          ex = nil
+
+          RSpec.describe "Aggregate failures", :aggregate_failures do
+            ex = example "fail and raise", example_meta do
+              expect(1).to be_even
+              expect(2).to be_odd
+              boom
+            end
+          end.run
+
+          expect(ex.execution_result.__send__(exception_attribute)).to have_attributes(
+            :all_exceptions => [
+              an_object_having_attributes(:message => 'expected `1.even?` to return true, got false'),
+              an_object_having_attributes(:message => 'expected `2.odd?` to return true, got false'),
+              an_object_having_attributes(:class => NameError, :message => /boom/)
+            ]
+          )
+        end
+      end
+    end
+  end
+
+  context "for a non-pending example" do
+    include_examples "failure aggregation", :exception, {}
+
+    it 'does not interfere with other `around` hooks' do
+      events = []
+
+      RSpec.describe "Outer" do
+        around do |ex|
+          events << :outer_before
+          ex.run
+          events << :outer_after
+        end
+
+        context "aggregating failures", :aggregate_failures do
+          context "inner" do
+            around do |ex|
+              events << :inner_before
+              ex.run
+              events << :inner_after
+            end
+
+            it "has multiple failures" do
+              events << :example_before
+              expect(1).to be_even
+              expect(2).to be_odd
+              events << :example_after
+            end
+          end
+        end
+      end.run
+
+      expect(events).to eq([:outer_before, :inner_before, :example_before,
+                            :example_after, :inner_after, :outer_after])
+    end
+  end
+
+  context "for a pending example" do
+    include_examples "failure aggregation", :pending_exception, :pending => true
   end
 end

--- a/spec/rspec/core/aggregate_failures_spec.rb
+++ b/spec/rspec/core/aggregate_failures_spec.rb
@@ -58,8 +58,6 @@ RSpec.describe "Aggregating failures" do
 
     context "via `:aggregate_failures` metadata" do
       it 'applies `aggregate_failures` to examples or groups tagged with `:aggregate_failures`' do
-        pending "Not yet working with pending examples" if example_meta.key?(:pending)
-
         ex = nil
 
         RSpec.describe "Aggregate failures", :aggregate_failures do
@@ -69,8 +67,10 @@ RSpec.describe "Aggregating failures" do
           end
         end.run
 
+        expect(ex.execution_result).not_to be_pending_fixed
+        expect(ex.execution_result.status).to eq(:pending) if example_meta.key?(:pending)
         expect(ex.execution_result.__send__(exception_attribute)).to have_attributes(
-          :failures => [
+          :all_exceptions => [
             an_object_having_attributes(:message => 'expected `1.even?` to return true, got false'),
             an_object_having_attributes(:message => 'expected `2.odd?` to return true, got false')
           ]

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -132,6 +132,13 @@ module RSpec::Core
         end
       end
 
+      describe "an empty backtrace" do
+        it "does not add the explanatory message about backtrace filtering" do
+          formatter = BacktraceFormatter.new
+          expect(formatter.format_backtrace([])).to eq([])
+        end
+      end
+
       context "when rspec is installed in the current working directory" do
         it "excludes lines from rspec libs by default", :unless => RSpec::Support::OS.windows? do
           backtrace = [

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -723,32 +723,35 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       expect(ex).to fail_with(RSpec::Mocks::MockExpectationError)
     end
 
-    it 'skips mock verification if the example has already failed' do
-      ex = nil
-      boom = StandardError.new("boom")
+    context "when the example has already failed" do
+      it 'appends the mock error to a `MultipleExceptionError` so the user can see both' do
+        ex = nil
+        boom = StandardError.new("boom")
 
-      RSpec.describe do
-        ex = example do
-          dbl = double
-          expect(dbl).to receive(:Foo)
-          raise boom
-        end
-      end.run
+        RSpec.describe do
+          ex = example do
+            dbl = double
+            expect(dbl).to receive(:Foo)
+            raise boom
+          end
+        end.run
 
-      expect(ex.exception).to be boom
+        expect(ex.exception).to be_a(RSpec::Core::MultipleExceptionError)
+        expect(ex.exception.all_exceptions).to match [boom, an_instance_of(RSpec::Mocks::MockExpectationError)]
+      end
     end
 
     it 'allows `after(:example)` hooks to satisfy mock expectations, since examples are not complete until their `after` hooks run' do
       ex = nil
 
       RSpec.describe do
-        let(:dbl) { double }
+        let(:the_dbl) { double }
 
         ex = example do
-          expect(dbl).to receive(:foo)
+          expect(the_dbl).to receive(:foo)
         end
 
-        after { dbl.foo }
+        after { the_dbl.foo }
       end.run
 
       expect(ex).to pass

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -31,11 +31,8 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
   end
 
   describe "#exception" do
-    it "supplies the first exception raised, if any" do
-      RSpec.configuration.output_stream = StringIO.new
-
+    it "supplies the exception raised, if there is one" do
       example = example_group.example { raise "first" }
-      example_group.after { raise "second" }
       example_group.run
       expect(example.exception.message).to eq("first")
     end
@@ -44,6 +41,25 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       example = example_group.example('example') { }
       example_group.run
       expect(example.exception).to be_nil
+    end
+
+    it 'provides a `MultipleExceptionError` if there are multiple exceptions (e.g. from `it`, `around` and `after`)' do
+      the_example = nil
+
+      after_ex   = StandardError.new("after")
+      around_ex  = StandardError.new("around")
+      example_ex = StandardError.new("example")
+
+      RSpec.describe do
+        the_example = example { raise example_ex }
+        after { raise after_ex }
+        around { |ex| ex.run; raise around_ex }
+      end.run
+
+      expect(the_example.exception).to have_attributes(
+        :class => RSpec::Core::MultipleExceptionError,
+        :all_exceptions => [example_ex, after_ex, around_ex]
+      )
     end
   end
 
@@ -401,65 +417,20 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       end
     end
 
-    context 'when the example raises an error' do
-      def run_and_capture_reported_message(group)
-        reported_msg = nil
-        # We can't use should_receive(:message).with(/.../) here,
-        # because if that fails, it would fail within our example-under-test,
-        # and since there's already two errors, it would just be reported again.
-        allow(RSpec.configuration.reporter).to receive(:message) { |msg| reported_msg = msg }
-        group.run
-        reported_msg
+    it "leaves raised exceptions unmodified (GH-1103)" do
+      # set the backtrace, otherwise MRI will build a whole new object,
+      # and thus mess with our expectations. Rubinius and JRuby are not
+      # affected.
+      exception = StandardError.new
+      exception.set_backtrace([])
+
+      group = RSpec.describe do
+        example { raise exception.freeze }
       end
+      group.run
 
-      it "prints any around hook errors rather than silencing them" do
-        group = RSpec.describe do
-          around(:each) { |e| e.run; raise "around" }
-          example("e") { raise "example" }
-        end
-
-        message = run_and_capture_reported_message(group)
-        expect(message).to match(/An error occurred in an `around.* hook/i)
-      end
-
-      it "prints any after hook errors rather than silencing them" do
-        group = RSpec.describe do
-          after(:each) { raise "after" }
-          example("e") { raise "example" }
-        end
-
-        message = run_and_capture_reported_message(group)
-        expect(message).to match(/An error occurred in an after.* hook/i)
-      end
-
-      it "does not print mock expectation errors" do
-        group = RSpec.describe do
-          example do
-            foo = double
-            expect(foo).to receive(:bar)
-            raise "boom"
-          end
-        end
-
-        message = run_and_capture_reported_message(group)
-        expect(message).to be_nil
-      end
-
-      it "leaves a raised exception unmodified (GH-1103)" do
-        # set the backtrace, otherwise MRI will build a whole new object,
-        # and thus mess with our expectations. Rubinius and JRuby are not
-        # affected.
-        exception = StandardError.new
-        exception.set_backtrace([])
-
-        group = RSpec.describe do
-          example { raise exception.freeze }
-        end
-        group.run
-
-        actual = group.examples.first.execution_result.exception
-        expect(actual.__id__).to eq(exception.__id__)
-      end
+      actual = group.examples.first.execution_result.exception
+      expect(actual.__id__).to eq(exception.__id__)
     end
 
     context "with --dry-run" do
@@ -750,6 +721,21 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       end.run
 
       expect(ex).to fail_with(RSpec::Mocks::MockExpectationError)
+    end
+
+    it 'skips mock verification if the example has already failed' do
+      ex = nil
+      boom = StandardError.new("boom")
+
+      RSpec.describe do
+        ex = example do
+          dbl = double
+          expect(dbl).to receive(:Foo)
+          raise boom
+        end
+      end.run
+
+      expect(ex.exception).to be boom
     end
 
     it 'allows `after(:example)` hooks to satisfy mock expectations, since examples are not complete until their `after` hooks run' do

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -338,6 +338,16 @@ module RSpec::Core
       }.to change(mee.other_errors, :count).by 1
     end
 
+    it 'ignores `Pending::PendingExampleFixedError` since it does not represent a real failure but rather the lack of one' do
+      mee = new_multiple_exception_error
+
+      expect {
+        mee.add Pending::PendingExampleFixedError.new
+      }.to avoid_changing(mee.other_errors, :count).
+       and avoid_changing(mee.all_exceptions, :count).
+       and avoid_changing(mee.failures, :count)
+    end
+
     it 'is tagged with a common module so it is clear it has the interface for multiple exceptions' do
       expect(MultipleExceptionError::InterfaceTag).to be === new_multiple_exception_error
     end

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -434,5 +434,34 @@ module RSpec::Core
       expected_metadata = ex.exception.aggregation_metadata
       expect(MultipleExceptionError.new.aggregation_metadata).to eq(expected_metadata)
     end
+
+    describe "::InterfaceTag.for" do
+      def value_for(ex)
+        described_class::InterfaceTag.for(ex)
+      end
+
+      context "when given an `#{described_class.name}`" do
+        it 'returns the provided error' do
+          ex = MultipleExceptionError.new
+          expect(value_for ex).to be ex
+        end
+      end
+
+      context "when given an `RSpec::Expectations::MultipleExpectationsNotMetError`" do
+        it 'returns the provided error' do
+          failure_aggregator = RSpec::Expectations::FailureAggregator.new(nil, {})
+          ex = RSpec::Expectations::MultipleExpectationsNotMetError.new(failure_aggregator)
+
+          expect(value_for ex).to be ex
+        end
+      end
+
+      context "when given any other exception" do
+        it 'wraps it in a `RSpec::Expectations::MultipleExceptionError`' do
+          ex = StandardError.new
+          expect(value_for ex).to be_a(MultipleExceptionError).and have_attributes(:all_exceptions => [ex])
+        end
+      end
+    end
   end
 end

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -186,7 +186,15 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
         expect(formatter.output_hash[:profile][:groups].first.keys).to match_array([:total_time, :count, :description, :average, :location, :start])
       end
 
-      it "ranks the example groups by average time" do
+      it "ranks the example groups by average time" do |ex|
+        if ENV['TRAVIS'] && RSpec::Support::Ruby.mri? && RUBY_VERSION == '2.0.0' &&
+           $original_rspec_configuration.loaded_spec_files.to_a == [File.expand_path(__FILE__)]
+          RSpec.current_example = ex # necessary due to sandboxing so that `skip` works.
+          skip "This spec fails on Travis on MRI 2.0.0 only when this spec file runs " \
+            "individually. It passes on Travis when run as part of the entire suite " \
+            "and I can't repro locally, so we are skipping it for this case."
+        end
+
         expect(formatter.output_hash[:profile][:groups].first[:description]).to eq("slow group")
       end
     end

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
 
     context "with multiple example groups", :slow do
       before do
-        example_clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 0.5)
+        example_clock = class_double(RSpec::Core::Time, :now => RSpec::Core::Time.now + 5)
 
         group1 = RSpec.describe("slow group") do
           example("example") do |example|

--- a/spec/rspec/core/hooks_spec.rb
+++ b/spec/rspec/core/hooks_spec.rb
@@ -74,6 +74,15 @@ module RSpec::Core
               instance.hooks.run(type, scope, double("Example").as_null_object)
             }.not_to yield_control
           end
+
+          if scope == :example
+            it "yields the example as an argument to the hook" do
+              group = RSpec.describe
+              ex = group.example { }
+
+              expect { |p| group.send(type, scope, &p); group.run }.to yield_with_args(ex)
+            end
+          end
         end
       end
     end

--- a/spec/rspec/core/notifications_spec.rb
+++ b/spec/rspec/core/notifications_spec.rb
@@ -275,6 +275,25 @@ RSpec.describe "FailedExampleNotification" do
         end
       end
     end
+
+    context "when the exception is a MultipleExceptionError" do
+      let(:sub_failure_1)  { StandardError.new("foo").tap { |e| e.set_backtrace([]) } }
+      let(:sub_failure_2)  { StandardError.new("bar").tap { |e| e.set_backtrace([]) } }
+      let(:exception)      { RSpec::Core::MultipleExceptionError.new(sub_failure_1, sub_failure_2) }
+
+      it "lists each sub-failure, just like with MultipleExpectationsNotMetError" do
+        expect(fully_formatted.lines.to_a.last(8)).to eq(dedent(<<-EOS).lines.to_a)
+          |
+          |     1.1) Failure/Error: Unable to find matching line from backtrace
+          |          StandardError:
+          |            foo
+          |
+          |     1.2) Failure/Error: Unable to find matching line from backtrace
+          |          StandardError:
+          |            bar
+        EOS
+      end
+    end
   end
 
   describe '#message_lines' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -109,4 +109,6 @@ RSpec.configure do |c|
       !(RUBY_VERSION.to_s =~ /^#{version.to_s}/)
     end
   }
+
+  $original_rspec_configuration = c
 end

--- a/spec/support/fake_libs/rspec/expectations.rb
+++ b/spec/support/fake_libs/rspec/expectations.rb
@@ -1,5 +1,6 @@
 module RSpec
   module Expectations
+    MultipleExpectationsNotMetError = Class.new(Exception)
   end
 
   module Matchers


### PR DESCRIPTION
This PR addresses a bunch of deficiencies I found in how rspec-core handles `aggregate_failures`.  This includes a fix for #1966, although the bigger fix is for how it handles a case like this:

``` ruby
it "has failures", :aggregate_failures do
  expect(x).to eq(2)

  raise_if_x_is_not_2(x)
end
```

Previously, the error from the last method call was reported as the example's main exception and the `expect(x).to eq(2)` failure was reported using a "An error occurred in an `around` hook" message, which was confusing and generally a bad experience.  The problem was that `aggregate_failures` handles any exceptions that happen within the block, but when using metadata it wraps rspec-core's handling of errors so the failure aggregator doesn't see the error that happens.  I had to change how we handle `aggregate_failures` a bit to deal with this.

I also introduced a `RSpec::Core::MultipleExceptionError` to more generally handle multiple exceptions for one example.

Finally, `pending` interacted weirdly with `aggregate_failures` so I dealt with that, too.

Note that this builds on top of rspec/rspec-expectations#800.

I'm hoping to release 3.3 once this is merged.

/cc @rspec/rspec 