### PR TITLE
add leniency to the command line

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -9,7 +9,7 @@ module RSpec
     class ConfigurationOptions
       # @param args [Array<String>] command line arguments
       def initialize(args)
-        @args = args.dup
+        @args = args.reject { |arg| arg =~ /(^|\/)rspec$/ }
         organize_options
       end
 

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
     expect(args).to eq(['-e', 'some spec'])
   end
 
+  it "ignores files named rspec" do
+    opts = config_options_object(*%w[./bin/rspec spec/file.rb])
+    expect(opts.options[:files_or_directories_to_run]).to eq(%w[spec/file.rb])
+  end
+
   describe "#configure" do
     let(:config) { RSpec::Core::Configuration.new }
 


### PR DESCRIPTION
Hi,

Very cool that the commands to rerun specs is at the bottom of a test run. And I often copy and paste the sample commands to rerun them.

Unfortunatly, I often type `bundle exec rspec` first, so I end up with 2 rspec commands on the line:

```bash
bundle exec rspec rspec ./spec/file_spec.rb
```

This PR ignores a duplicate `rspec` command.

It is (my) user error, but it happens enough that I would imagine that others do the same.

Thanks
