### PR TITLE
Add example.metadata[:extra_failure_lines] to ExceptionPresenter

### DIFF
--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -19,6 +19,7 @@ module RSpec
           @indentation             = options.fetch(:indentation, 2)
           @skip_shared_group_trace = options.fetch(:skip_shared_group_trace, false)
           @failure_lines           = options[:failure_lines]
+          @extra_failure_lines     = Array(example.metadata[:extra_failure_lines])
         end
 
         def message_lines
@@ -131,6 +132,11 @@ module RSpec
               lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
               encoded_string(exception.message.to_s).split("\n").each do |line|
                 lines << "  #{line}"
+              end
+              unless @extra_failure_lines.empty?
+                lines << ''
+                lines.concat(@extra_failure_lines)
+                lines << ''
               end
               lines
             end

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -18,12 +18,14 @@ module RSpec::Core::Formatters
       send_notification :example_failed, example_notification( double("example 1",
                :description => "first example",
                :full_description => "group first example",
-               :execution_result => execution_result(:status => :failed, :exception => Exception.new)
+               :execution_result => execution_result(:status => :failed, :exception => Exception.new),
+               :metadata => {}
               ))
       send_notification :example_failed, example_notification( double("example 2",
                :description => "second example",
                :full_description => "group second example",
-               :execution_result => execution_result(:status => :failed, :exception => Exception.new)
+               :execution_result => execution_result(:status => :failed, :exception => Exception.new),
+               :metadata => {}
               ))
 
       expect(formatter_output.string).to match(/first example \(FAILED - 1\)/m)

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -150,6 +150,25 @@ module RSpec::Core
           |     #   ./spec/rspec/core/formatters/exception_presenter_spec.rb:133
         EOS
       end
+
+      it "adds extra failure lines from the example metadata" do
+        extra_example = example.clone
+        failure_line = 'http://www.example.com/job_details/123'
+        extra_example.metadata[:extra_failure_lines] = [failure_line]
+        the_presenter = Formatters::ExceptionPresenter.new(exception, extra_example, :indentation => 4)
+        indent = ' ' * 7 # work around: RSpec behaves like library wide checks has no malformed whitespace
+        expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |    1) Example
+          |       Failure/Error: # The failure happened here!#{ encoding_check }
+          |         Boom
+          |         Bam
+          |#{indent}
+          |       #{failure_line}
+          |#{indent}
+          |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
     end
     describe "#read_failed_line" do
       def read_failed_line


### PR DESCRIPTION
Allows Selenium tests to easily link to the failure details without having to monkey patch RSpec.

Fix #2091

/cc @JonRowe 