### PR TITLE
Stop rescuing all exceptions.

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -101,9 +101,9 @@ Proc:
 RedundantReturn:
   AllowMultipleReturnValues: true
 
-# We have to rescue Exception in the `raise_error` matcher for it to work properly.
+# Exceptions should be rescued with `Support::AllExceptionsExceptOnesWeMustNotRescue`
 RescueException:
-  Enabled: false
+  Enabled: true
 
 # We haven't adopted the `fail` to signal exceptions vs `raise` for re-raises convention.
 SignalException:

--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,8 @@ Enhancements:
   (Jon Rowe, #2052)
 * Append the root `cause` of a failure or error to the printed failure
   output when a `cause` is available. (Adam Magan)
+* Stop rescuing `NoMemoryError`, `SignalExcepetion`, `Interrupt` and
+  `SystemExit`. It is dangerous to interfere with these. (Myron Marston, #2063)
 
 Bug Fixes:
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1754,7 +1754,7 @@ module RSpec
         around(:example, :aggregate_failures => true) do |procsy|
           begin
             aggregate_failures(nil, :hide_backtrace => true, &procsy)
-          rescue Exception => exception
+          rescue Support::AllExceptionsExceptOnesWeMustNotRescue => exception
             procsy.example.set_aggregate_failures_exception(exception)
           end
         end

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -227,14 +227,14 @@ module RSpec
               rescue Pending::SkipDeclaredInExample
                 # no-op, required metadata has already been set by the `skip`
                 # method.
-              rescue Exception => e
+              rescue Support::AllExceptionsExceptOnesWeMustNotRescue => e
                 set_exception(e)
               ensure
                 run_after_example
               end
             end
           end
-        rescue Exception => e
+        rescue Support::AllExceptionsExceptOnesWeMustNotRescue => e
           set_exception(e)
         ensure
           @example_group_instance = nil # if you love something... let it go
@@ -400,7 +400,7 @@ module RSpec
 
       def with_around_example_hooks
         hooks.run(:around, :example, self) { yield }
-      rescue Exception => e
+      rescue Support::AllExceptionsExceptOnesWeMustNotRescue => e
         set_exception(e)
       end
 
@@ -457,7 +457,7 @@ module RSpec
 
       def verify_mocks
         @example_group_instance.verify_mocks_for_rspec if mocks_need_verification?
-      rescue Exception => e
+      rescue Support::AllExceptionsExceptOnesWeMustNotRescue => e
         set_exception(e)
       end
 
@@ -476,7 +476,7 @@ module RSpec
 
       def generate_description
         RSpec::Matchers.generated_description
-      rescue Exception => e
+      rescue Support::AllExceptionsExceptOnesWeMustNotRescue => e
         location_description + " (Got an error when generating description " \
           "from matcher: #{e.class}: #{e.message} -- #{e.backtrace.first})"
       end

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -227,7 +227,7 @@ module RSpec
               rescue Pending::SkipDeclaredInExample
                 # no-op, required metadata has already been set by the `skip`
                 # method.
-              rescue Support::AllExceptionsExceptOnesWeMustNotRescue => e
+              rescue AllExceptionsExcludingDangerousOnesOnRubiesThatAllowIt => e
                 set_exception(e)
               ensure
                 run_after_example
@@ -243,6 +243,20 @@ module RSpec
         finish(reporter)
       ensure
         RSpec.current_example = nil
+      end
+
+      if RSpec::Support::Ruby.jruby? || RUBY_VERSION.to_f < 1.9
+        # :nocov:
+        # For some reason, rescuing `Support::AllExceptionsExceptOnesWeMustNotRescue`
+        # in place of `Exception` above can cause the exit status to be the wrong
+        # thing. I have no idea why. See:
+        # https://github.com/rspec/rspec-core/pull/2063#discussion_r38284978
+        # @private
+        AllExceptionsExcludingDangerousOnesOnRubiesThatAllowIt = Exception
+        # :nocov:
+      else
+        # @private
+        AllExceptionsExcludingDangerousOnesOnRubiesThatAllowIt = Support::AllExceptionsExceptOnesWeMustNotRescue
       end
 
       # Wraps both a `Proc` and an {Example} for use in {Hooks#around

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -524,7 +524,7 @@ module RSpec
         rescue Pending::SkipDeclaredInExample => ex
           for_filtered_examples(reporter) { |example| example.skip_with_exception(reporter, ex) }
           true
-        rescue Exception => ex
+        rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
           RSpec.world.wants_to_quit = true if fail_fast?
           for_filtered_examples(reporter) { |example| example.fail_with_exception(reporter, ex) }
           false

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -362,7 +362,7 @@ module RSpec
       class AfterHook < Hook
         def run(example)
           example.instance_exec(example, &block)
-        rescue Exception => ex
+        rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
           example.set_exception(ex)
         end
       end
@@ -371,7 +371,7 @@ module RSpec
       class AfterContextHook < Hook
         def run(example)
           example.instance_exec(example, &block)
-        rescue Exception => e
+        rescue Support::AllExceptionsExceptOnesWeMustNotRescue => e
           # TODO: Come up with a better solution for this.
           RSpec.configuration.reporter.message <<-EOS
 


### PR DESCRIPTION
We do want to generally rescue `Exception` and
any subclasses but there are a few exceptions
we should not rescue. For example, if we rescue
`SystemExit`, it prevents `exit` from exiting.

Attempted fix for #2058.

Note that the spec I added failed without these changes and passes with it...but there are some other weird effects that I do not understand:

```
➜  rspec-core git:(stop-rescuing-all-exceptions) bin/rspec spec/integration
Run options:
  include {:focus=>true}
  exclude {:ruby=>#<Proc:./spec/spec_helper.rb:106>}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 9279
...........

Finished in 2.12 seconds (files took 0.11962 seconds to load)
11 examples, 0 failures

Randomized with seed 9279

.......

Finished in 2.3 seconds (files took 0.11962 seconds to load)
18 examples, 0 failures

Randomized with seed 9279
```

```
➜  rspec-core git:(stop-rescuing-all-exceptions) bin/rspec --seed 33805
Run options:
  include {:focus=>true}
  exclude {:ruby=>#<Proc:./spec/spec_helper.rb:106>}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 33805
..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) RSpec::Core::Metadata for an example points :example_group to the same hash object as other examples in the same group
     # Cannot maintain this and provide full `:example_group` backwards compatibility (see GH #1490):(
     Failure/Error: expect(b[:description]).to eq("new description")

       expected: "new description"
            got: "group"

       (compared using ==)
     # ./spec/rspec/core/metadata_spec.rb:138:in `block (3 levels) in <module:Core>'
     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'

Finished in 8.28 seconds (files took 0.7278 seconds to load)
1399 examples, 0 failures, 1 pending

Randomized with seed 33805

....................................................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) RSpec::Core::Metadata for an example points :example_group to the same hash object as other examples in the same group
     # Cannot maintain this and provide full `:example_group` backwards compatibility (see GH #1490):(
     Failure/Error: expect(b[:description]).to eq("new description")

       expected: "new description"
            got: "group"

       (compared using ==)
     # ./spec/rspec/core/metadata_spec.rb:138:in `block (3 levels) in <module:Core>'
     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'

Failures:

  1) When an example forks and exits it the subprocess prints the results only once
     Failure/Error: expect(finished_lines.count).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     # ./spec/integration/subprocess_exit_spec.rb:21:in `block (3 levels) in <top (required)>'
     # ./bundle/ruby/2.1.0/gems/aruba-0.6.2/lib/aruba/api.rb:46:in `chdir'
     # ./bundle/ruby/2.1.0/gems/aruba-0.6.2/lib/aruba/api.rb:46:in `in_current_dir'
     # ./spec/integration/subprocess_exit_spec.rb:19:in `block (2 levels) in <top (required)>'
     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'

Finished in 11.92 seconds (files took 0.7278 seconds to load)
1803 examples, 1 failure, 1 pending

Failed examples:

rspec ./spec/integration/subprocess_exit_spec.rb:7 # When an example forks and exits it the subprocess prints the results only once

Randomized with seed 33805
```

I'm a bit at a loss for what's causing this.  Anyone from @rspec/rspec got any ideas?