### PR TITLE
Make rspec-expectations and rspec-mocks APIs available in `before(:suite)` hooks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@ Enhancements:
 * Combine multiple `--pattern` arguments making them equivalent to
   `--pattern=1,2,...,n`. (Jon Rowe, #2002)
 
+Bug Fixes:
+
+* Correctly run `before(:suite)` (and friends) in the context of an example
+  group instance, thus making the expected RSpec environment available.
+  (Jon Rowe, #1986)
+
 ### 3.3.0 / 2015-06-12
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.2.3...v3.3.0)
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -558,6 +558,7 @@ module RSpec
     class SuiteHookContext < Example
       def initialize
         super(AnonymousExampleGroup, "", {})
+        @example_group_instance = AnonymousExampleGroup.new
       end
 
       # rubocop:disable Style/AccessorMethodName

--- a/spec/rspec/core/suite_hooks_spec.rb
+++ b/spec/rspec/core/suite_hooks_spec.rb
@@ -23,6 +23,30 @@ module RSpec::Core
           }.to raise_error(ZeroDivisionError)
         end
 
+        it 'runs in the context of an example group' do
+          run_context = nil
+          RSpec.configuration.__send__(registration_method, :suite) { run_context = self }
+          RSpec.configuration.with_suite_hooks { }
+          expect(run_context).to be_a ExampleGroup
+        end
+
+        it 'allows access to rspec-mocks methods within the hook' do
+          run = false
+          RSpec.configuration.__send__(registration_method, :suite) do
+            RSpec::Mocks.with_temporary_scope { double('something') }
+            run = true
+          end
+          RSpec.configuration.with_suite_hooks { }
+          expect(run).to be true
+        end
+
+        it 'allows access to rspec-expectation methods within the hook' do
+          RSpec.configuration.__send__(registration_method, :suite) { expect(true).to be false }
+          expect {
+            RSpec.configuration.with_suite_hooks { }
+          }.to raise_error RSpec::Expectations::ExpectationNotMetError
+        end
+
         context "registered on an example group" do
           it "is ignored with a clear warning" do
             sequence = []


### PR DESCRIPTION
Currently users get errors if they try to use rspec-expectations or rspec-mocks APIs (e.g. `expect(x).to y` or `allow(x).to receive`) in a `before` or `after` `:suite` hook.  It's not a common need (and not something I've ever wanted!) but for consistency/parity with the other hook types they should be available.   It looks like the hooks are intended to run in the context of a `SuiteHookContext` object but somehow it's actually being run in the context of `nil` (woops!).

See rspec/rspec-mocks#966 for an example use case.