### PR TITLE
Use our optimized require over a bare require.

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -1,4 +1,4 @@
-require 'rspec/support/reentrant_mutex'
+RSpec::Support.require_rspec_support 'reentrant_mutex'
 
 module RSpec
   module Core


### PR DESCRIPTION
Besides being faster (at least for environments with lots
of directories on the load path), this avoids potentially
loading the file twice, since rspec-mocks loads it in this
fashion rather than with a bare require.

Fixes rspec/rspec-support#244.