### PR TITLE
Encode the output of the exception presenter properly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,11 @@ AllCops:
 ClassLength:
   Max: 330
 
+Encoding:
+  EnforcedStyle: when_needed
+  Exclude:
+    - lib/rspec/core/formatters/exception_presenter.rb
+
 # This should go down over time.
 LineLength:
   Max: 130

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module RSpec
   module Core
     module Formatters

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'pathname'
 
 module RSpec::Core
@@ -15,13 +16,13 @@ module RSpec::Core
     describe "#fully_formatted" do
       line_num = __LINE__ + 2
       let(:exception) { instance_double(Exception, :message => "Boom\nBam", :backtrace => [ "#{__FILE__}:#{line_num}"]) }
-      # The failure happened here!
+      # The failure happened here! Handles encoding too! ЙЦ
 
       it "formats the exception with all the normal details" do
         expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |  1) Example
-          |     Failure/Error: # The failure happened here!
+          |     Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
           |       Boom
           |       Bam
           |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -32,7 +33,7 @@ module RSpec::Core
         expect(presenter.fully_formatted(100)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |  100) Example
-          |       Failure/Error: # The failure happened here!
+          |       Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
           |         Boom
           |         Bam
           |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -45,7 +46,7 @@ module RSpec::Core
         expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |    1) Example
-          |       Failure/Error: # The failure happened here!
+          |       Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
           |         Boom
           |         Bam
           |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -61,7 +62,7 @@ module RSpec::Core
           |
           |    1) Example
           |       Some Detail
-          |       Failure/Error: # The failure happened here!
+          |       Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
           |         Boom
           |         Bam
           |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -76,7 +77,7 @@ module RSpec::Core
         expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |  1) Detail!
-          |     Failure/Error: # The failure happened here!
+          |     Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
           |       Boom
           |       Bam
           |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -88,7 +89,7 @@ module RSpec::Core
 
         expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
-          |  1) Failure/Error: # The failure happened here!
+          |  1) Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
           |       Boom
           |       Bam
           |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -105,7 +106,7 @@ module RSpec::Core
         expect(presenter.fully_formatted(2)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |  2) Example
-          |     Failure/Error: # The failure happened here!
+          |     Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
           |       Boom
           |       Bam
           |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -14,15 +14,23 @@ module RSpec::Core
     end
 
     describe "#fully_formatted" do
-      line_num = __LINE__ + 2
+      if RSpec::Support::OS.windows?
+        let(:encoding_check) { '' }
+        line_num = __LINE__ + 1
+        # The failure happened here!
+        it 'should check that output is not mangled'
+      else
+        let(:encoding_check) { ' Handles encoding too! ЙЦ' }
+        line_num = __LINE__ + 1
+        # The failure happened here! Handles encoding too! ЙЦ
+      end
       let(:exception) { instance_double(Exception, :message => "Boom\nBam", :backtrace => [ "#{__FILE__}:#{line_num}"]) }
-      # The failure happened here! Handles encoding too! ЙЦ
 
       it "formats the exception with all the normal details" do
         expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |  1) Example
-          |     Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
+          |     Failure/Error: # The failure happened here!#{ encoding_check }
           |       Boom
           |       Bam
           |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -33,7 +41,7 @@ module RSpec::Core
         expect(presenter.fully_formatted(100)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |  100) Example
-          |       Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
+          |       Failure/Error: # The failure happened here!#{ encoding_check }
           |         Boom
           |         Bam
           |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -46,7 +54,7 @@ module RSpec::Core
         expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |    1) Example
-          |       Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
+          |       Failure/Error: # The failure happened here!#{ encoding_check }
           |         Boom
           |         Bam
           |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -62,7 +70,7 @@ module RSpec::Core
           |
           |    1) Example
           |       Some Detail
-          |       Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
+          |       Failure/Error: # The failure happened here!#{ encoding_check }
           |         Boom
           |         Bam
           |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -77,7 +85,7 @@ module RSpec::Core
         expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |  1) Detail!
-          |     Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
+          |     Failure/Error: # The failure happened here!#{ encoding_check }
           |       Boom
           |       Bam
           |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -89,7 +97,7 @@ module RSpec::Core
 
         expect(presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
-          |  1) Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
+          |  1) Failure/Error: # The failure happened here!#{ encoding_check }
           |       Boom
           |       Bam
           |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
@@ -106,7 +114,7 @@ module RSpec::Core
         expect(presenter.fully_formatted(2)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |  2) Example
-          |     Failure/Error: # The failure happened here! Handles encoding too! ЙЦ
+          |     Failure/Error: # The failure happened here!#{ encoding_check }
           |       Boom
           |       Bam
           |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}


### PR DESCRIPTION
Without the magic comment the exception presenter mangles the encoding of it's strings (due to the default literal encoding being ASCII on 1.9.3 etc) this fixes it. Check rspec/rspec-expectations#847