### PR TITLE
Add ability to filter hooks via simple keys.

### DIFF
--- a/features/hooks/filtering.feature
+++ b/features/hooks/filtering.feature
@@ -283,3 +283,147 @@ Feature: filters
       """
     When I run `rspec filter_example_hooks_with_symbol_spec.rb`
     Then the examples should all pass
+
+  Scenario: Filtering hooks using a hash
+    Given a file named "filter_example_hooks_with_hash_spec.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.before(:example, :foo => { :bar => :baz, :slow => true }) do
+          invoked_hooks << :before_example_foo_bar
+        end
+      end
+
+      RSpec.describe "a filtered before :example hook" do
+        let(:invoked_hooks) { [] }
+
+        describe "group without matching metadata" do
+          it "does not run the hook" do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "does not run the hook for an example if only part of the filter matches", :foo => { :bar => :baz } do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "runs the hook for an example if the metadata contains all key value pairs from the filter", :foo => { :bar => :baz, :slow => true, :extra => :pair } do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+
+        describe "group with matching metadata", :foo => { :bar => :baz, :slow => true } do
+          it "runs the hook" do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+      end
+      """
+    When I run `rspec filter_example_hooks_with_hash_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Filtering hooks using a Proc
+    Given a file named "filter_example_hooks_with_proc_spec.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.before(:example, :foo => Proc.new { |value| value.is_a?(String) } ) do
+          invoked_hooks << :before_example_foo_bar
+        end
+      end
+
+      RSpec.describe "a filtered before :example hook" do
+        let(:invoked_hooks) { [] }
+
+        describe "group without matching metadata" do
+          it "does not run the hook" do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "does not run the hook if the proc returns false", :foo => :bar do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "runs the hook if the proc returns true", :foo => 'bar' do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+
+        describe "group with matching metadata", :foo => 'bar' do
+          it "runs the hook" do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+      end
+      """
+    When I run `rspec filter_example_hooks_with_proc_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Filtering hooks using a regular expression
+    Given a file named "filter_example_hooks_with_regexp_spec.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.before(:example, :foo => /bar/ ) do
+          invoked_hooks << :before_example_foo_bar
+        end
+      end
+
+      RSpec.describe "a filtered before :example hook" do
+        let(:invoked_hooks) { [] }
+
+        describe "group without matching metadata" do
+          it "does not run the hook" do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "does not run the hook if the value does not match", :foo => 'baz' do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "runs the hook if the value matches", :foo => 'bar' do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+
+        describe "group with matching metadata", :foo => 'bar' do
+          it "runs the hook" do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+      end
+      """
+    When I run `rspec filter_example_hooks_with_regexp_spec.rb`
+    Then the examples should all pass
+
+  Scenario: Filtering hooks using string comparison
+    Given a file named "filter_example_hooks_with_strcmp_spec.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.before(:example, :foo => :bar ) do
+          invoked_hooks << :before_example_foo_bar
+        end
+      end
+
+      RSpec.describe "a filtered before :example hook" do
+        let(:invoked_hooks) { [] }
+
+        describe "group without matching metadata" do
+          it "does not run the hook" do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "does not run the hook if the coerced values do not match", :foo => 'baz' do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "does not run the hook if the coerced values match", :foo => 'bar' do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+
+        describe "group with matching metadata", :foo => 'bar' do
+          it "runs the hook" do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+      end
+      """
+    When I run `rspec filter_example_hooks_with_strcmp_spec.rb`
+    Then the examples should all pass

--- a/features/hooks/filtering.feature
+++ b/features/hooks/filtering.feature
@@ -244,3 +244,42 @@ Feature: filters
       .after context
       """
 
+  Scenario: Filtering hooks using symbols
+    Given a file named "filter_example_hooks_with_symbol_spec.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.before(:example, :foo) do
+          invoked_hooks << :before_example_foo_bar
+        end
+      end
+
+      RSpec.describe "a filtered before :example hook" do
+        let(:invoked_hooks) { [] }
+
+        describe "group without a matching metadata key" do
+          it "does not run the hook" do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "does not run the hook for an example with metadata hash containing the key with a falsey value", :foo => nil do
+            expect(invoked_hooks).to be_empty
+          end
+
+          it "runs the hook for an example with metadata hash containing the key with a truthy value", :foo => :bar do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+
+          it "runs the hook for an example with only the key defined", :foo do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+
+        describe "group with matching metadata key", :foo do
+          it "runs the hook" do
+            expect(invoked_hooks).to eq([:before_example_foo_bar])
+          end
+        end
+      end
+      """
+    When I run `rspec filter_example_hooks_with_symbol_spec.rb`
+    Then the examples should all pass

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -27,11 +27,7 @@ module RSpec
             when Regexp
               metadata[key] =~ value
             when Proc
