### PR TITLE
allows rspec executable to take arguments from STDIN

### DIFF
--- a/exe/rspec
+++ b/exe/rspec
@@ -1,4 +1,8 @@
 #!/usr/bin/env ruby
 
+unless $stdin.tty?
+  ARGV.concat($stdin.read.scan(/\S+/))
+end
+
 require 'rspec/core'
 RSpec::Core::Runner.invoke


### PR DESCRIPTION
This makes it possible to pipe (`|`) arguments from the previous process's `STDOUT` directly into `rspec`. `STDIN` args are simply concated onto `ARGV` and are handled by `RSpec::Core::Runner` as usual.

This is ignored when `STDIN` is associated with a terminal device (`tty`), i.e. when there is no process preceding and piped into `rspec`.

**Examples:**

```
  $ echo 'test_spec.rb' | rspec --color

  $ cat list_of_test_files.txt | rspec

  $ git status | grep -oe '\S*_spec.rb' | rspec --format doc
```

**Use Case:**

The idea for this came about when @jmschles and I got tired of copying and pasting filenames from the `git status` output into the prompt after the `rspec` command.
```
$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   lib/gelato.rb
	modified:   spec/gelato_spec.rb
	modified:   spec/gelato/support_spec.rb

no changes added to commit (use "git add" and/or "git commit -a")

$ git status | grep --only-matching --regex='\S*_spec.rb'
spec/gelato_spec.rb
spec/gelato/support_spec.rb

$ git status | grep --only-matching --regex='\S*_spec.rb' | rspec
.....................FF...

Finished in 0.0315 seconds (files took 0.21353 seconds to load)
26 examples, 2 failures
```
---
Lemme know if you have any questions. I hope this is helpful! :smile_cat: :smile_cat: :smile_cat: 