### PR TITLE
Issue 2020  remove ansicon warning

### DIFF
--- a/features/.nav
+++ b/features/.nav
@@ -40,6 +40,7 @@
   - run_all_when_everything_filtered.feature
 - configuration:
   - read_options_from_file.feature
+  - color.feature
   - fail_fast.feature
   - custom_settings.feature
   - alias_example_to.feature

--- a/features/configuration/color.feature
+++ b/features/configuration/color.feature
@@ -1,0 +1,22 @@
+Feature: Windows may require additional solutions to display color
+
+  The output uses [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) to show text in color.  Windows
+  systems (shells) often don't interpret those codes at all.
+
+  If you're on Windows and you see ANSI escape codes in the output
+  (something like `[1m [31m` ) and your text isn't in different colors,
+  you may need to install a utility so that your Windows shell will
+  interpret those codes correctly and show the colors.  Here are some
+  popular solutions:
+
+    * [ANSICON](https://github.com/adoxa/ansicon): ANSICON runs 'on top of' cmd or powershell. This is a very
+      popular solution. You can set it up so that it's always used whenever
+      you use cmd or powershell, or use it only at specific times.
+
+    * Alternatives to cmd.exe or powershell: [ConEmu](http://conemu.github.io/), [Console2](http://sourceforge.net/projects/console/),
+      [ConsoleZ](https://github.com/cbucher/console)
+
+    * Unix-like shells and utilities:  [cygwin](https://www.cygwin.com/), [babun](http://babun.github.io/index.html),
+      [MinGW](http://www.mingw.org/) (Minimalist GNU for Windows)
+
+  To find out more, search for information about those solutions.

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -695,7 +695,9 @@ module RSpec
       #
       # @see color_enabled?
       # @return [Boolean]
-      attr_writer :color
+      def color
+        value_for(:color) { @color }
+      end
 
       # Check if color is enabled for a particular output.
       # @param output [IO] an output stream to use, defaults to the current
@@ -706,11 +708,7 @@ module RSpec
       end
 
       # Toggle output color.
-      # @attr true_or_false [Boolean] toggle color enabled
-      def color=(true_or_false)
-        return unless true_or_false
-        @color = !!true_or_false
-      end
+      attr_writer :color
 
       # @private
       def libs=(libs)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -695,9 +695,7 @@ module RSpec
       #
       # @see color_enabled?
       # @return [Boolean]
-      def color
-        value_for(:color) { @color }
-      end
+      attr_writer :color
 
       # Check if color is enabled for a particular output.
       # @param output [IO] an output stream to use, defaults to the current
@@ -711,15 +709,7 @@ module RSpec
       # @attr true_or_false [Boolean] toggle color enabled
       def color=(true_or_false)
         return unless true_or_false
-
-        if RSpec::Support::OS.windows? && !ENV['ANSICON']
-          RSpec.warning "You must use ANSICON 1.31 or later " \
-                        "(http://adoxa.3eeweb.com/ansicon/) to use colour " \
-                        "on Windows"
-          @color = false
-        else
-          @color = true
-        end
+        @color = !!true_or_false
       end
 
       # @private

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1156,58 +1156,6 @@ module RSpec::Core
         end
       end
 
-      context "on windows" do
-        before do
-          @original_host  = RbConfig::CONFIG['host_os']
-          RbConfig::CONFIG['host_os'] = 'mingw'
-          allow(config).to receive(:require)
-        end
-
-        after do
-          RbConfig::CONFIG['host_os'] = @original_host
-        end
-
-        context "with ANSICON available" do
-          around(:each) { |e| with_env_vars('ANSICON' => 'ANSICON', &e) }
-
-          it "enables colors" do
-            config.output_stream = StringIO.new
-            allow(config.output_stream).to receive_messages :tty? => true
-            config.color = true
-            expect(config.color).to be_truthy
-          end
-
-          it "leaves output stream intact" do
-            config.output_stream = $stdout
-            allow(config).to receive(:require) do |what|
-              config.output_stream = 'foo' if what =~ /Win32/
-            end
-            config.color = true
-            expect(config.output_stream).to eq($stdout)
-          end
-        end
-
-        context "with ANSICON NOT available" do
-          around { |e| without_env_vars('ANSICON', &e) }
-
-          before do
-            allow_warning
-          end
-
-          it "warns to install ANSICON" do
-            allow(config).to receive(:require) { raise LoadError }
-            expect_warning_with_call_site(__FILE__, __LINE__ + 1, /You must use ANSICON/)
-            config.color = true
-          end
-
-          it "sets color to false" do
-            allow(config).to receive(:require) { raise LoadError }
-            config.color = true
-            expect(config.color).to be_falsey
-          end
-        end
-      end
-
       it "prefers incoming cli_args" do
         config.output_stream = StringIO.new
         allow(config.output_stream).to receive_messages :tty? => true


### PR DESCRIPTION
I just removed the code that tested for and warned about ANSICON.  
I put documentation (a note about using ANSICON or other utilities) into ```features/configuration/read_options_from_file.feature```.  I'm not sure if that's the right or best place for it.  It seemed to be the most appropriate place.  
