### PR TITLE
Remove deprecations

### DIFF
--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -98,7 +98,7 @@ Then /^the output from `([^`]+)` should not contain "(.*?)"$/  do |cmd, expected
 end
 
 Given /^I have a brand new project with no files$/ do
-  in_current_dir do
+  in_current_directory do
     expect(Dir["**/*"]).to eq([])
   end
 end
@@ -115,7 +115,7 @@ Given(/^a vendored gem named "(.*?)" containing a file named "(.*?)" with:$/) do
 end
 
 When "I accept the recommended settings by removing `=begin` and `=end` from `spec/spec_helper.rb`" do
-  in_current_dir do
+  in_current_directory do
     spec_helper = File.read("spec/spec_helper.rb")
     expect(spec_helper).to include("=begin", "=end")
 
@@ -138,7 +138,7 @@ Given(/^I have run `([^`]*)` once, resulting in "([^"]*)"$/) do |command, output
 end
 
 When(/^I fix "(.*?)" by replacing "(.*?)" with "(.*?)"$/) do |file_name, original, replacement|
-  in_current_dir do
+  in_current_directory do
     contents = File.read(file_name)
     expect(contents).to include(original)
     fixed = contents.sub(original, replacement)
@@ -151,7 +151,7 @@ Then(/^it should fail with "(.*?)"$/) do |snippet|
 end
 
 Given(/^I have not configured `example_status_persistence_file_path`$/) do
-  in_current_dir do
+  in_current_directory do
     return unless File.exist?("spec/spec_helper.rb")
     return unless File.read("spec/spec_helper.rb").include?("example_status_persistence_file_path")
     File.open("spec/spec_helper.rb", "w") { |f| f.write("") }

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -2,7 +2,7 @@ require 'support/aruba_support'
 
 RSpec.describe 'Filtering' do
   include_context "aruba support"
-  before { clean_current_dir }
+  before { clean_current_directory }
 
   it 'prints a rerun command for shared examples in external files that works to rerun' do
     write_file "spec/support/shared_examples.rb", "

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe 'Filtering' do
       expect(last_cmd_stdout).to match(/3 examples, 0 failures/)
 
       # Using absolute paths...
-      spec_root = in_current_dir { File.expand_path("spec") }
+      spec_root = in_current_directory { File.expand_path("spec") }
       run_command "#{spec_root}/file_1_spec.rb[1:1,1:3] #{spec_root}/file_2_spec.rb[1:2]"
       expect(last_cmd_stdout).to match(/3 examples, 0 failures/)
     end

--- a/spec/integration/order_spec.rb
+++ b/spec/integration/order_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'command line', :ui do
   end
 
   describe '--order defined on CLI with --order rand in .rspec' do
-    after { remove_file '.rspec' }
+    after { remove '.rspec' }
 
     it "overrides --order rand with --order defined" do
       write_file '.rspec', '--order rand'
@@ -147,7 +147,7 @@ RSpec.describe 'command line', :ui do
   end
 
   context 'when a custom order is configured' do
-    after { remove_file 'spec/custom_order_spec.rb' }
+    after { remove 'spec/custom_order_spec.rb' }
 
     before do
       write_file 'spec/custom_order_spec.rb', "

--- a/spec/integration/persistence_failures_spec.rb
+++ b/spec/integration/persistence_failures_spec.rb
@@ -2,7 +2,7 @@ require 'support/aruba_support'
 
 RSpec.describe 'Persistence failures' do
   include_context "aruba support"
-  before { clean_current_dir }
+  before { clean_current_directory }
 
   context "when `config.example_status_persistence_file_path` is configured" do
     context "to an invalid file path (e.g. spec/spec_helper.rb/examples.txt)" do

--- a/spec/integration/persistence_failures_spec.rb
+++ b/spec/integration/persistence_failures_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Persistence failures' do
         "
 
         write_file_formatted "spec/examples.txt", ""
-        in_current_dir do
+        in_current_directory do
           FileUtils.chmod 0000, "spec/examples.txt"
         end
       end

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -23,7 +23,7 @@ RSpec.shared_context "aruba support" do
     cmd_parts = Shellwords.split(cmd)
 
     handle_current_dir_change do
-      in_current_dir do
+      in_current_directory do
         RSpec::Core::Runner.run(cmd_parts, temp_stderr, temp_stdout)
       end
     end


### PR DESCRIPTION
15 failures when running the test suite locally:

<img width="555" alt="screen shot 2015-07-17 at 11 54 20" src="https://cloud.githubusercontent.com/assets/5038475/8745834/63fa50e0-2c7b-11e5-8154-42d8b2a86757.png">

All gone when replacing the deprecated methods:
- `in_current_dir`
-  `remove_file`
-  `clean_current_dir`
