### PR TITLE
Revert "Always verify mocks at the end of each example."

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -441,9 +441,13 @@ module RSpec
       end
 
       def verify_mocks
-        @example_group_instance.verify_mocks_for_rspec
+        @example_group_instance.verify_mocks_for_rspec if mocks_need_verification?
       rescue Exception => e
         set_exception(e)
+      end
+
+      def mocks_need_verification?
+        exception.nil? || execution_result.pending_fixed?
       end
 
       def assign_generated_description

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -723,35 +723,32 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       expect(ex).to fail_with(RSpec::Mocks::MockExpectationError)
     end
 
-    context "when the example has already failed" do
-      it 'appends the mock error to a `MultipleExceptionError` so the user can see both' do
-        ex = nil
-        boom = StandardError.new("boom")
+    it 'skips mock verification if the example has already failed' do
+      ex = nil
+      boom = StandardError.new("boom")
 
-        RSpec.describe do
-          ex = example do
-            dbl = double
-            expect(dbl).to receive(:Foo)
-            raise boom
-          end
-        end.run
+      RSpec.describe do
+        ex = example do
+          dbl = double
+          expect(dbl).to receive(:Foo)
+          raise boom
+        end
+      end.run
 
-        expect(ex.exception).to be_a(RSpec::Core::MultipleExceptionError)
-        expect(ex.exception.all_exceptions).to match [boom, an_instance_of(RSpec::Mocks::MockExpectationError)]
-      end
+      expect(ex.exception).to be boom
     end
 
     it 'allows `after(:example)` hooks to satisfy mock expectations, since examples are not complete until their `after` hooks run' do
       ex = nil
 
       RSpec.describe do
-        let(:the_dbl) { double }
+        let(:dbl) { double }
 
         ex = example do
-          expect(the_dbl).to receive(:foo)
+          expect(dbl).to receive(:foo)
         end
 
-        after { the_dbl.foo }
+        after { dbl.foo }
       end.run
 
       expect(ex).to pass

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -742,13 +742,13 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       ex = nil
 
       RSpec.describe do
-        let(:dbl) { double }
+        let(:the_dbl) { double }
 
         ex = example do
-          expect(dbl).to receive(:foo)
+          expect(the_dbl).to receive(:foo)
         end
 
-        after { dbl.foo }
+        after { the_dbl.foo }
       end.run
 
       expect(ex).to pass


### PR DESCRIPTION
This reverts commit f989168c9dbbcd930af6e7cc61e08057194929a8.

This is necessary to avoid the issue discussed in rspec/rspec-mocks#203. I'm reverting it so we can release 3.3. We may bring this back for 3.4 if we can find a better solution.