### PR TITLE
Provide a human readable format when inspecting an RSpec::Core::Example

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -170,6 +170,12 @@ module RSpec
         @reporter = RSpec::Core::NullReporter
       end
 
+      # Provide a human-readable representation of this class
+      def inspect
+        "#<#{self.class.name} #{description.inspect}>"
+      end
+      alias to_s inspect
+
       # @return [RSpec::Core::Reporter] the current reporter for the example
       attr_reader :reporter
 
@@ -256,13 +262,13 @@ module RSpec
         attr_reader :example
 
         Example.public_instance_methods(false).each do |name|
-          next if name.to_sym == :run || name.to_sym == :inspect
+          next if name.to_sym == :run || name.to_sym == :inspect || name.to_sym == :to_s
 
           define_method(name) { |*a, &b| @example.__send__(name, *a, &b) }
         end
 
         Proc.public_instance_methods(false).each do |name|
-          next if name.to_sym == :call || name.to_sym == :inspect || name.to_sym == :to_proc
+          next if name.to_sym == :call || name.to_sym == :inspect || name.to_sym == :to_s || name.to_sym == :to_proc
 
           define_method(name) { |*a, &b| @proc.__send__(name, *a, &b) }
         end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
     expect { ignoring_warnings { pp example_instance }}.to output(/RSpec::Core::Example/).to_stdout
   end
 
+  describe "human readable output" do
+    it 'prints a human readable description when inspected' do
+      expect(example_instance.inspect).to eq("#<RSpec::Core::Example \"example description\">")
+    end
+
+    it 'prints a human readable description for #to_s' do
+      expect(example_instance.to_s).to eq("#<RSpec::Core::Example \"example description\">")
+    end
+  end
+
   describe "#rerun_argument" do
     it "returns the location-based rerun argument" do
       allow(RSpec.configuration).to receive_messages(:loaded_spec_files => [__FILE__])


### PR DESCRIPTION
To address issue #1922