-              case value.arity
-              when 0 then value.call
-              when 2 then value.call(metadata[key], metadata)
-              else value.call(metadata[key])
-              end
+              proc_filter_applies?(key, value, metadata)
             else
               metadata[key].to_s == value.to_s
             end
@@ -60,6 +56,14 @@ module RSpec
         def line_number_filter_applies?(line_numbers, metadata)
           preceding_declaration_lines = line_numbers.map { |n| RSpec.world.preceding_declaration_line(n) }
           !(relevant_line_numbers(metadata) & preceding_declaration_lines).empty?
+        end
+
+        def proc_filter_applies?(key, proc, metadata)
+          case proc.arity
+          when 0 then proc.call
+          when 2 then proc.call(metadata[key], metadata)
+          else proc.call(metadata[key])
+          end
         end
 
         def relevant_line_numbers(metadata)

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -15,12 +15,13 @@ module RSpec
         # @private
         def filter_applies?(key, value, metadata)
           silence_metadata_example_group_deprecations do
-            return filter_applies_to_any_value?(key, value, metadata) if Array === metadata[key] && !(Proc === value)
             return location_filter_applies?(value, metadata)          if key == :locations
             return id_filter_applies?(value, metadata)                if key == :ids
             return filters_apply?(key, value, metadata)               if Hash === value
 
             return false unless metadata.key?(key)
+            return true if TrueClass === value && !!metadata[key]
+            return filter_applies_to_any_value?(key, value, metadata) if Array === metadata[key] && !(Proc === value)
 
             case value
             when Regexp

--- a/spec/rspec/core/metadata_filter_spec.rb
+++ b/spec/rspec/core/metadata_filter_spec.rb
@@ -157,6 +157,11 @@ module RSpec
             metadata = { :foo => "words" }
             expect(filter_applies?(:foo, { :bar => /word/ }, metadata)).to be_falsey
           end
+
+          it 'matches when a metadata key is specified without a value and exists in the metadata hash' do
+            metadata = { :foo => "words" }
+            expect(filter_applies?(:foo, true, metadata)).to be_truthy
+          end
         end
 
         context "with an Array" do
@@ -198,6 +203,10 @@ module RSpec
 
           it "does not match a proc that evaluates to false" do
             expect(filter_applies?(:tag, lambda { |values| values.include? 'nothing' }, metadata_with_array)).to be_falsey
+          end
+
+          it 'matches when a metadata key is specified without a value and exists in the metadata hash' do
+            expect(filter_applies?(:tag, true, metadata_with_array)).to be_truthy
           end
         end
       end


### PR DESCRIPTION
Also, add feature spec documentation for various filter types.


This resolves a pain point for me, where we want to create conditional before/after/around blocks that run if a key is set on an example with any value.  Previously, in order to handle any possible value, we had to provide a Proc which evaluates to true for this to work.  This PR adds the ability to simply specify the key as a filter, and if it exists in the metadata hash, it will run the block (provided no other filters filter it out).

For example, suppose we want to timecop an entire example to a specified date/time.  Previously, this would require a Proc to handle evaluation of the metadata value in order to make the block run:

```ruby
config.around(:example, travel: ->(date_time) { date_time.present? }) do |example|
  Timecop.travel example.metadata[:travel] do
    example.run
  end
end
```

This PR makes this scenario simpler and more efficient due to not having to evaluate a Proc for every example containing the specified key:

```ruby
config.around(:example, :travel) do |example|
  Timecop.travel example.metadata[:travel] do
    example.run
  end
end
```

I also added feature specs for all of the filter types, except `:location` and `:ids`, which seem to be more specific to the CLI.  These various options were previously undocumented and only apparent if you actually read through the `Core::MetadataFilter` class or tests.

Necessary Changes:
- Add a filter for when only a key is provided.
- Minor refactor of `Core::MetadataFilter#filter_applies?` to satisfy rubocop, and satisfy this feature.
- Add tests!

All previously existing tests pass without modification, so this should be a backwards compatible feature.