### PR TITLE
Add silence_filter_announcements config option

### DIFF
--- a/Filtering.md
+++ b/Filtering.md
@@ -159,3 +159,16 @@ end
 ```
 
 These declarations can also be overridden from the command line.
+
+## Silencing filter announcements
+
+By default, RSpec will print a message before your specs run indicating what filters are configured, for instance, it might print "Run options: include {:focus=>true}" if you set `config.filter_run_including :focus => true`.
+
+If you wish to prevent those messages from appearing in your spec output, you can set the `silence_filter_announcements` config setting to `true` like this:
+
+``` ruby
+RSpec.configure do |c|
+  c.filter_run_including :foo => :bar
+  c.silence_filter_announcements = true
+end
+```

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -293,6 +293,11 @@ module RSpec
       #   :cyan]`
       add_setting :detail_color
 
+      # @macro add_setting
+      # Don't print filter info i.e. "Run options: include {:focus=>true}"
+      # (default `false`).
+      add_setting :silence_filter_announcements
+
       # Deprecated. This config option was added in RSpec 2 to pave the way
       # for this being the default behavior in RSpec 3. Now this option is
       # a no-op.

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -106,6 +106,8 @@ module RSpec
       # Notify reporter of filters.
       def announce_filters
         fail_if_config_and_cli_options_invalid
+        return if @configuration.silence_filter_announcements?
+
         filter_announcements = []
 
         announce_inclusion_filter filter_announcements

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -106,8 +106,6 @@ module RSpec
       # Notify reporter of filters.
       def announce_filters
         fail_if_config_and_cli_options_invalid
-        return if @configuration.silence_filter_announcements?
-
         filter_announcements = []
 
         announce_inclusion_filter filter_announcements
@@ -115,14 +113,14 @@ module RSpec
 
         unless filter_manager.empty?
           if filter_announcements.length == 1
-            reporter.message("Run options: #{filter_announcements[0]}")
+            report_filter_message("Run options: #{filter_announcements[0]}")
           else
-            reporter.message("Run options:\n  #{filter_announcements.join("\n  ")}")
+            report_filter_message("Run options:\n  #{filter_announcements.join("\n  ")}")
           end
         end
 
         if @configuration.run_all_when_everything_filtered? && example_count.zero? && !@configuration.only_failures?
-          reporter.message("#{everything_filtered_message}; ignoring #{inclusion_filter.description}")
+          report_filter_message("#{everything_filtered_message}; ignoring #{inclusion_filter.description}")
           filtered_examples.clear
           inclusion_filter.clear
         end
@@ -131,10 +129,15 @@ module RSpec
 
         example_groups.clear
         if filter_manager.empty?
-          reporter.message("No examples found.")
+          report_filter_message("No examples found.")
         elsif exclusion_filter.empty? || inclusion_filter.empty?
-          reporter.message(everything_filtered_message)
+          report_filter_message(everything_filtered_message)
         end
+      end
+
+      # @private
+      def report_filter_message(message)
+        reporter.message(message) unless @configuration.silence_filter_announcements?
       end
 
       # @private

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -224,6 +224,15 @@ module RSpec::Core
             world.announce_filters
           end
         end
+
+        context "with a filter but with silence_filter_announcements" do
+          it "does not announce" do
+            configuration.silence_filter_announcements = true
+            configuration.filter_run_including :foo => 'bar'
+            expect(reporter).to_not receive(:message)
+            world.announce_filters
+          end
+        end
       end
 
       context "with examples" do


### PR DESCRIPTION
We run specs with a couple of filters, but when I run them at the command like, I'd like to avoid cluttering the output with filter announcements like "Run options: include {:focus=>true}".

This add a new config option `silence_filter_announcements` (default `false`) which allows you to prevent the filter announcements from being printed when you don't want them to be.

This fixes this issue: https://github.com/rspec/rspec-core/issues/1896 and would resolve this Stack Overflow question: http://stackoverflow.com/questions/27698184/how-to-suppress-rspec-output-run-options-include-focus-true (as of now, 8 upvotes and 142 views)