### PR TITLE
Add before_register hook to RSpec World

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1684,6 +1684,17 @@ module RSpec
         @hooks ||= HookCollections.new(self, FilterableItemRepository::QueryOptimized)
       end
 
+      # Invokes block before defining an example group
+      def on_example_group_definition(&block)
+        on_example_group_definition_callbacks << block
+      end
+
+      # @api private
+      # Returns an array of blocks to call before defining an example group
+      def on_example_group_definition_callbacks
+        @on_example_group_definition_callbacks ||= []
+      end
+
     private
 
       def handle_suite_hook(args, collection, append_or_prepend, hook_type, block)

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -49,6 +49,7 @@ module RSpec
       #
       # Register an example group.
       def register(example_group)
+        @configuration.on_example_group_definition_callbacks.each { |block| block.call(example_group) }
         example_groups << example_group
         @example_group_counts_by_spec_file[example_group.metadata[:absolute_file_path]] += 1
         example_group

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -18,6 +18,24 @@ module RSpec::Core
       end
     end
 
+    describe '#on_example_group_definition' do
+      let(:configuration) do
+        tmp_config = RSpec::Core::Configuration.new
+        tmp_config.on_example_group_definition do |example_group|
+          example_group.examples.first.metadata[:new_key] = :new_value
+        end
+        tmp_config
+      end
+      let(:world) { RSpec::Core::World.new(configuration) }
+
+      it 'successfully invokes the block' do
+        example_group = RSpec.describe("group") { it "example 1" do; end}
+        world.register(example_group)
+        example = world.example_groups.first.examples.first
+        expect(example.metadata[:new_key]).to eq(:new_value)
+      end
+    end
+
     describe '#deprecation_stream' do
       it 'defaults to standard error' do
         expect($rspec_core_without_stderr_monkey_patch.deprecation_stream).to eq STDERR


### PR DESCRIPTION
Fix https://github.com/rspec/rspec-core/issues/2078

Use case: 
- [sauce_rspec/rspec.rb](https://github.com/bootstraponline/sauce_rspec/blob/db6904bfd8fc3b7038f77ad64960ebaef5171a0f/lib/sauce_rspec/rspec.rb)
- [SauceRSpec config](https://github.com/bootstraponline/sauce_connect_ruby/blob/f2b5e9cd0c941492ced15912b26cb36987e3439c/helper/sauce_helper.rb#L4)

Enables running an unmodified test suite on multiple Selenium browsers.