### PR TITLE
Update comment in spec_helper.rb

### DIFF
--- a/lib/rspec/core/project_initializer/spec/spec_helper.rb
+++ b/lib/rspec/core/project_initializer/spec/spec_helper.rb
@@ -59,7 +59,7 @@ RSpec.configure do |config|
   # recommended. For more details, see:
   #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
+  #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#zero-monkey-patching-mode
   config.disable_monkey_patching!
 
   # This setting enables warnings. It's recommended, but in some cases may


### PR DESCRIPTION
There is not `http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching'
It will has moved to '#zero-monkey-patching-mode'