### PR TITLE
Add a spec for interrupt trapping in Runner

### DIFF
--- a/BUILD_DETAIL.md
+++ b/BUILD_DETAIL.md
@@ -1,5 +1,5 @@
 <!---
-This file was generated on 2015-07-27T23:49:06-07:00 from the rspec-dev repo.
+This file was generated on 2015-12-07T22:01:00+11:00 from the rspec-dev repo.
 DO NOT modify it by hand as your changes will get lost the next time it is generated.
 -->
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!---
-This file was generated on 2015-07-27T23:49:06-07:00 from the rspec-dev repo.
+This file was generated on 2015-12-07T22:01:00+11:00 from the rspec-dev repo.
 DO NOT modify it by hand as your changes will get lost the next time it is generated.
 -->
 
@@ -10,33 +10,50 @@ values contributions from anyone, the RSpec project has adopted the
 following code of conduct. All contributors and participants (including
 maintainers!) are expected to abide by its terms.
 
-As contributors and maintainers of this project, we pledge to respect all
-people who contribute through reporting issues, posting feature requests,
-updating documentation, submitting pull requests or patches, and other
-activities.
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
 
 We are committed to making participation in this project a harassment-free
 experience for everyone, regardless of level of experience, gender, gender
 identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion or similar personal characteristic.
+body size, race, ethnicity, age, religion, or nationality.
 
-Examples of unacceptable behavior by participants include, but are not limited
-to, the use of sexual language or imagery, derogatory comments or personal
-attacks, trolling, public or private harassment, insults, or other
-unprofessional conduct.
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct. Project maintainers who do not
-follow the Code of Conduct may be removed from the project team.
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
 
-This code of conduct applies both within project spaces and in public spaces
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by opening an issue or contacting one or more of the project
-maintainers.
+reported by contacting one of the project maintainers listed at
+http://rspec.info/about/. All complaints will be reviewed and investigated
+and will result in a response that is deemed necessary and appropriate to the
+circumstances. Maintainers are obligated to maintain confidentiality with
+regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the [Contributor
-Covenant](http://contributor-covenant.org), version 1.1.0, available at
-[http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 <!---
-This file was generated on 2015-07-27T23:49:06-07:00 from the rspec-dev repo.
+This file was generated on 2015-12-07T22:01:00+11:00 from the rspec-dev repo.
 DO NOT modify it by hand as your changes will get lost the next time it is generated.
 -->
 
 # Contributing
 
-RSpec is a community-driven project that has benefited from improvements from over over *500* contributors.
+RSpec is a community-driven project that has benefited from improvements from over *500* contributors.
 We welcome contributions from *everyone*. While contributing, please follow the project [code of conduct](CODE_OF_CONDUCT.md), so that everyone can be included.
 
 If you'd like to help make RSpec better, here are some ways you can contribute:

--- a/Changelog.md
+++ b/Changelog.md
@@ -49,6 +49,9 @@ Enhancements:
   (Yuji Nakayama, #2083)
 * Add `max_displayed_failure_line_count` configuration option
   (defaults to 10). (Yuji Nakayama, #2083)
+* Enhance `fail_fast` option so it can take a number (e.g. `--fail-fast=3`)
+  to force the run to abort after the specified number of failures.
+  (Jack Scotti, #2065)
 
 Bug Fixes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,8 @@ Enhancements:
   line from backtrace" messages. (Myron Marston, #2088)
 * Add support for `:extra_failure_lines` example metadata that will
   be appended to the failure output. (bootstraponline, #2092).
+* Add `RSpec::Core::Example#duplicate_with` to produce new examples
+  with cloned metadata. (bootstraponline, #2098)
 
 Bug Fixes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,8 @@ Enhancements:
   be appended to the failure output. (bootstraponline, #2092).
 * Add `RSpec::Core::Example#duplicate_with` to produce new examples
   with cloned metadata. (bootstraponline, #2098)
+* Add `on_example_group_definition` to register hooks to be invoked when
+  example groups are created. (bootstraponline, #2094)
 
 Bug Fixes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -40,8 +40,10 @@ Enhancements:
   be appended to the failure output. (bootstraponline, #2092).
 * Add `RSpec::Core::Example#duplicate_with` to produce new examples
   with cloned metadata. (bootstraponline, #2098)
-* Add `on_example_group_definition` to register hooks to be invoked when
-  example groups are created. (bootstraponline, #2094)
+* Add `RSpec::Core::Configuration#on_example_group_definition` to register
+  hooks to be invoked when example groups are created. (bootstraponline, #2094)
+* Add `add_example` and `remove_example` to `RSpec::Core::ExampleGroup` to
+  allow  manipulating an example groups examples. (bootstraponline, #2095)
 
 Bug Fixes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -52,6 +52,9 @@ Enhancements:
 * Enhance `fail_fast` option so it can take a number (e.g. `--fail-fast=3`)
   to force the run to abort after the specified number of failures.
   (Jack Scotti, #2065)
+* Syntax highlight the failure snippets in text formatters when `color`
+  is enabled and the `coderay` gem is installed on a POSIX system.
+  (Myron Marston, #2109)
 
 Bug Fixes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -44,6 +44,11 @@ Enhancements:
   hooks to be invoked when example groups are created. (bootstraponline, #2094)
 * Add `add_example` and `remove_example` to `RSpec::Core::ExampleGroup` to
   allow  manipulating an example groups examples. (bootstraponline, #2095)
+* Display multiline failure source lines in failure output when Ripper is
+  available (MRI >= 1.9.2, and JRuby >= 1.7.5 && < 9.0.0.0.rc1).
+  (Yuji Nakayama, #2083)
+* Add `max_displayed_failure_line_count` configuration option
+  (defaults to 10). (Yuji Nakayama, #2083)
 
 Bug Fixes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -49,6 +49,8 @@ Bug Fixes:
 * Fix regression in 3.3 that caused spec file names with square brackets in
   them (such as `1[]_spec.rb`) to not be loaded properly. (Myron Marston, #2041)
 * Fix output encoding issue caused by ASCII literal on 1.9.3 (Jon Rowe, #2072)
+* Fix requires in `rspec/core/rake_task.rb` to avoid double requires
+  seen by some users. (Myron Marston, #2101)
 
 ### 3.3.2 / 2015-07-15
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.3.1...v3.3.2)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
-### 3.4.0 Development
-[Full Changelog](http://github.com/rspec/rspec-core/compare/v3.3.2...master)
+### 3.4.0 / 2015-11-11
+[Full Changelog](http://github.com/rspec/rspec-core/compare/v3.3.2...v3.4.0)
 
 Enhancements:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### 3.4.1 / 2015-11-18
+[Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.0...v3.4.1)
+
+Bug Fixes:
+
+* Fix backtrace formatter to handle backtraces that are `nil`.
+  (Myron Marston, #2118)
+
 ### 3.4.0 / 2015-11-11
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.3.2...v3.4.0)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,5 @@
 <!---
-This file was generated on 2015-07-27T23:49:06-07:00 from the rspec-dev repo.
+This file was generated on 2015-12-07T22:01:00+11:00 from the rspec-dev repo.
 DO NOT modify it by hand as your changes will get lost the next time it is generated.
 -->
 

--- a/features/command_line/fail_fast.feature
+++ b/features/command_line/fail_fast.feature
@@ -3,17 +3,29 @@ Feature: `--fail-fast` option
   Use the `--fail-fast` option to tell RSpec to stop running the test suite on
   the first failed test.
 
-  You may also specify `--no-fail-fast` to turn it off (default behaviour).
+  You may add a parameter to tell RSpec to stop running the test suite after N
+  failed tests, for example: `--fail-fast=3`.
+
+  You can also specify `--no-fail-fast` to turn it off (default behaviour).
 
   Background:
     Given a file named "fail_fast_spec.rb" with:
       """ruby
       RSpec.describe "fail fast" do
         it "passing test" do; end
-        it "failing test" do
+        it "1st failing test" do
           fail
         end
-        it "this should not be run" do; end
+        it "2nd failing test" do
+          fail
+        end
+        it "3rd failing test" do
+          fail
+        end
+        it "4th failing test" do
+          fail
+        end
+        it "passing test" do; end
       end
       """
 
@@ -22,6 +34,11 @@ Feature: `--fail-fast` option
     Then the output should contain ".F"
     Then the output should not contain ".F."
 
+  Scenario: Using `--fail-fast=3`
+    When I run `rspec . --fail-fast=3`
+    Then the output should contain ".FFF"
+    Then the output should not contain ".FFFF."
+
   Scenario: Using `--no-fail-fast`
     When I run `rspec . --no-fail-fast`
-    Then the output should contain ".F."
+    Then the output should contain ".FFFF."

--- a/features/configuration/fail_fast.feature
+++ b/features/configuration/fail_fast.feature
@@ -1,6 +1,6 @@
 Feature: fail fast
 
-  Use the `fail_fast` option to tell RSpec to abort the run on after N failures:
+  Use the `fail_fast` option to tell RSpec to abort the run after N failures:
 
   Scenario: `fail_fast` with no failures (runs all examples)
     Given a file named "spec/spec_helper.rb" with:

--- a/features/configuration/fail_fast.feature
+++ b/features/configuration/fail_fast.feature
@@ -1,19 +1,13 @@
 Feature: fail fast
 
-  Use the `fail_fast` option to tell RSpec to abort the run on first failure:
-
-  ```ruby
-  RSpec.configure { |c| c.fail_fast = true }
-  ```
-
-  Background:
-    Given a file named "spec/spec_helper.rb" with:
-      """ruby
-      RSpec.configure {|c| c.fail_fast = true}
-      """
+  Use the `fail_fast` option to tell RSpec to abort the run on after N failures:
 
   Scenario: `fail_fast` with no failures (runs all examples)
-    Given a file named "spec/example_spec.rb" with:
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure {|c| c.fail_fast = 1}
+      """
+    And a file named "spec/example_spec.rb" with:
       """ruby
       RSpec.describe "something" do
         it "passes" do
@@ -27,7 +21,11 @@ Feature: fail fast
     Then the examples should all pass
 
   Scenario: `fail_fast` with first example failing (only runs the one example)
-    Given a file named "spec/example_spec.rb" with:
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure {|c| c.fail_fast = 1}
+      """
+    And a file named "spec/example_spec.rb" with:
       """ruby
       require "spec_helper"
       RSpec.describe "something" do
@@ -43,7 +41,11 @@ Feature: fail fast
     Then the output should contain "1 example, 1 failure"
 
   Scenario: `fail_fast` with multiple files, second example failing (only runs the first two examples)
-    Given a file named "spec/example_1_spec.rb" with:
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure {|c| c.fail_fast = 1}
+      """
+    And a file named "spec/example_1_spec.rb" with:
       """ruby
       require "spec_helper"
       RSpec.describe "something" do
@@ -77,3 +79,31 @@ Feature: fail fast
       """
     When I run `rspec spec`
     Then the output should contain "2 examples, 1 failure"
+
+
+  Scenario: `fail_fast 2` with 1st and 3rd examples failing (only runs the first 3 examples)
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure {|c| c.fail_fast = 2}
+      """
+    And a file named "spec/example_spec.rb" with:
+      """ruby
+      require "spec_helper"
+      RSpec.describe "something" do
+        it "fails once" do
+          fail
+        end
+
+        it "passes once" do
+        end
+
+        it "fails twice" do
+          fail
+        end
+
+        it "passes" do
+        end
+      end
+      """
+    When I run `rspec spec/example_spec.rb -fd`
+    Then the output should contain "3 examples, 2 failures"

--- a/features/expectation_framework_integration/aggregating_failures.feature
+++ b/features/expectation_framework_integration/aggregating_failures.feature
@@ -1,6 +1,6 @@
 Feature: Aggregating Failures
 
-  RSpec::Expectations provides [`aggregate_failures`](/rspec/rspec-expectations/v/3-4/docs/aggregating-failures), an API that allows you to group a set of expectations and see all the failures at once, rather than it aborting on the first failure. RSpec::Core improves on this feature in a couple of ways:
+  RSpec::Expectations provides [`aggregate_failures`](https://relishapp.com/rspec/rspec-expectations/docs/aggregating-failures), an API that allows you to group a set of expectations and see all the failures at once, rather than it aborting on the first failure. RSpec::Core improves on this feature in a couple of ways:
 
     * RSpec::Core provides much better failure output, adding code snippets and backtraces to the sub-failures, just like it does for any normal failure.
     * RSpec::Core provides [metadata](../metadata/user-defined-metadata) integration for this feature. Each example that is tagged with `:aggregate_failures` will be wrapped in an `aggregate_failures` block. You can also use `config.define_derived_metadata` to apply this to every example automatically.

--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -31,6 +31,7 @@ module RSpec
       end
 
       def format_backtrace(backtrace, options={})
+        return [] unless backtrace
         return backtrace if options[:full_backtrace] || backtrace.empty?
 
         backtrace.map { |l| backtrace_line(l) }.compact.

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -332,6 +332,11 @@ module RSpec
       # Currently this will place a mutex around memoized values such as let blocks.
       add_setting :threadsafe
 
+      # @macro add_setting
+      # Maximum count of failed source lines to display in the failure reports.
+      # (default `10`).
+      add_setting :max_displayed_failure_line_count
+
       # @private
       add_setting :tty
       # @private
@@ -387,6 +392,7 @@ module RSpec
         @libs = []
         @derived_metadata_blocks = FilterableItemRepository::QueryOptimized.new(:any?)
         @threadsafe = true
+        @max_displayed_failure_line_count = 10
 
         define_built_in_hooks
       end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -186,7 +186,8 @@ module RSpec
       end
 
       # @macro add_setting
-      # Clean up and exit after the first failure (default: `false`).
+      # If specified, indicates the number of failures required before cleaning
+      # up and exit (default: `false`).
       add_setting :fail_fast
 
       # @macro add_setting

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -187,7 +187,7 @@ module RSpec
 
       # @macro add_setting
       # If specified, indicates the number of failures required before cleaning
-      # up and exit (default: `false`).
+      # up and exit (default: `nil`).
       add_setting :fail_fast
 
       # @macro add_setting

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1684,6 +1684,17 @@ module RSpec
         @hooks ||= HookCollections.new(self, FilterableItemRepository::QueryOptimized)
       end
 
+      # Invokes block before defining an example group
+      def on_example_group_definition(&block)
+        on_example_group_definition_callbacks << block
+      end
+
+      # @api private
+      # Returns an array of blocks to call before defining an example group
+      def on_example_group_definition_callbacks
+        @on_example_group_definition_callbacks ||= []
+      end
+
     private
 
       def handle_suite_hook(args, collection, append_or_prepend, hook_type, block)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -136,7 +136,9 @@ module RSpec
           new_metadata.delete reserved_key
         end
 
-        Example.new(example_group.clone, description.clone,
+        # don't clone the example group because the new example
+        # must belong to the same example group (not a clone).
+        Example.new(example_group, description.clone,
                     new_metadata, new_metadata[:block])
       end
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -124,6 +124,22 @@ module RSpec
         id.match(/\A(.*?)(?:\[([\d\s:,]+)\])?\z/).captures
       end
 
+      # Duplicates the example and overrides metadata with the provided
+      # hash.
+      #
+      # @param metadata_overrides [Hash] the hash to override the example metadata
+      # @return [Example] a duplicate of the example with modified metadata
+      def duplicate_with(metadata_overrides={})
+        new_metadata = metadata.clone.merge(metadata_overrides)
+
+        RSpec::Core::Metadata::RESERVED_KEYS.each do |reserved_key|
+          new_metadata.delete reserved_key
+        end
+
+        Example.new(example_group.clone, description.clone,
+                    new_metadata, new_metadata[:block])
+      end
+
       # @attr_reader
       #
       # Returns the first exception raised in the context of running this

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -547,8 +547,8 @@ module RSpec
           for_filtered_examples(reporter) { |example| example.skip_with_exception(reporter, ex) }
           true
         rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
-          RSpec.world.wants_to_quit = true if fail_fast?
           for_filtered_examples(reporter) { |example| example.fail_with_exception(reporter, ex) }
+          RSpec.world.wants_to_quit = true if reporter.fail_fast_limit_met?
           false
         ensure
           run_after_context_hooks(new('after(:context) hook')) if should_run_context_hooks
@@ -579,7 +579,7 @@ module RSpec
           instance = new(example.inspect_output)
           set_ivars(instance, before_context_ivars)
           succeeded = example.run(instance, reporter)
-          if !succeeded && fail_fast? && reporter.fail_fast_limit_met?
+          if !succeeded && reporter.fail_fast_limit_met?
             RSpec.world.wants_to_quit = true
           end
           succeeded
@@ -596,11 +596,6 @@ module RSpec
           reporter.example_group_finished(child)
         end
         false
-      end
-
-      # @private
-      def self.fail_fast?
-        RSpec.configuration.fail_fast?
       end
 
       # @private

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -579,7 +579,9 @@ module RSpec
           instance = new(example.inspect_output)
           set_ivars(instance, before_context_ivars)
           succeeded = example.run(instance, reporter)
-          RSpec.world.wants_to_quit = true if fail_fast? && !succeeded
+          if !succeeded && fail_fast? && reporter.fail_fast_limit_met?
+            RSpec.world.wants_to_quit = true
+          end
           succeeded
         end.all?
       end

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -348,7 +348,6 @@ module RSpec
         @_descendants = nil
         @parent_groups = nil
         @declaration_line_numbers = nil
-        @before_context_ivars = nil
       end
 
       # Adds an example to the example group

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -2,6 +2,7 @@ RSpec::Support.require_rspec_support 'recursive_const_methods'
 
 module RSpec
   module Core
+    # rubocop:disable Metrics/ClassLength
     # ExampleGroup and {Example} are the main structural elements of
     # rspec-core. Consider this example:
     #
@@ -340,6 +341,28 @@ module RSpec
         find_and_eval_shared("examples", name, caller.first, *args, &block)
       end
 
+      # Clear memoized values when adding/removing examples
+      # @private
+      def self.reset_memoized
+        @descendant_filtered_examples = nil
+        @_descendants = nil
+        @parent_groups = nil
+        @declaration_line_numbers = nil
+        @before_context_ivars = nil
+      end
+
+      # Adds an example to the example group
+      def self.add_example(example)
+        reset_memoized
+        examples << example
+      end
+
+      # Removes an example from the example group
+      def self.remove_example(example)
+        reset_memoized
+        examples.delete example
+      end
+
       # @private
       def self.find_and_eval_shared(label, name, inclusion_location, *args, &customization_block)
         shared_block = RSpec.world.shared_example_group_registry.find(parent_groups, name)
@@ -671,6 +694,7 @@ module RSpec
         super
       end
     end
+    # rubocop:enable Metrics/ClassLength
 
     # @private
     # Unnamed example group used by `SuiteHookContext`.

--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -73,6 +73,7 @@ module RSpec::Core::Formatters
   autoload :ProfileFormatter,         'rspec/core/formatters/profile_formatter'
   autoload :JsonFormatter,            'rspec/core/formatters/json_formatter'
   autoload :BisectFormatter,          'rspec/core/formatters/bisect_formatter'
+  autoload :ExceptionPresenter,       'rspec/core/formatters/exception_presenter'
 
   # Register the formatter class
   # @param formatter_class [Class] formatter class to register

--- a/lib/rspec/core/formatters/bisect_progress_formatter.rb
+++ b/lib/rspec/core/formatters/bisect_progress_formatter.rb
@@ -39,7 +39,7 @@ module RSpec
         end
 
         def bisect_dependency_check_failed(_notification)
-          output.puts " failure is not order-dependent"
+          output.puts " failure(s) do not require any non-failures to run first"
         end
 
         def bisect_round_started(notification, include_trailing_space=true)

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -192,8 +192,9 @@ module RSpec
           end
 
           file_path, line_number = matching_line.match(/(.+?):(\d+)(|:\d+)/)[1..2]
+          max_line_count = RSpec.configuration.max_displayed_failure_line_count
           RSpec::Support.require_rspec_core "formatters/snippet_extractor"
-          SnippetExtractor.extract_expression_lines_at(file_path, line_number.to_i)
+          SnippetExtractor.extract_expression_lines_at(file_path, line_number.to_i, max_line_count)
         rescue SnippetExtractor::NoSuchFileError
           ["Unable to find #{file_path} to read failed line"]
         rescue SnippetExtractor::NoSuchLineError

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -140,7 +140,17 @@ module RSpec
         end
 
         def failure_lines
-          @failure_lines ||= failure_slash_error_lines + exception_lines + extra_failure_lines
+          @failure_lines ||= [].tap do |lines|
+            lines.concat(failure_slash_error_lines)
+
+            sections = [failure_slash_error_lines, exception_lines]
+            if sections.any? { |section| section.size > 1 } && !exception_lines.first.empty?
+              lines << ''
+            end
+
+            lines.concat(exception_lines)
+            lines.concat(extra_failure_lines)
+          end
         end
 
         def failure_slash_error_lines

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -125,21 +125,20 @@ module RSpec
         end
 
         def failure_lines
-          @failure_lines ||=
-            begin
-              lines = []
-              lines << failure_slash_error_line unless (description == failure_slash_error_line)
-              lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
-              encoded_string(exception.message.to_s).split("\n").each do |line|
-                lines << "  #{line}"
-              end
-              unless @extra_failure_lines.empty?
-                lines << ''
-                lines.concat(@extra_failure_lines)
-                lines << ''
-              end
-              lines
+          @failure_lines ||= begin
+            lines = []
+            lines << failure_slash_error_line unless (description == failure_slash_error_line)
+            lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
+            encoded_string(exception.message.to_s).split("\n").each do |line|
+              lines << "  #{line}"
             end
+            unless @extra_failure_lines.empty?
+              lines << ''
+              lines.concat(@extra_failure_lines)
+              lines << ''
+            end
+            lines
+          end
         end
 
         def add_shared_group_lines(lines, colorizer)

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -93,7 +93,7 @@ module RSpec
       private
 
         def final_exception(exception)
-          if exception.cause
+          if exception.cause && exception != exception.cause
             final_exception(exception.cause)
           else
             exception

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -92,9 +92,11 @@ module RSpec
 
       private
 
-        def final_exception(exception)
-          if exception.cause && exception != exception.cause
-            final_exception(exception.cause)
+        def final_exception(exception, previous=[])
+          cause = exception.cause
+          if cause && !previous.include?(cause)
+            previous << cause
+            final_exception(cause, previous)
           else
             exception
           end

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -35,7 +35,7 @@ module RSpec
         end
 
         def formatted_backtrace(exception=@exception)
-          backtrace_formatter.format_backtrace((exception.backtrace || []), example.metadata) +
+          backtrace_formatter.format_backtrace(exception.backtrace, example.metadata) +
             formatted_cause(exception)
         end
 

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -159,7 +159,7 @@ module RSpec
           if lines.count == 1
             lines[0] = "Failure/Error: #{lines[0].strip}"
           else
-            least_indentation = lines.map { |line| line[/^[ \t]*/] }.min
+            least_indentation = SnippetExtractor.least_indentation_from(lines)
             lines = lines.map { |line| line.sub(/^#{least_indentation}/, '  ') }
             lines.unshift('Failure/Error:')
           end
@@ -204,7 +204,8 @@ module RSpec
 
           file_path, line_number = matching_line.match(/(.+?):(\d+)(|:\d+)/)[1..2]
           max_line_count = RSpec.configuration.max_displayed_failure_line_count
-          SnippetExtractor.extract_expression_lines_at(file_path, line_number.to_i, max_line_count)
+          lines = SnippetExtractor.extract_expression_lines_at(file_path, line_number.to_i, max_line_count)
+          RSpec.world.source_cache.syntax_highlighter.highlight(lines)
         rescue SnippetExtractor::NoSuchFileError
           ["Unable to find #{file_path} to read failed line"]
         rescue SnippetExtractor::NoSuchLineError

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+RSpec::Support.require_rspec_core "formatters/snippet_extractor"
 RSpec::Support.require_rspec_support "encoded_string"
 
 module RSpec
@@ -203,7 +204,6 @@ module RSpec
 
           file_path, line_number = matching_line.match(/(.+?):(\d+)(|:\d+)/)[1..2]
           max_line_count = RSpec.configuration.max_displayed_failure_line_count
-          RSpec::Support.require_rspec_core "formatters/snippet_extractor"
           SnippetExtractor.extract_expression_lines_at(file_path, line_number.to_i, max_line_count)
         rescue SnippetExtractor::NoSuchFileError
           ["Unable to find #{file_path} to read failed line"]

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -137,12 +137,12 @@ module RSpec
         # spec. For example, you could output links to images or other files
         # produced during the specs.
         def extra_failure_content(failure)
-          RSpec::Support.require_rspec_core "formatters/snippet_extractor"
+          RSpec::Support.require_rspec_core "formatters/html_snippet_extractor"
           backtrace = (failure.exception.backtrace || []).map do |line|
             RSpec.configuration.backtrace_formatter.backtrace_line(line)
           end
           backtrace.compact!
-          @snippet_extractor ||= SnippetExtractor.new
+          @snippet_extractor ||= HtmlSnippetExtractor.new
           "    <pre class=\"ruby\"><code>#{@snippet_extractor.snippet(backtrace)}</code></pre>"
         end
       end

--- a/lib/rspec/core/formatters/html_snippet_extractor.rb
+++ b/lib/rspec/core/formatters/html_snippet_extractor.rb
@@ -5,7 +5,7 @@ module RSpec
       #
       # Extracts code snippets by looking at the backtrace of the passed error
       # and applies synax highlighting and line numbers using html.
-      class SnippetExtractor
+      class HtmlSnippetExtractor
         # @private
         module NullConverter
           def self.convert(code)

--- a/lib/rspec/core/formatters/snippet_extractor.rb
+++ b/lib/rspec/core/formatters/snippet_extractor.rb
@@ -1,0 +1,129 @@
+RSpec::Support.require_rspec_core "source"
+
+module RSpec
+  module Core
+    module Formatters
+      # @private
+      class SnippetExtractor
+        NoSuchFileError = Class.new(StandardError)
+        NoSuchLineError = Class.new(StandardError)
+
+        def self.extract_line_at(file_path, line_number)
+          source = source_from_file(file_path)
+          line = source.lines[line_number - 1]
+          raise NoSuchLineError unless line
+          line
+        end
+
+        def self.source_from_file(path)
+          raise NoSuchFileError unless File.exist?(path)
+          RSpec.world.source_cache.source_from_file(path)
+        end
+
+        if RSpec::Support::RubyFeatures.ripper_supported?
+          NoExpressionAtLineError = Class.new(StandardError)
+
+          PAREN_TOKEN_TYPE_PAIRS = {
+            :on_lbracket    => :on_rbracket,
+            :on_lparen      => :on_rparen,
+            :on_lbrace      => :on_rbrace,
+            :on_heredoc_beg => :on_heredoc_end
+          }
+
+          attr_reader :source, :beginning_line_number
+
+          def self.extract_expression_lines_at(file_path, beginning_line_number)
+            source = source_from_file(file_path)
+            new(source, beginning_line_number).expression_lines
+          end
+
+          def initialize(source, beginning_line_number)
+            @source = source
+            @beginning_line_number = beginning_line_number
+          end
+
+          def expression_lines
+            line_range = line_range_of_expression
+            source.lines[(line_range.begin - 1)..(line_range.end - 1)]
+          rescue NoExpressionAtLineError
+            [self.class.extract_line_at(source.path, beginning_line_number)]
+          end
+
+          private
+
+          def line_range_of_expression
+            @line_range_of_expression ||= begin
+              line_range = line_range_of_location_nodes_in_expression
+              initial_unclosed_parens = unclosed_paren_tokens_in_line_range(line_range)
+              unclosed_parens = initial_unclosed_parens
+
+              until (initial_unclosed_parens & unclosed_parens).empty?
+                line_range = (line_range.begin)..(line_range.end + 1)
+                unclosed_parens = unclosed_paren_tokens_in_line_range(line_range)
+              end
+
+              line_range
+            end
+          end
+
+          def unclosed_paren_tokens_in_line_range(line_range)
+            tokens = FlatMap.flat_map(line_range) do |line_number|
+              source.tokens_by_line_number[line_number]
+            end
+
+            tokens.each_with_object([]) do |token, unclosed_tokens|
+              if PAREN_TOKEN_TYPE_PAIRS.keys.include?(token.type)
+                unclosed_tokens << token
+              else
+                index = unclosed_tokens.rindex do |unclosed_token|
+                  PAREN_TOKEN_TYPE_PAIRS[unclosed_token.type] == token.type
+                end
+                unclosed_tokens.delete_at(index) if index
+              end
+            end
+          end
+
+          def line_range_of_location_nodes_in_expression
+            line_numbers = expression_node.each_with_object(Set.new) do |node, set|
+              set << node.location.line if node.location
+            end
+
+            line_numbers.min..line_numbers.max
+          end
+
+          def expression_node
+            raise NoExpressionAtLineError if location_nodes_at_beginning_line.empty?
+
+            @expression_node ||= begin
+              common_ancestor_nodes = location_nodes_at_beginning_line.map do |node|
+                node.each_ancestor.to_a
+              end.reduce(:&)
+
+              common_ancestor_nodes.find { |node| expression_outmost_node?(node) }
+            end
+          end
+
+          def expression_outmost_node?(node)
+            return true unless node.parent
+            return false if node.type.to_s.start_with?('@')
+            ![node, node.parent].all? do |n|
+              # See `Ripper::PARSER_EVENTS` for the complete list of sexp types.
+              type = n.type.to_s
+              type.end_with?('call') || type.start_with?('method_add_')
+            end
+          end
+
+          def location_nodes_at_beginning_line
+            source.nodes_by_line_number[beginning_line_number]
+          end
+        else
+          # :nocov:
+          def self.extract_expression_lines_at(file_path, beginning_line_number)
+            [extract_line_at(file_path, beginning_line_number)]
+          end
+          # :nocov:
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/core/formatters/snippet_extractor.rb
+++ b/lib/rspec/core/formatters/snippet_extractor.rb
@@ -55,7 +55,7 @@ module RSpec
             end
 
             source.lines[(line_range.begin - 1)..(line_range.end - 1)]
-          rescue NoExpressionAtLineError
+          rescue SyntaxError, NoExpressionAtLineError
             [self.class.extract_line_at(source.path, beginning_line_number)]
           end
 

--- a/lib/rspec/core/formatters/snippet_extractor.rb
+++ b/lib/rspec/core/formatters/snippet_extractor.rb
@@ -133,6 +133,10 @@ module RSpec
           end
           # :nocov:
         end
+
+        def self.least_indentation_from(lines)
+          lines.map { |line| line[/^[ \t]*/] }.min
+        end
       end
     end
   end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -1,7 +1,6 @@
 RSpec::Support.require_rspec_core "formatters/exception_presenter"
 RSpec::Support.require_rspec_core "formatters/helpers"
 RSpec::Support.require_rspec_core "shell_escape"
-RSpec::Support.require_rspec_support "encoded_string"
 
 module RSpec::Core
   # Notifications are value objects passed to formatters to provide them

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -281,10 +281,8 @@ module RSpec::Core
     # @attr pending_examples [Array<RSpec::Core::Example>] the pending examples
     # @attr load_time [Float] the number of seconds taken to boot RSpec
     #                         and load the spec files
-    # @attr syntax_highlighting_unavailable [Boolean] indicates if syntax highlighting
-    #       was attempted to be used but was unavailable.
-    SummaryNotification = Struct.new(:duration, :examples, :failed_examples, :pending_examples,
-                                     :load_time, :syntax_highlighting_unavailable)
+    SummaryNotification = Struct.new(:duration, :examples, :failed_examples,
+                                     :pending_examples, :load_time)
     class SummaryNotification
       # @api
       # @return [Fixnum] the number of examples run
@@ -362,11 +360,7 @@ module RSpec::Core
       # @return [String] The summary information fully formatted in the way that
       #   RSpec's built-in formatters emit.
       def fully_formatted(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
-        formatted = ""
-        if syntax_highlighting_unavailable
-          formatted << "\nSyntax highlighting of failure snippets unavailable -- install the coderay gem to enable it.\n"
-        end
-        formatted << "\nFinished in #{formatted_duration} " \
+        formatted = "\nFinished in #{formatted_duration} " \
                     "(files took #{formatted_load_time} to load)\n" \
                     "#{colorized_totals_line(colorizer)}\n"
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -281,7 +281,10 @@ module RSpec::Core
     # @attr pending_examples [Array<RSpec::Core::Example>] the pending examples
     # @attr load_time [Float] the number of seconds taken to boot RSpec
     #                         and load the spec files
-    SummaryNotification = Struct.new(:duration, :examples, :failed_examples, :pending_examples, :load_time)
+    # @attr syntax_highlighting_unavailable [Boolean] indicates if syntax highlighting
+    #       was attempted to be used but was unavailable.
+    SummaryNotification = Struct.new(:duration, :examples, :failed_examples, :pending_examples,
+                                     :load_time, :syntax_highlighting_unavailable)
     class SummaryNotification
       # @api
       # @return [Fixnum] the number of examples run
@@ -359,7 +362,11 @@ module RSpec::Core
       # @return [String] The summary information fully formatted in the way that
       #   RSpec's built-in formatters emit.
       def fully_formatted(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
-        formatted = "\nFinished in #{formatted_duration} " \
+        formatted = ""
+        if syntax_highlighting_unavailable
+          formatted << "\nSyntax highlighting of failure snippets unavailable -- install the coderay gem to enable it.\n"
+        end
+        formatted << "\nFinished in #{formatted_duration} " \
                     "(files took #{formatted_load_time} to load)\n" \
                     "#{colorized_totals_line(colorizer)}\n"
 

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -71,7 +71,18 @@ module RSpec::Core
           bisect_and_exit(argument)
         end
 
-        parser.on('--[no-]fail-fast', 'Abort the run on first failure.') do |value|
+        parser.on('--[no-]fail-fast[=COUNT]', 'Abort the run after a certain number of failures (1 by default).') do |argument|
+          if argument == true
+            value = 1
+          elsif argument == false || argument == 0
+            value = false
+          else
+            begin
+              value = Integer(argument)
+            rescue ArgumentError
+              RSpec.warning "Non integer specified as fail count."
+            end
+          end
           set_fail_fast(options, value)
         end
 
@@ -176,7 +187,7 @@ FILTERING
         parser.on("--next-failure", "Apply `--only-failures` and abort after one failure.",
                   "  (Equivalent to `--only-failures --fail-fast --order defined`)") do
           configure_only_failures(options)
-          set_fail_fast(options, true)
+          set_fail_fast(options, 1)
           options[:order] ||= 'defined'
         end
 

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -80,7 +80,7 @@ module RSpec::Core
             begin
               value = Integer(argument)
             rescue ArgumentError
-              RSpec.warning "Non integer specified as fail count."
+              RSpec.warning "Expected an integer value for `--fail-fast`, got: #{argument.inspect}", :call_site => nil
             end
           end
           set_fail_fast(options, value)

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -1,8 +1,14 @@
 require 'rake'
 require 'rake/tasklib'
 require 'rspec/support'
-require 'rspec/support/ruby_features'
-require 'rspec/core/shell_escape'
+
+RSpec::Support.require_rspec_support "ruby_features"
+
+unless RSpec::Support.respond_to?(:require_rspec_core)
+  RSpec::Support.define_optimized_require_for_rspec(:core) { |f| require_relative "../#{f}" }
+end
+
+RSpec::Support.require_rspec_core "shell_escape"
 
 module RSpec
   module Core

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -4,9 +4,11 @@ require 'rspec/support'
 
 RSpec::Support.require_rspec_support "ruby_features"
 
+# :nocov:
 unless RSpec::Support.respond_to?(:require_rspec_core)
   RSpec::Support.define_optimized_require_for_rspec(:core) { |f| require_relative "../#{f}" }
 end
+# :nocov:
 
 RSpec::Support.require_rspec_core "shell_escape"
 

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -197,6 +197,16 @@ module RSpec::Core
       exit!(exit_status)
     end
 
+    # @private
+    def fail_fast_limit_met?
+      failures_required <= @failed_examples.size
+    end
+
+    # @private
+    def failures_required
+      @configuration.fail_fast == true ? 1 : @configuration.fail_fast
+    end
+
   private
 
     def close

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -22,8 +22,6 @@ module RSpec::Core
 
     # @private
     attr_reader :examples, :failed_examples, :pending_examples
-    # @private
-    attr_accessor :syntax_highlighting_unavailable
 
     # @private
     def reset
@@ -167,8 +165,7 @@ module RSpec::Core
                                                                        @profiler.example_groups)
         end
         notify :dump_summary, Notifications::SummaryNotification.new(@duration, @examples, @failed_examples,
-                                                                     @pending_examples, @load_time,
-                                                                     syntax_highlighting_unavailable)
+                                                                     @pending_examples, @load_time)
         notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
       end
     end

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -22,6 +22,8 @@ module RSpec::Core
 
     # @private
     attr_reader :examples, :failed_examples, :pending_examples
+    # @private
+    attr_accessor :syntax_highlighting_unavailable
 
     # @private
     def reset
@@ -165,7 +167,8 @@ module RSpec::Core
                                                                        @profiler.example_groups)
         end
         notify :dump_summary, Notifications::SummaryNotification.new(@duration, @examples, @failed_examples,
-                                                                     @pending_examples, @load_time)
+                                                                     @pending_examples, @load_time,
+                                                                     syntax_highlighting_unavailable)
         notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
       end
     end

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -199,12 +199,13 @@ module RSpec::Core
 
     # @private
     def fail_fast_limit_met?
-      failures_required <= @failed_examples.size
-    end
+      return false unless (fail_fast = @configuration.fail_fast)
 
-    # @private
-    def failures_required
-      @configuration.fail_fast == true ? 1 : @configuration.fail_fast
+      if fail_fast == true
+        @failed_examples.any?
+      else
+        fail_fast <= @failed_examples.size
+      end
     end
 
   private
@@ -216,7 +217,7 @@ module RSpec::Core
     def mute_profile_output?
       # Don't print out profiled info if there are failures and `--fail-fast` is
       # used, it just clutters the output.
-      !@configuration.profile_examples? || (@configuration.fail_fast? && @failed_examples.size > 0)
+      !@configuration.profile_examples? || fail_fast_limit_met?
     end
 
     def seed_used?

--- a/lib/rspec/core/ruby_project.rb
+++ b/lib/rspec/core/ruby_project.rb
@@ -6,7 +6,7 @@ module RSpec
     # @private
     module RubyProject
       def add_to_load_path(*dirs)
-        dirs.map { |dir| add_dir_to_load_path(File.join(root, dir)) }
+        dirs.each { |dir| add_dir_to_load_path(File.join(root, dir)) }
       end
 
       def add_dir_to_load_path(dir)

--- a/lib/rspec/core/source.rb
+++ b/lib/rspec/core/source.rb
@@ -1,0 +1,60 @@
+RSpec::Support.require_rspec_core 'source/node'
+RSpec::Support.require_rspec_core 'source/token'
+
+module RSpec
+  module Core
+    # @private
+    # Represents a Ruby source file and provides access to AST and tokens.
+    class Source
+      attr_reader :source, :path
+
+      def self.from_file(path)
+        source = File.read(path)
+        new(source, path)
+      end
+
+      def initialize(source_string, path=nil)
+        @source = source_string
+        @path = path ? File.expand_path(path) : '(string)'
+      end
+
+      def lines
+        @lines ||= source.split("\n")
+      end
+
+      def ast
+        @ast ||= begin
+          require 'ripper'
+          sexp = Ripper.sexp(source)
+          Node.new(sexp)
+        end
+      end
+
+      def tokens
+        @tokens ||= begin
+          require 'ripper'
+          tokens = Ripper.lex(source)
+          Token.tokens_from_ripper_tokens(tokens)
+        end
+      end
+
+      def nodes_by_line_number
+        @nodes_by_line_number ||= begin
+          nodes_by_line_number = ast.select(&:location).group_by { |node| node.location.line }
+          Hash.new { |hash, key| hash[key] = [] }.merge(nodes_by_line_number)
+        end
+      end
+
+      def tokens_by_line_number
+        @tokens_by_line_number ||= begin
+          nodes_by_line_number = tokens.group_by { |token| token.location.line }
+          Hash.new { |hash, key| hash[key] = [] }.merge(nodes_by_line_number)
+        end
+      end
+
+      def inspect
+        "#<#{self.class} #{path}>"
+      end
+    end
+  end
+end

--- a/lib/rspec/core/source.rb
+++ b/lib/rspec/core/source.rb
@@ -55,6 +55,17 @@ module RSpec
       def inspect
         "#<#{self.class} #{path}>"
       end
+
+      # @private
+      class Cache
+        def initialize
+          @sources_by_path = {}
+        end
+
+        def source_from_file(path)
+          @sources_by_path[path] ||= Source.from_file(path)
+        end
+      end
     end
   end
 end

--- a/lib/rspec/core/source.rb
+++ b/lib/rspec/core/source.rb
@@ -26,6 +26,7 @@ module RSpec
         @ast ||= begin
           require 'ripper'
           sexp = Ripper.sexp(source)
+          raise SyntaxError unless sexp
           Node.new(sexp)
         end
       end

--- a/lib/rspec/core/source.rb
+++ b/lib/rspec/core/source.rb
@@ -1,4 +1,5 @@
 RSpec::Support.require_rspec_core 'source/node'
+RSpec::Support.require_rspec_core 'source/syntax_highlighter'
 RSpec::Support.require_rspec_core 'source/token'
 
 module RSpec
@@ -59,8 +60,11 @@ module RSpec
 
       # @private
       class Cache
-        def initialize
+        attr_reader :syntax_highlighter
+
+        def initialize(configuration)
           @sources_by_path = {}
+          @syntax_highlighter = SyntaxHighlighter.new(configuration)
         end
 
         def source_from_file(path)

--- a/lib/rspec/core/source/location.rb
+++ b/lib/rspec/core/source/location.rb
@@ -1,0 +1,13 @@
+module RSpec
+  module Core
+    class Source
+      # @private
+      # Represents a source location of node or token.
+      Location = Struct.new(:line, :column) do
+        def self.location?(array)
+          array.is_a?(Array) && array.size == 2 && array.all? { |e| e.is_a?(Integer) }
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/core/source/node.rb
+++ b/lib/rspec/core/source/node.rb
@@ -1,0 +1,93 @@
+RSpec::Support.require_rspec_core "source/location"
+
+module RSpec
+  module Core
+    class Source
+      # @private
+      # A wrapper for Ripper AST node which is generated with `Ripper.sexp`.
+      class Node
+        include Enumerable
+
+        attr_reader :sexp, :parent
+
+        def self.sexp?(array)
+          array.is_a?(Array) && array.first.is_a?(Symbol)
+        end
+
+        def initialize(ripper_sexp, parent=nil)
+          @sexp = ripper_sexp.freeze
+          @parent = parent
+        end
+
+        def type
+          sexp[0]
+        end
+
+        def args
+          @args ||= raw_args.map do |raw_arg|
+            if Node.sexp?(raw_arg)
+              Node.new(raw_arg, self)
+            elsif Location.location?(raw_arg)
+              Location.new(*raw_arg)
+            elsif raw_arg.is_a?(Array)
+              GroupNode.new(raw_arg, self)
+            else
+              raw_arg
+            end
+          end.freeze
+        end
+
+        def children
+          @children ||= args.select { |arg| arg.is_a?(Node) }.freeze
+        end
+
+        def location
+          @location ||= args.find { |arg| arg.is_a?(Location) }
+        end
+
+        def each(&block)
+          return to_enum(__method__) unless block_given?
+
+          yield self
+
+          children.each do |child|
+            child.each(&block)
+          end
+        end
+
+        def each_ancestor
+          return to_enum(__method__) unless block_given?
+
+          current_node = self
+
+          while (current_node = current_node.parent)
+            yield current_node
+          end
+        end
+
+        def inspect
+          "#<#{self.class} #{type}>"
+        end
+
+      private
+
+        def raw_args
+          sexp[1..-1] || []
+        end
+      end
+
+      # @private
+      class GroupNode < Node
+        def type
+          :group
+        end
+
+      private
+
+        def raw_args
+          sexp
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/core/source/syntax_highlighter.rb
+++ b/lib/rspec/core/source/syntax_highlighter.rb
@@ -31,10 +31,8 @@ module RSpec
         def color_enabled_implementation
           @color_enabled_implementation ||= begin
             ::Kernel.require 'coderay'
-            @configuration.reporter.syntax_highlighting_unavailable = false
             CodeRayImplementation
           rescue LoadError
-            @configuration.reporter.syntax_highlighting_unavailable = true
             NoSyntaxHighlightingImplementation
           end
         end

--- a/lib/rspec/core/source/syntax_highlighter.rb
+++ b/lib/rspec/core/source/syntax_highlighter.rb
@@ -1,0 +1,73 @@
+module RSpec
+  module Core
+    class Source
+      # @private
+      # Provides terminal syntax highlighting of code snippets
+      # when coderay is available.
+      class SyntaxHighlighter
+        def initialize(configuration)
+          @configuration = configuration
+        end
+
+        def highlight(lines)
+          implementation.highlight_syntax(lines)
+        end
+
+      private
+
+        if RSpec::Support::OS.windows?
+          # :nocov:
+          def implementation
+            WindowsImplementation
+          end
+          # :nocov:
+        else
+          def implementation
+            return color_enabled_implementation if @configuration.color_enabled?
+            NoSyntaxHighlightingImplementation
+          end
+        end
+
+        def color_enabled_implementation
+          @color_enabled_implementation ||= begin
+            ::Kernel.require 'coderay'
+            @configuration.reporter.syntax_highlighting_unavailable = false
+            CodeRayImplementation
+          rescue LoadError
+            @configuration.reporter.syntax_highlighting_unavailable = true
+            NoSyntaxHighlightingImplementation
+          end
+        end
+
+        # @private
+        module CodeRayImplementation
+          RESET_CODE = "\e[0m"
+
+          def self.highlight_syntax(lines)
+            highlighted = begin
+              CodeRay.encode(lines.join("\n"), :ruby, :terminal)
+            rescue Support::AllExceptionsExceptOnesWeMustNotRescue
+              return lines
+            end
+
+            highlighted.split("\n").map do |line|
+              line.sub(/\S/) { |char| char.insert(0, RESET_CODE) }
+            end
+          end
+        end
+
+        # @private
+        module NoSyntaxHighlightingImplementation
+          def self.highlight_syntax(lines)
+            lines
+          end
+        end
+
+        # @private
+        # Not sure why, but our code above (and/or coderay itself) does not work
+        # on Windows, so we disable the feature on Windows.
+        WindowsImplementation = NoSyntaxHighlightingImplementation
+      end
+    end
+  end
+end

--- a/lib/rspec/core/source/token.rb
+++ b/lib/rspec/core/source/token.rb
@@ -1,0 +1,43 @@
+RSpec::Support.require_rspec_core "source/location"
+
+module RSpec
+  module Core
+    class Source
+      # @private
+      # A wrapper for Ripper token which is generated with `Ripper.lex`.
+      class Token
+        attr_reader :token
+
+        def self.tokens_from_ripper_tokens(ripper_tokens)
+          ripper_tokens.map { |ripper_token| new(ripper_token) }.freeze
+        end
+
+        def initialize(ripper_token)
+          @token = ripper_token.freeze
+        end
+
+        def location
+          @location ||= Location.new(*token[0])
+        end
+
+        def type
+          token[1]
+        end
+
+        def string
+          token[2]
+        end
+
+        def ==(other)
+          token == other.token
+        end
+
+        alias_method :eql?, :==
+
+        def inspect
+          "#<#{self.class} #{type} #{string.inspect}>"
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/core/version.rb
+++ b/lib/rspec/core/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec Core.
     module Version
       # Current version of RSpec Core, in semantic versioning format.
-      STRING = '3.4.0'
+      STRING = '3.5.0.pre'
     end
   end
 end

--- a/lib/rspec/core/version.rb
+++ b/lib/rspec/core/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec Core.
     module Version
       # Current version of RSpec Core, in semantic versioning format.
-      STRING = '3.4.0.pre'
+      STRING = '3.4.0'
     end
   end
 end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -107,6 +107,14 @@ module RSpec
         @configuration.reporter
       end
 
+      # @private
+      def source_cache
+        @source_cache ||= begin
+          RSpec::Support.require_rspec_core "source"
+          Source::Cache.new
+        end
+      end
+
       # @api private
       #
       # Notify reporter of filters.

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -111,7 +111,7 @@ module RSpec
       def source_cache
         @source_cache ||= begin
           RSpec::Support.require_rspec_core "source"
-          Source::Cache.new
+          Source::Cache.new(@configuration)
         end
       end
 

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -49,6 +49,7 @@ module RSpec
       #
       # Register an example group.
       def register(example_group)
+        @configuration.on_example_group_definition_callbacks.each { |block| block.call(example_group) }
         example_groups << example_group
         @example_group_counts_by_spec_file[example_group.metadata[:absolute_file_path]] += 1
         example_group

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
 
-  s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : ["~> 1.5", "< 1.6.6.3"])
+  s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : ["~> 1.5", "< 1.6.6.3", "> 1.6.6.4"])
   s.add_development_dependency "coderay",  "~> 1.0.9"
 
   s.add_development_dependency "mocha",        "~> 0.13.0"

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
 
-  s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : ["~> 1.5", "!= 1.6.6.3"])
+  s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : ["~> 1.5", "!= 1.6.6.3", "!= 1.6.6.4"])
   s.add_development_dependency "coderay",  "~> 1.0.9"
 
   s.add_development_dependency "mocha",        "~> 0.13.0"

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
 
-  s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : ["~> 1.5", "< 1.6.6.3", "> 1.6.6.4"])
+  s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : ["~> 1.5", "!= 1.6.6.3"])
   s.add_development_dependency "coderay",  "~> 1.0.9"
 
   s.add_development_dependency "mocha",        "~> 0.13.0"

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
 
-  s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : "~> 1.5")
+  s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : ["~> 1.5", "< 1.6.6.3"])
   s.add_development_dependency "coderay",  "~> 1.0.9"
 
   s.add_development_dependency "mocha",        "~> 0.13.0"

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -132,10 +132,20 @@ module RSpec::Core
         end
       end
 
-      describe "an empty backtrace" do
+      describe "for an empty backtrace" do
         it "does not add the explanatory message about backtrace filtering" do
           formatter = BacktraceFormatter.new
           expect(formatter.format_backtrace([])).to eq([])
+        end
+      end
+
+      describe "for a `nil` backtrace (since exceptions can have no backtrace!)" do
+        it 'returns a blank array, with no explanatory message' do
+          exception = Exception.new
+          expect(exception.backtrace).to be_nil
+
+          formatter = BacktraceFormatter.new
+          expect(formatter.format_backtrace(exception.backtrace)).to eq([])
         end
       end
 

--- a/spec/rspec/core/bisect/coordinator_spec.rb
+++ b/spec/rspec/core/bisect/coordinator_spec.rb
@@ -108,7 +108,7 @@ module RSpec::Core
           |Bisect started using options: ""
           |Running suite to find failures... (n.nnnn seconds)
           |Starting bisect with 1 failing example and 7 non-failing examples.
-          |Checking that failure(s) are order-dependent... failure is not order-dependent
+          |Checking that failure(s) are order-dependent... failure(s) do not require any non-failures to run first
           |
           |Bisect complete! Reduced necessary non-failing examples from 7 to 0 in n.nnnn seconds.
           |

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -2172,6 +2172,17 @@ module RSpec::Core
       end
     end
 
+    describe '#max_displayed_failure_line_count' do
+      it 'defaults to 10' do
+        expect(config.max_displayed_failure_line_count).to eq 10
+      end
+
+      it 'is configurable' do
+        config.max_displayed_failure_line_count = 5
+        expect(config.max_displayed_failure_line_count).to eq 5
+      end
+    end
+
     # assigns files_or_directories_to_run and triggers post-processing
     # via `files_to_run`.
     def assign_files_or_directories_to_run(*value)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -18,6 +18,24 @@ module RSpec::Core
       end
     end
 
+    describe '#on_example_group_definition' do
+      let(:configuration) do
+        tmp_config = RSpec::Core::Configuration.new
+        tmp_config.on_example_group_definition do |example_group|
+          example_group.examples.first.metadata[:new_key] = :new_value
+        end
+        tmp_config
+      end
+      let(:world) { RSpec::Core::World.new(configuration) }
+
+      it 'successfully invokes the block' do
+        example_group = RSpec.describe("group") { it "example 1" do; end}
+        world.register(example_group)
+        example = world.example_groups.first.examples.first
+        expect(example.metadata[:new_key]).to eq(:new_value)
+      end
+    end
+
     describe '#deprecation_stream' do
       it 'defaults to standard error' do
         expect($rspec_core_without_stderr_monkey_patch.deprecation_stream).to eq STDERR

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -36,6 +36,12 @@ module RSpec::Core
       end
     end
 
+    describe "#fail_fast" do
+      it "defaults to `nil`" do
+        expect(RSpec::Core::Configuration.new.fail_fast).to be(nil)
+      end
+    end
+
     describe '#deprecation_stream' do
       it 'defaults to standard error' do
         expect($rspec_core_without_stderr_monkey_patch.deprecation_stream).to eq STDERR

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1345,9 +1345,9 @@ module RSpec::Core
 
       context "with fail_fast and failures_required == 1" do
         let(:group) do
-          the_group = RSpec.describe
-          allow(the_group).to receive(:fail_fast?) { true }
-          the_group
+          group = RSpec.describe
+          allow(group).to receive(:fail_fast?) { true }
+          group
         end
         let(:config)   { Configuration.new }
         let(:reporter) do
@@ -1358,28 +1358,28 @@ module RSpec::Core
 
         it "does not run examples after the failed example" do
           examples_run = []
-          self.group.example('example 1') { examples_run << self }
-          self.group.example('example 2') { examples_run << self; fail; }
-          self.group.example('example 3') { examples_run << self }
+          group().example('example 1') { examples_run << self }
+          group().example('example 2') { examples_run << self; fail; }
+          group().example('example 3') { examples_run << self }
 
-          self.group.run(reporter)
+          group().run(reporter)
 
           expect(examples_run.length).to eq(2)
         end
 
         it "sets RSpec.world.wants_to_quit flag if encountering an exception in before(:all)" do
-          self.group.before(:all) { raise "error in before all" }
-          self.group.example("equality") { expect(1).to eq(2) }
-          expect(self.group.run).to be_falsey
+          group().before(:all) { raise "error in before all" }
+          group().example("equality") { expect(1).to eq(2) }
+          expect(group().run).to be_falsey
           expect(RSpec.world.wants_to_quit).to be_truthy
         end
       end
 
       context "with fail_fast and failures_required = 3" do
         let(:group) do
-          the_group = RSpec.describe
-          allow(the_group).to receive(:fail_fast?) { true }
-          the_group
+          group = RSpec.describe
+          allow(group).to receive(:fail_fast?) { true }
+          group
         end
         let(:config) { Configuration.new }
 
@@ -1391,21 +1391,21 @@ module RSpec::Core
 
         it "does not run examples after 3 failed examples" do
           examples_run = []
-          self.group.example('example 1') { examples_run << self }
-          self.group.example('example 2') { examples_run << self; fail; }
-          self.group.example('example 3') { examples_run << self; fail; }
-          self.group.example('example 4') { examples_run << self; fail; }
-          self.group.example('example 5') { examples_run << self }
+          group().example('example 1') { examples_run << self }
+          group().example('example 2') { examples_run << self; fail; }
+          group().example('example 3') { examples_run << self; fail; }
+          group().example('example 4') { examples_run << self; fail; }
+          group().example('example 5') { examples_run << self }
 
-          self.group.run(reporter)
+          group().run(reporter)
 
           expect(examples_run.length).to eq(4)
         end
 
         it "sets RSpec.world.wants_to_quit flag if encountering an exception in before(:all)" do
-          self.group.before(:all) { raise "error in before all" }
-          self.group.example("equality") { expect(1).to eq(2) }
-          expect(self.group.run).to be_falsey
+          group().before(:all) { raise "error in before all" }
+          group().example("equality") { expect(1).to eq(2) }
+          expect(group().run).to be_falsey
           expect(RSpec.world.wants_to_quit).to be_truthy
         end
       end
@@ -1421,7 +1421,7 @@ module RSpec::Core
 
         it "returns without starting the group" do
           expect(reporter).not_to receive(:example_group_started)
-          self.group.run(reporter)
+          group().run(reporter)
         end
       end
 

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -713,6 +713,51 @@ module RSpec::Core
           group.run
           expect(order).to eq([:example, :after_example, :example, :after_example])
         end
+
+        describe "#currently_executing_a_context_hook?" do
+          it "sets currently_executing_a_context_hook? to false initially" do
+            group = RSpec.describe
+            expect(group.currently_executing_a_context_hook?).to be false
+          end
+
+          it "sets currently_executing_a_context_hook? during before(:context) execution" do
+            group = RSpec.describe
+            hook_result = nil
+            group.before(:context) { hook_result = group.currently_executing_a_context_hook? }
+            group.example("") {}
+            group.run
+            expect(hook_result).to be true
+          end
+
+          it "does not set currently_executing_a_context_hook? outside of before(:context) execution" do
+            group = RSpec.describe
+            hook_result = nil
+
+            group.before(:context) { hook_result = group.currently_executing_a_context_hook? }
+            group.before(:each) { hook_result = group.currently_executing_a_context_hook? }
+            group.example("") {}
+            group.run
+            expect(hook_result).to be false
+          end
+
+          it "sets currently_executing_a_context_hook? during after(:context) execution" do
+            group = RSpec.describe
+            hook_result = nil
+
+            group.after(:context) { hook_result = group.currently_executing_a_context_hook? }
+            group.example("") {}
+            group.run
+            expect(hook_result).to be true
+          end
+
+          it "unsets currently_executing_a_context_hook? after an after(:context) hook is done" do
+            group = RSpec.describe
+            group.after(:context) { }
+            group.example("") {}
+            group.run
+            expect(group.currently_executing_a_context_hook?).to be false
+          end
+        end
       end
 
       it "runs the before alls in order" do

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1796,9 +1796,7 @@ module RSpec::Core
 
       group.add_example group.examples.first
       expect(group.examples.length).to eq(2)
-
-      new_ids = group_ids group
-      new_ids.each_with_index { |id, idx| expect(id).to_not eq(original_ids[idx]) }
+      expect(original_ids).to_not eq(group_ids(group))
     end
 
     it 'allows removing examples' do
@@ -1813,9 +1811,7 @@ module RSpec::Core
 
       group.remove_example group.examples.first
       expect(group.examples.length).to eq(0)
-
-      new_ids = group_ids group
-      new_ids.each_with_index { |id, idx| expect(id).to_not eq(original_ids[idx]) }
+      expect(original_ids).to_not eq(group_ids(group))
     end
   end
 end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1775,5 +1775,47 @@ module RSpec::Core
         expect(inspect_output).to end_with("\"example at #{path}:#{line}\">")
       end
     end
+
+    def group_ids group
+      ids = []
+      ['descendant_filtered_examples', 'descendants',
+       'parent_groups', 'declaration_line_numbers', 'before_context_ivars'].each do |method|
+        ids << group.send(method).object_id
+      end
+      ids
+    end
+
+    it 'allows adding examples' do
+      group = RSpec.describe('group') do
+          example('ex 1') { expect(1).to eq(1) }
+      end
+
+      # ids should remain the same until we add/remove an example
+      original_ids = group_ids group
+      expect(original_ids).to eq(group_ids(group))
+
+      group.add_example group.examples.first
+      expect(group.examples.length).to eq(2)
+
+      new_ids = group_ids group
+      new_ids.each_with_index { |id, idx| expect(id).to_not eq(original_ids[idx]) }
+    end
+
+    it 'allows removing examples' do
+      group = RSpec.describe('group') do
+        example('ex 1') { expect(1).to eq(1) }
+      end
+      group.add_example group.examples.first
+
+      # ids should remain the same until we add/remove an example
+      original_ids = group_ids group
+      expect(original_ids).to eq(group_ids(group))
+
+      group.remove_example group.examples.first
+      expect(group.examples.length).to eq(0)
+
+      new_ids = group_ids group
+      new_ids.each_with_index { |id, idx| expect(id).to_not eq(original_ids[idx]) }
+    end
   end
 end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -52,6 +52,9 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
 
       # cloned examples must have unique ids
       expect(example.id).to_not eq(example2.id)
+
+      # cloned examples must both refer to the same example group (not a clone)
+      expect(example.example_group.object_id).to eq(example2.example_group.object_id)
     end
   end
 

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
     end
   end
 
+  describe '#duplicate_with' do
+    it 'successfully duplicates an example' do
+      example = example_group.example { raise 'first' }
+      example2 = example.duplicate_with({ :custom_key => :custom_value })
+
+      # ensure metadata is unique for each example
+      expect(example.metadata.object_id).to_not eq(example2.metadata.object_id)
+      expect(example.metadata[:custom_key]).to eq(nil)
+      expect(example2.metadata[:custom_key]).to eq(:custom_value)
+
+      # cloned examples must have unique ids
+      expect(example.id).to_not eq(example2.id)
+    end
+  end
+
   describe "#exception" do
     it "supplies the exception raised, if there is one" do
       example = example_group.example { raise "first" }

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -107,8 +107,8 @@ module RSpec::Core
 
       it 'allows a caller to specify extra details that are added to the bottom' do
         the_presenter = Formatters::ExceptionPresenter.new(
-          exception, example, :extra_detail_formatter => lambda do |failure_number, colorizer, indentation|
-            "#{indentation}extra detail for failure: #{failure_number}\n"
+          exception, example, :extra_detail_formatter => lambda do |failure_number, colorizer|
+            "extra detail for failure: #{failure_number}"
           end
         )
 
@@ -156,16 +156,15 @@ module RSpec::Core
         failure_line = 'http://www.example.com/job_details/123'
         extra_example.metadata[:extra_failure_lines] = [failure_line]
         the_presenter = Formatters::ExceptionPresenter.new(exception, extra_example, :indentation => 4)
-        indent = ' ' * 7 # work around: RSpec behaves like library wide checks has no malformed whitespace
         expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
           |    1) Example
           |       Failure/Error: # The failure happened here!#{ encoding_check }
           |         Boom
           |         Bam
-          |#{indent}
+          |
           |       #{failure_line}
-          |#{indent}
+          |
           |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
         EOS
       end

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -177,18 +177,35 @@ module RSpec::Core
       context 'when the failed expression spans multiple lines', :if => RSpec::Support::RubyFeatures.ripper_supported? do
         let(:exception) do
           begin
-            expect('RSpec').to start_with('R').
+            expect('RSpec').to be_a(String).
+                           and start_with('R').
                            and end_with('z')
           rescue RSpec::Expectations::ExpectationNotMetError => exception
             exception
           end
         end
 
-        it 'returns all the lines' do
-          expect(read_failed_lines).to eq([
-            "            expect('RSpec').to start_with('R').",
-            "                           and end_with('z')"
-          ])
+        context 'and the line count does not exceed RSpec.configuration.max_displayed_failure_line_count' do
+          it 'returns all the lines' do
+            expect(read_failed_lines).to eq([
+              "            expect('RSpec').to be_a(String).",
+              "                           and start_with('R').",
+              "                           and end_with('z')"
+            ])
+          end
+        end
+
+        context 'and the line count exceeds RSpec.configuration.max_displayed_failure_line_count' do
+          before do
+            RSpec.configuration.max_displayed_failure_line_count = 2
+          end
+
+          it 'returns the lines without exceeding the max count' do
+            expect(read_failed_lines).to eq([
+              "            expect('RSpec').to be_a(String).",
+              "                           and start_with('R')."
+            ])
+          end
         end
       end
 

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -81,7 +81,7 @@ module RSpec::Core
       it 'allows the caller to omit the description' do
         the_presenter = Formatters::ExceptionPresenter.new(exception, example,
                                                        :detail_formatter => Proc.new { "Detail!" },
-                                                       :description_formatter => Proc.new { })
+                                                       :description => nil)
 
         expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |
@@ -94,7 +94,7 @@ module RSpec::Core
       end
 
       it 'allows the failure/error line to be used as the description' do
-        the_presenter = Formatters::ExceptionPresenter.new(exception, example, :description_formatter => lambda { |p| p.failure_slash_error_line })
+        the_presenter = Formatters::ExceptionPresenter.new(exception, example, :description => nil)
 
         expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
           |

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -179,6 +179,27 @@ module RSpec::Core
         EOS
       end
 
+      it 'wont produce a stack error when the cause is an older exception', :if => RSpec::Support::RubyFeatures.supports_exception_cause? do
+        allow(the_exception).to receive(:cause) do
+          instance_double(Exception, :cause => the_exception, :message => "A loop", :backtrace => the_exception.backtrace)
+        end
+        the_presenter = Formatters::ExceptionPresenter.new(the_exception, example)
+
+        expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |  1) Example
+          |     Failure/Error: # The failure happened here!#{ encoding_check }
+          |
+          |       Boom
+          |       Bam
+          |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+          |     # ------------------
+          |     # --- Caused by: ---
+          |     #   A loop
+          |     #   ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
+
       it "adds extra failure lines from the example metadata" do
         extra_example = example.clone
         failure_line = 'http://www.example.com/job_details/123'

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -187,6 +187,24 @@ module RSpec::Core
           end
         end
 
+        describe "syntax highlighting" do
+          let(:expression) do
+            expect('RSpec').to be_a(Integer)
+          end
+
+          it 'uses our syntax highlighter on the code snippet to format it nicely' do
+            syntax_highlighter = instance_double(Source::SyntaxHighlighter)
+            allow(syntax_highlighter).to receive(:highlight) do |lines|
+              lines.map { |l| "<highlighted>#{l.strip}</highlighted>" }
+            end
+
+            allow(RSpec.world.source_cache).to receive_messages(:syntax_highlighter => syntax_highlighter)
+
+            formatted = presenter.fully_formatted(1)
+            expect(formatted).to include("<highlighted>expect('RSpec').to be_a(Integer)</highlighted>")
+          end
+        end
+
         context 'with single line expression and single line RSpec exception message' do
           let(:expression) do
             expect('RSpec').to be_a(Integer)

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -159,6 +159,26 @@ module RSpec::Core
         EOS
       end
 
+      it 'wont produce a stack error when cause is the exception itself', :if => RSpec::Support::RubyFeatures.supports_exception_cause? do
+        allow(the_exception).to receive(:cause) { the_exception }
+        the_presenter = Formatters::ExceptionPresenter.new(the_exception, example)
+
+        expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |  1) Example
+          |     Failure/Error: # The failure happened here!#{ encoding_check }
+          |
+          |       Boom
+          |       Bam
+          |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+          |     # ------------------
+          |     # --- Caused by: ---
+          |     #   Boom
+          |     #   Bam
+          |     #   ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
+
       it "adds extra failure lines from the example metadata" do
         extra_example = example.clone
         failure_line = 'http://www.example.com/job_details/123'

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -404,11 +404,6 @@ module RSpec::Core
       context "when backtrace will generate a security error" do
         let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"]) }
 
-        before do
-          # We lazily require SnippetExtractor but requiring it in $SAFE 3 environment raises error.
-          RSpec::Support.require_rspec_core "formatters/snippet_extractor"
-        end
-
         it "is handled gracefully" do
           with_safe_set_to_level_that_triggers_security_errors do
             expect { read_failed_lines }.not_to raise_error

--- a/spec/rspec/core/formatters/html_snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/html_snippet_extractor_spec.rb
@@ -1,41 +1,41 @@
-require 'rspec/core/formatters/snippet_extractor'
+require 'rspec/core/formatters/html_snippet_extractor'
 
 module RSpec
   module Core
     module Formatters
-      RSpec.describe SnippetExtractor do
+      RSpec.describe HtmlSnippetExtractor do
         it "falls back on a default message when it doesn't understand a line" do
-          expect(RSpec::Core::Formatters::SnippetExtractor.new.snippet_for("blech")).to eq(["# Couldn't get snippet for blech", 1])
+          expect(RSpec::Core::Formatters::HtmlSnippetExtractor.new.snippet_for("blech")).to eq(["# Couldn't get snippet for blech", 1])
         end
 
         it "falls back on a default message when it doesn't find the file" do
-          expect(RSpec::Core::Formatters::SnippetExtractor.new.lines_around("blech", 8)).to eq("# Couldn't get snippet for blech")
+          expect(RSpec::Core::Formatters::HtmlSnippetExtractor.new.lines_around("blech", 8)).to eq("# Couldn't get snippet for blech")
         end
 
         it "falls back on a default message when it gets a security error" do
           message = nil
           with_safe_set_to_level_that_triggers_security_errors do
-            message = RSpec::Core::Formatters::SnippetExtractor.new.lines_around("blech", 8)
+            message = RSpec::Core::Formatters::HtmlSnippetExtractor.new.lines_around("blech", 8)
           end
           expect(message).to eq("# Couldn't get snippet for blech")
         end
 
         describe "snippet extraction" do
           let(:snippet) do
-            SnippetExtractor.new.snippet(["#{__FILE__}:#{__LINE__}"])
+            HtmlSnippetExtractor.new.snippet(["#{__FILE__}:#{__LINE__}"])
           end
 
           before do
             # `send` is required for 1.8.7...
-            @orig_converter = SnippetExtractor.send(:class_variable_get, :@@converter)
+            @orig_converter = HtmlSnippetExtractor.send(:class_variable_get, :@@converter)
           end
 
           after do
-            SnippetExtractor.send(:class_variable_set, :@@converter, @orig_converter)
+            HtmlSnippetExtractor.send(:class_variable_set, :@@converter, @orig_converter)
           end
 
           it 'suggests you install coderay when it cannot be loaded' do
-            SnippetExtractor.send(:class_variable_set, :@@converter, SnippetExtractor::NullConverter)
+            HtmlSnippetExtractor.send(:class_variable_set, :@@converter, HtmlSnippetExtractor::NullConverter)
 
             expect(snippet).to include("Install the coderay gem")
           end

--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -1,0 +1,265 @@
+require 'rspec/core/formatters/snippet_extractor'
+
+module RSpec::Core::Formatters
+  RSpec.describe SnippetExtractor do
+    subject(:expression_lines) do
+      SnippetExtractor.extract_expression_lines_at(file_path, line_number)
+    end
+
+    let(:file_path) do
+      location[0]
+    end
+
+    let(:line_number) do
+      location[1]
+    end
+
+    let(:location) do
+      error.backtrace.find do |line|
+        !line.include?('do_something_fail') && line.match(%r{\A(.+?):(\d+)})
+      end
+
+      location = Regexp.last_match.captures
+      location[1] = location[1].to_i
+      location
+    end
+
+    let(:error) do
+      begin
+        source
+      rescue ExpectedError => error
+        error
+      ensure
+        raise 'No ExpectedError has been raised' unless error
+      end
+    end
+
+    ExpectedError = Class.new(StandardError)
+
+    # We use this helper method to raise an error while allowing any arguments,
+    #
+    # Note that MRI 1.9 strangely reports backtrace line as the first argument line instead of the
+    # beginning of the method invocation. It's not SnippetExtractor's fault and even affects to the
+    # simple single line extraction.
+    def do_something_fail(*)
+      raise ExpectedError
+    end
+
+    def another_expression(*)
+    end
+
+    context 'when the given file does not exist' do
+      let(:file_path) do
+        '/non-existent.rb'
+      end
+
+      let(:line_number) do
+        1
+      end
+
+      it 'raises NoSuchFileError' do
+        expect { expression_lines }.to raise_error(SnippetExtractor::NoSuchFileError)
+      end
+    end
+
+    context 'when the given line does not exist in the file' do
+      let(:file_path) do
+        __FILE__
+      end
+
+      let(:line_number) do
+        99999
+      end
+
+      it 'raises NoSuchLineError' do
+        expect { expression_lines }.to raise_error(SnippetExtractor::NoSuchLineError)
+      end
+    end
+
+    context 'when the expression fits into a single line' do
+      let(:source) do
+        do_something_fail :foo
+      end
+
+      it 'returns the line' do
+        expect(expression_lines).to eq([
+          '        do_something_fail :foo'
+        ])
+      end
+    end
+
+    context 'in Ripper supported environment', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+      context 'when the expression spans multiple lines' do
+        let(:source) do
+          do_something_fail :foo,
+                            :bar
+        end
+
+        it 'returns the lines' do
+          expect(expression_lines).to eq([
+            '          do_something_fail :foo,',
+            '                            :bar'
+          ])
+        end
+      end
+
+      context 'when the expression ends with ")"-only line' do
+        let(:source) do
+          do_something_fail(:foo
+          )
+        end
+
+        it 'returns all the lines' do
+          expect(expression_lines).to eq([
+            '          do_something_fail(:foo',
+            '          )'
+          ])
+        end
+      end
+
+      context 'when the expression ends with "}"-only line' do
+        let(:source) do
+          do_something_fail {
+          }
+        end
+
+        it 'returns all the lines' do
+          expect(expression_lines).to eq([
+            '          do_something_fail {',
+            '          }'
+          ])
+        end
+      end
+
+      context 'when the expression ends with "]"-only line' do
+        let(:source) do
+          do_something_fail :foo, [
+          ]
+        end
+
+        it 'returns all the lines' do
+          expect(expression_lines).to eq([
+            '          do_something_fail :foo, [',
+            '          ]'
+          ])
+        end
+      end
+
+      context "when the expression ends with multiple paren-only lines of same type" do
+        let(:source) do
+          do_something_fail(:foo, (:bar
+            )
+          )
+        end
+
+        it 'returns all the lines' do
+          expect(expression_lines).to eq([
+            '          do_something_fail(:foo, (:bar',
+            '            )',
+            '          )'
+          ])
+        end
+      end
+
+      context "when the expression includes paren and heredoc pairs as non-nested structure" do
+        let(:source) do
+          do_something_fail(<<-END)
+            foo
+          END
+        end
+
+        it 'returns all the lines' do
+          expect(expression_lines).to eq([
+            '          do_something_fail(<<-END)',
+            '            foo',
+            '          END'
+          ])
+        end
+      end
+
+      context 'when the expression spans lines after the closing paren line' do
+        let(:source) do
+          do_something_fail(:foo
+          ).
+          do_something_chain
+        end
+
+        # [:program,
+        #  [[:call,
+        #    [:method_add_arg, [:fcall, [:@ident, "do_something_fail", [1, 10]]], [:arg_paren, nil]],
+        #    :".",
+        #    [:@ident, "do_something_chain", [3, 10]]]]]
+
+        it 'returns all the lines' do
+          expect(expression_lines).to eq([
+            '          do_something_fail(:foo',
+            '          ).',
+            '          do_something_chain'
+          ])
+        end
+      end
+
+      context "when the expression's final line includes the same type of opening paren of another multiline expression" do
+        let(:source) do
+          do_something_fail(:foo
+          ); another_expression(:bar
+          )
+        end
+
+        it 'ignores another expression' do
+          expect(expression_lines).to eq([
+            '          do_something_fail(:foo',
+            '          ); another_expression(:bar'
+          ])
+        end
+      end
+
+      context "when the expression's first line includes a closing paren of another multiline expression" do
+        let(:source) do
+          another_expression(:bar
+          ); do_something_fail(:foo
+          )
+        end
+
+        it 'ignores another expression' do
+          expect(expression_lines).to eq([
+            '          ); do_something_fail(:foo',
+            '          )'
+          ])
+        end
+      end
+
+      context 'when no expression exists at the line' do
+        let(:file_path) do
+          __FILE__
+        end
+
+        let(:line_number) do
+          __LINE__ + 1
+          # The failure happened here without expression
+        end
+
+        it 'returns the line by falling back to the simple single line extraction' do
+          expect(expression_lines).to eq([
+            '          # The failure happened here without expression'
+          ])
+        end
+      end
+    end
+
+    context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do
+      context 'when the expression spans multiple lines' do
+        let(:source) do
+          do_something_fail :foo,
+                            :bar
+        end
+
+        it 'returns only the first line' do
+          expect(expression_lines).to eq([
+            '          do_something_fail :foo,'
+          ])
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -250,6 +250,28 @@ module RSpec::Core::Formatters
         end
       end
 
+      context 'when Ripper cannot parse the source (which can happen on JRuby -- see jruby/jruby#2427)', :isolated_directory do
+        let(:file_path) { 'invalid_source.rb' }
+
+        let(:line_number) { 1 }
+
+        let(:source) { <<-EOS.gsub(/^ +\|/, '') }
+          |expect("some string").to include(
+          |  "some", "string"
+          |]
+        EOS
+
+        before do
+          File.open(file_path, 'w') { |file| file.write(source) }
+        end
+
+        it 'returns the line by falling back to the simple single line extraction' do
+          expect(expression_lines).to eq([
+            'expect("some string").to include('
+          ])
+        end
+      end
+
       context 'when max line count is given' do
         let(:max_line_count) do
           2

--- a/spec/rspec/core/notifications_spec.rb
+++ b/spec/rspec/core/notifications_spec.rb
@@ -229,13 +229,14 @@ RSpec.describe "FailedExampleNotification" do
         end
 
         it 'lists both types in the exception listing' do
-          expect(fully_formatted.lines.to_a.last(9)).to eq(dedent(<<-EOS).lines.to_a)
+          expect(fully_formatted.lines.to_a.last(10)).to eq(dedent(<<-EOS).lines.to_a)
             |
             |     1.1) Failure/Error: expect(1).to fail_with_description("foo")
             |            expected pass, but foo
             |          # #{RSpec::Core::Metadata.relative_path(__FILE__)}:#{aggregate_line + 1}
             |
             |     1.2) Failure/Error: raise "boom"
+            |
             |          RuntimeError:
             |            boom
             |          # #{RSpec::Core::Metadata.relative_path(__FILE__)}:#{aggregate_line + 2}
@@ -283,13 +284,15 @@ RSpec.describe "FailedExampleNotification" do
       let(:exception)      { RSpec::Core::MultipleExceptionError.new(sub_failure_1, sub_failure_2) }
 
       it "lists each sub-failure, just like with MultipleExpectationsNotMetError" do
-        expect(fully_formatted.lines.to_a.last(8)).to eq(dedent(<<-EOS).lines.to_a)
+        expect(fully_formatted.lines.to_a.last(10)).to eq(dedent(<<-EOS).lines.to_a)
           |
           |     1.1) Failure/Error: Unable to find matching line from backtrace
+          |
           |          StandardError:
           |            foo
           |
           |     1.2) Failure/Error: Unable to find matching line from backtrace
+          |
           |          StandardError:
           |            bar
         EOS

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -343,9 +343,7 @@ module RSpec::Core
 
     describe '--fail-fast' do
       it 'warns when a non-integer is specified as fail count' do
-        expect(::Kernel).to receive(:warn) do |message|
-          expect(message).to match "Non integer specified as fail count"
-        end
+        expect_warning_without_call_site a_string_including("--fail-fast", "three")
         Parser.parse(%w[--fail-fast=three])
       end
     end

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -341,6 +341,15 @@ module RSpec::Core
       end
     end
 
+    describe '--fail-fast' do
+      it 'warns when a non-integer is specified as fail count' do
+        expect(::Kernel).to receive(:warn) do |message|
+          expect(message).to match "Non integer specified as fail count"
+        end
+        Parser.parse(%w[--fail-fast=three])
+      end
+    end
+
     describe '--warning' do
       around do |ex|
         verbose = $VERBOSE

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -34,6 +34,34 @@ module RSpec::Core
 
         reporter.finish
       end
+
+      let(:install_coderay_snippet) { "install the coderay gem" }
+
+      def formatter_notified_of_dump_summary(syntax_highlighting_unavailable)
+        formatter = spy("formatter")
+        reporter.syntax_highlighting_unavailable = syntax_highlighting_unavailable
+        reporter.register_listener formatter, :dump_summary
+
+        reporter.start(0)
+        reporter.finish
+        formatter
+      end
+
+      it "includes a note about install coderay if syntax highlighting is unavailable" do
+        formatter = formatter_notified_of_dump_summary(true)
+
+        expect(formatter).to have_received(:dump_summary).with(an_object_having_attributes(
+          :fully_formatted => a_string_including(install_coderay_snippet)
+        ))
+      end
+
+      it "does not include a note about installing coderay if syntax highlighting is available" do
+        formatter = formatter_notified_of_dump_summary(false)
+
+        expect(formatter).to have_received(:dump_summary).with(an_object_having_attributes(
+          :fully_formatted => a_string_excluding(install_coderay_snippet)
+        ))
+      end
     end
 
     describe 'start' do

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -279,5 +279,22 @@ module RSpec::Core
         reporter.finish
       end
     end
+
+    describe "#failures_required" do
+      it "returns 1 when RSpec.configuration.fail_fast == true" do
+        config.fail_fast = true
+        expect(reporter.failures_required).to eq 1
+      end
+
+      it "returns 1 when RSpec.configuration.fail_fast == 1" do
+        config.fail_fast = 1
+        expect(reporter.failures_required).to eq 1
+      end
+
+      it "returns RSpec.configuration.fail_fast when RSpec.configuration.fail_fast > 1" do
+        config.fail_fast = 3
+        expect(reporter.failures_required).to eq 3
+      end
+    end
   end
 end

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -279,22 +279,5 @@ module RSpec::Core
         reporter.finish
       end
     end
-
-    describe "#failures_required" do
-      it "returns 1 when RSpec.configuration.fail_fast == true" do
-        config.fail_fast = true
-        expect(reporter.failures_required).to eq 1
-      end
-
-      it "returns 1 when RSpec.configuration.fail_fast == 1" do
-        config.fail_fast = 1
-        expect(reporter.failures_required).to eq 1
-      end
-
-      it "returns RSpec.configuration.fail_fast when RSpec.configuration.fail_fast > 1" do
-        config.fail_fast = 3
-        expect(reporter.failures_required).to eq 3
-      end
-    end
   end
 end

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -35,33 +35,6 @@ module RSpec::Core
         reporter.finish
       end
 
-      let(:install_coderay_snippet) { "install the coderay gem" }
-
-      def formatter_notified_of_dump_summary(syntax_highlighting_unavailable)
-        formatter = spy("formatter")
-        reporter.syntax_highlighting_unavailable = syntax_highlighting_unavailable
-        reporter.register_listener formatter, :dump_summary
-
-        reporter.start(0)
-        reporter.finish
-        formatter
-      end
-
-      it "includes a note about install coderay if syntax highlighting is unavailable" do
-        formatter = formatter_notified_of_dump_summary(true)
-
-        expect(formatter).to have_received(:dump_summary).with(an_object_having_attributes(
-          :fully_formatted => a_string_including(install_coderay_snippet)
-        ))
-      end
-
-      it "does not include a note about installing coderay if syntax highlighting is available" do
-        formatter = formatter_notified_of_dump_summary(false)
-
-        expect(formatter).to have_received(:dump_summary).with(an_object_having_attributes(
-          :fully_formatted => a_string_excluding(install_coderay_snippet)
-        ))
-      end
     end
 
     describe 'start' do

--- a/spec/rspec/core/source/node_spec.rb
+++ b/spec/rspec/core/source/node_spec.rb
@@ -1,0 +1,114 @@
+require 'rspec/core/source/node'
+
+class RSpec::Core::Source
+  RSpec.describe Node, :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    let(:root_node) do
+      Node.new(sexp)
+    end
+
+    let(:sexp) do
+      require 'ripper'
+      Ripper.sexp(source)
+    end
+
+    let(:source) { <<-END }
+      variable = do_something(1, 2)
+      variable.do_anything do |arg|
+        puts arg
+      end
+    END
+
+    # [:program,
+    #  [[:assign,
+    #    [:var_field, [:@ident, "variable", [1, 6]]],
+    #    [:method_add_arg,
+    #     [:fcall, [:@ident, "do_something", [1, 17]]],
+    #     [:arg_paren,
+    #      [:args_add_block,
+    #       [[:@int, "1", [1, 30]], [:@int, "2", [1, 33]]],
+    #       false]]]],
+    #   [:method_add_block,
+    #    [:call,
+    #     [:var_ref, [:@ident, "variable", [2, 6]]],
+    #     :".",
+    #     [:@ident, "do_anything", [2, 15]]],
+    #    [:do_block,
+    #     [:block_var,
+    #      [:params, [[:@ident, "arg", [2, 31]]], nil, nil, nil, nil, nil, nil],
+    #      false],
+    #     [[:command,
+    #       [:@ident, "puts", [3, 8]],
+    #       [:args_add_block, [[:var_ref, [:@ident, "arg", [3, 13]]]], false]]]]]]]
+
+    describe '#args' do
+      context 'when the sexp args consist of direct child sexps' do
+        let(:target_node) do
+          root_node.find { |node| node.type == :method_add_arg }
+        end
+
+        it 'returns the child nodes' do
+          expect(target_node.args).to match([
+            an_object_having_attributes(:type => :fcall),
+            an_object_having_attributes(:type => :arg_paren)
+          ])
+        end
+      end
+
+      context 'when the sexp args include an array of sexps' do
+        let(:target_node) do
+          root_node.find { |node| node.type == :args_add_block }
+        end
+
+        it 'returns pseudo group node for the array' do
+          expect(target_node.args).to match([
+            an_object_having_attributes(:type => :group),
+            false
+          ])
+        end
+      end
+    end
+
+    describe '#each_ancestor' do
+      let(:target_node) do
+        root_node.find { |node| node.type == :arg_paren }
+      end
+
+      it 'yields ancestor nodes from parent to root' do
+        expect { |b| target_node.each_ancestor(&b) }.to yield_successive_args(
+          an_object_having_attributes(:type => :method_add_arg),
+          an_object_having_attributes(:type => :assign),
+          an_object_having_attributes(:type => :group),
+          an_object_having_attributes(:type => :program)
+        )
+      end
+    end
+
+    describe '#location' do
+      context 'with identifier type node' do
+        let(:target_node) do
+          root_node.find { |node| node.type == :@ident }
+        end
+
+        it 'returns a Location object with line and column numbers' do
+          expect(target_node.location).to have_attributes(:line => 1, :column => 6)
+        end
+      end
+
+      context 'with non-identifier type node' do
+        let(:target_node) do
+          root_node.find { |node| node.type == :assign }
+        end
+
+        it 'returns nil' do
+          expect(target_node.location).to be_nil
+        end
+      end
+    end
+
+    describe '#inspect' do
+      it 'returns a string including class name and node type' do
+        expect(root_node.inspect).to eq('#<RSpec::Core::Source::Node program>')
+      end
+    end
+  end
+end

--- a/spec/rspec/core/source/syntax_highlighter_spec.rb
+++ b/spec/rspec/core/source/syntax_highlighter_spec.rb
@@ -5,10 +5,6 @@ class RSpec::Core::Source
     let(:config)      { RSpec::Core::Configuration.new.tap { |c| c.color = true } }
     let(:highlighter) { SyntaxHighlighter.new(config)  }
 
-    def be_highlighted
-      include("\e[32m")
-    end
-
     context "when CodeRay is available", :unless => RSpec::Support::OS.windows? do
       before { expect { require 'coderay' }.not_to raise_error }
 
@@ -40,22 +36,6 @@ class RSpec::Core::Source
         expect(highlighter.highlight(['[:ok, "ok"]']).first).to be_highlighted
         config.color = false
         expect(highlighter.highlight(['[:ok, "ok"]']).first).not_to be_highlighted
-      end
-
-      it 'notifies the reporter' do
-        config.reporter.syntax_highlighting_unavailable = true
-
-        expect {
-          highlighter.highlight([""])
-        }.to change { config.reporter.syntax_highlighting_unavailable }.to(false)
-      end
-
-      it 'does not notify the reporter if highlighting is never attempted' do
-        config.reporter.syntax_highlighting_unavailable = true
-
-        expect {
-          SyntaxHighlighter.new(config)
-        }.not_to change { config.reporter.syntax_highlighting_unavailable }
       end
 
       it "rescues coderay failures since we do not want a coderay error to be displayed instead of the user's error" do
@@ -95,21 +75,11 @@ class RSpec::Core::Source
         expect(highlighter.highlight(lines)).to eq(lines)
       end
 
-      it 'notifies the reporter', :unless => RSpec::Support::OS.windows? do
-        config.reporter.syntax_highlighting_unavailable = false
-
-        expect {
-          highlighter.highlight([""])
-        }.to change { config.reporter.syntax_highlighting_unavailable }.to(true)
-      end
-
-      it 'does not notify the reporter if highlighting is never attempted' do
-        config.reporter.syntax_highlighting_unavailable = false
-
-        expect {
-          SyntaxHighlighter.new(config)
-        }.not_to change { config.reporter.syntax_highlighting_unavailable }
-      end
     end
+
+    def be_highlighted
+      include("\e[32m")
+    end
+
   end
 end

--- a/spec/rspec/core/source/syntax_highlighter_spec.rb
+++ b/spec/rspec/core/source/syntax_highlighter_spec.rb
@@ -1,0 +1,115 @@
+require 'rspec/core/source/syntax_highlighter'
+
+class RSpec::Core::Source
+  RSpec.describe SyntaxHighlighter do
+    let(:config)      { RSpec::Core::Configuration.new.tap { |c| c.color = true } }
+    let(:highlighter) { SyntaxHighlighter.new(config)  }
+
+    def be_highlighted
+      include("\e[32m")
+    end
+
+    context "when CodeRay is available", :unless => RSpec::Support::OS.windows? do
+      before { expect { require 'coderay' }.not_to raise_error }
+
+      it 'highlights the syntax of the provided lines' do
+        highlighted = highlighter.highlight(['[:ok, "ok"]'])
+        expect(highlighted.size).to eq(1)
+        expect(highlighted.first).to be_highlighted.and include(":ok")
+      end
+
+      it 'prefixes the each line with a reset escape code so it can be interpolated in a colored string without affecting the syntax highlighting of the snippet' do
+        highlighted = highlighter.highlight(['a = 1', 'b = 2'])
+        expect(highlighted).to all start_with("\e[0m")
+      end
+
+      it 'leaves leading spaces alone so it can be re-indented as needed without the leading reset code interfering' do
+        highlighted = highlighter.highlight(['  a = 1', '  b = 2'])
+        expect(highlighted).to all start_with("  \e[0m")
+      end
+
+      it 'returns the provided lines unmodified if color is disabled' do
+        config.color = false
+        expect(highlighter.highlight(['[:ok, "ok"]'])).to eq(['[:ok, "ok"]'])
+      end
+
+      it 'dynamically adjusts to changing color config' do
+        config.color = false
+        expect(highlighter.highlight(['[:ok, "ok"]']).first).not_to be_highlighted
+        config.color = true
+        expect(highlighter.highlight(['[:ok, "ok"]']).first).to be_highlighted
+        config.color = false
+        expect(highlighter.highlight(['[:ok, "ok"]']).first).not_to be_highlighted
+      end
+
+      it 'notifies the reporter' do
+        config.reporter.syntax_highlighting_unavailable = true
+
+        expect {
+          highlighter.highlight([""])
+        }.to change { config.reporter.syntax_highlighting_unavailable }.to(false)
+      end
+
+      it 'does not notify the reporter if highlighting is never attempted' do
+        config.reporter.syntax_highlighting_unavailable = true
+
+        expect {
+          SyntaxHighlighter.new(config)
+        }.not_to change { config.reporter.syntax_highlighting_unavailable }
+      end
+
+      it "rescues coderay failures since we do not want a coderay error to be displayed instead of the user's error" do
+        allow(CodeRay).to receive(:encode).and_raise(Exception.new "boom")
+        lines = [":ok"]
+        expect(highlighter.highlight(lines)).to eq(lines)
+      end
+    end
+
+    context "when CodeRay is unavailable" do
+      before do
+        allow(::Kernel).to receive(:require).with("coderay").and_raise(LoadError)
+      end
+
+      it 'does not highlight the syntax' do
+        unhighlighted = highlighter.highlight(['[:ok, "ok"]'])
+        expect(unhighlighted.size).to eq(1)
+        expect(unhighlighted.first).not_to be_highlighted
+      end
+
+      it 'does not mutate the input array' do
+        lines = ["a = 1", "b = 2"]
+        expect { highlighter.highlight(lines) }.not_to change { lines }
+      end
+
+      it 'does not add the comment about coderay if the snippet is only one line as we do not want to convert it to multiline just for the comment' do
+        expect(highlighter.highlight(["a = 1"])).to eq(["a = 1"])
+      end
+
+      it 'does not add the comment about coderay if given no lines' do
+        expect(highlighter.highlight([])).to eq([])
+      end
+
+      it 'does not add the comment about coderay if color id disabled even when given a multiline snippet' do
+        config.color = false
+        lines = ["a = 1", "b = 2"]
+        expect(highlighter.highlight(lines)).to eq(lines)
+      end
+
+      it 'notifies the reporter', :unless => RSpec::Support::OS.windows? do
+        config.reporter.syntax_highlighting_unavailable = false
+
+        expect {
+          highlighter.highlight([""])
+        }.to change { config.reporter.syntax_highlighting_unavailable }.to(true)
+      end
+
+      it 'does not notify the reporter if highlighting is never attempted' do
+        config.reporter.syntax_highlighting_unavailable = false
+
+        expect {
+          SyntaxHighlighter.new(config)
+        }.not_to change { config.reporter.syntax_highlighting_unavailable }
+      end
+    end
+  end
+end

--- a/spec/rspec/core/source/token_spec.rb
+++ b/spec/rspec/core/source/token_spec.rb
@@ -1,0 +1,67 @@
+require 'rspec/core/source/token'
+
+class RSpec::Core::Source
+  RSpec.describe Token, :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    let(:target_token) do
+      tokens.first
+    end
+
+    let(:tokens) do
+      Token.tokens_from_ripper_tokens(ripper_tokens)
+    end
+
+    let(:ripper_tokens) do
+      require 'ripper'
+      Ripper.lex(source)
+    end
+
+    let(:source) do
+      'puts :foo'
+    end
+
+    # [
+    #   [[1, 0], :on_ident, "puts"],
+    #   [[1, 4], :on_sp, " "],
+    #   [[1, 5], :on_symbeg, ":"],
+    #   [[1, 6], :on_ident, "foo"]
+    # ]
+
+    describe '#location' do
+      it 'returns a Location object with line and column numbers' do
+        expect(target_token.location).to have_attributes(:line => 1, :column => 0)
+      end
+    end
+
+    describe '#type' do
+      it 'returns a type of the token' do
+        expect(target_token.type).to eq(:on_ident)
+      end
+    end
+
+    describe '#string' do
+      it 'returns a source string corresponding to the token' do
+        expect(target_token.string).to eq('puts')
+      end
+    end
+
+    describe '#==' do
+      context 'when both tokens have same Ripper token' do
+        it 'returns true' do
+          expect(Token.new(ripper_tokens[0]) == Token.new(ripper_tokens[0])).to be true
+        end
+      end
+
+      context 'when both tokens have different Ripper token' do
+        it 'returns false' do
+          expect(Token.new(ripper_tokens[0]) == Token.new(ripper_tokens[1])).to be false
+        end
+      end
+    end
+
+    describe '#inspect' do
+      it 'returns a string including class name, token type and source string' do
+        expect(target_token.inspect).to eq('#<RSpec::Core::Source::Token on_ident "puts">')
+      end
+    end
+  end
+end

--- a/spec/rspec/core/source_spec.rb
+++ b/spec/rspec/core/source_spec.rb
@@ -1,0 +1,120 @@
+require 'rspec/core/source'
+
+module RSpec::Core
+  RSpec.describe Source, :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    subject(:source) do
+      Source.new(source_string)
+    end
+
+    let(:source_string) { <<-END.gsub(/^ +\|/, '') }
+      |2.times do
+      |  puts :foo
+      |end
+    END
+
+    # [:program,
+    #  [[:method_add_block,
+    #    [:call, [:@int, "2", [1, 0]], :".", [:@ident, "times", [1, 2]]],
+    #    [:do_block,
+    #     nil,
+    #     [[:command,
+    #       [:@ident, "puts", [2, 2]],
+    #       [:args_add_block,
+    #        [[:symbol_literal, [:symbol, [:@ident, "foo", [2, 8]]]]],
+    #        false]]]]]]]
+
+    describe '.from_file', :isolated_directory do
+      subject(:source) do
+        Source.from_file(path)
+      end
+
+      let(:path) do
+        'source.rb'
+      end
+
+      before do
+        File.open(path, 'w') { |file| file.write(source_string) }
+      end
+
+      it 'returns a Source with the absolute path' do
+        expect(source.lines.first).to eq('2.times do')
+        expect(source.path).not_to eq(path)
+        expect(source.path).to end_with(path)
+      end
+    end
+
+    describe '#lines' do
+      it 'returns an array of lines without linefeed' do
+        expect(source.lines).to eq([
+          '2.times do',
+          '  puts :foo',
+          'end'
+        ])
+      end
+    end
+
+    describe '#ast' do
+      it 'returns a root node' do
+        expect(source.ast).to have_attributes(:type => :program)
+      end
+    end
+
+    describe '#tokens' do
+      it 'returns an array of tokens' do
+        expect(source.tokens).to all be_a(Source::Token)
+      end
+    end
+
+    describe '#nodes_by_line_number' do
+      it 'returns a hash containing nodes for each line number' do
+        expect(source.nodes_by_line_number).to match(
+          1 => [
+            an_object_having_attributes(:type => :@int),
+            an_object_having_attributes(:type => :@ident)
+          ],
+          2 => [
+            an_object_having_attributes(:type => :@ident),
+            an_object_having_attributes(:type => :@ident)
+          ]
+        )
+
+        expect(source.nodes_by_line_number[0]).to be_empty
+      end
+    end
+
+    describe '#tokens_by_line_number' do
+      it 'returns a hash containing tokens for each line number' do
+        expect(source.tokens_by_line_number).to match(
+          1 => [
+            an_object_having_attributes(:type => :on_int),
+            an_object_having_attributes(:type => :on_period),
+            an_object_having_attributes(:type => :on_ident),
+            an_object_having_attributes(:type => :on_sp),
+            an_object_having_attributes(:type => :on_kw),
+            an_object_having_attributes(:type => :on_ignored_nl)
+          ],
+          2 => [
+            an_object_having_attributes(:type => :on_sp),
+            an_object_having_attributes(:type => :on_ident),
+            an_object_having_attributes(:type => :on_sp),
+            an_object_having_attributes(:type => :on_symbeg),
+            an_object_having_attributes(:type => :on_ident),
+            an_object_having_attributes(:type => :on_nl)
+          ],
+          3 => [
+            an_object_having_attributes(:type => :on_kw),
+            an_object_having_attributes(:type => :on_nl)
+          ]
+        )
+
+        expect(source.tokens_by_line_number[0]).to be_empty
+      end
+    end
+
+    describe '#inspect' do
+      it 'returns a string including class name and file path' do
+        expect(source.inspect).to start_with('#<RSpec::Core::Source (string)>')
+      end
+    end
+  end
+end

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -129,6 +129,18 @@ module RSpec::Core
       end
     end
 
+    describe '#source_cache' do
+      def source_from_file(path)
+        world.source_cache.source_from_file(path)
+      end
+
+      it 'caches Source instances by file path' do
+        expect(source_from_file(__FILE__)).to be_a(Source).
+                                          and have_attributes(:path => __FILE__).
+                                          and equal(source_from_file(__FILE__))
+      end
+    end
+
     describe "#announce_filters" do
       let(:reporter) { instance_spy(Reporter) }
       before { allow(world).to receive(:reporter) { reporter } }

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -80,18 +80,21 @@ module FormatterSupport
         |
         |  3) a failing spec with odd backtraces fails with a backtrace that has no file
         |     Failure/Error: Unable to find (erb) to read failed line
+        |
         |     RuntimeError:
         |       foo
         |     # (erb):1
         |
         |  4) a failing spec with odd backtraces fails with a backtrace containing an erb file
         |     Failure/Error: Unable to find /foo.html.erb to read failed line
+        |
         |     Exception:
         |       Exception
         |     # /foo.html.erb:1:in `<main>': foo (RuntimeError)
         |
         |  5) a failing spec with odd backtraces with a `nil` backtrace raises
         |     Failure/Error: Unable to find matching line from backtrace
+        |
         |     RuntimeError:
         |       boom
         |
@@ -150,6 +153,7 @@ module FormatterSupport
         |
         |  3) a failing spec with odd backtraces fails with a backtrace that has no file
         |     Failure/Error: ERB.new("<%= raise 'foo' %>").result
+        |
         |     RuntimeError:
         |       foo
         |     # (erb):1:in `<main>'
@@ -160,12 +164,14 @@ module FormatterSupport
         |
         |  4) a failing spec with odd backtraces fails with a backtrace containing an erb file
         |     Failure/Error: Unable to find /foo.html.erb to read failed line
+        |
         |     Exception:
         |       Exception
         |     # /foo.html.erb:1:in `<main>': foo (RuntimeError)
         |
         |  5) a failing spec with odd backtraces with a `nil` backtrace raises
         |     Failure/Error: Unable to find matching line from backtrace
+        |
         |     RuntimeError:
         |       boom
         |

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -122,5 +122,6 @@ RSpec::Matchers.alias_matcher :a_file_collection, :contain_files
 RSpec::Matchers.define_negated_matcher :avoid_outputting, :output
 RSpec::Matchers.define_negated_matcher :exclude, :include
 RSpec::Matchers.define_negated_matcher :excluding, :include
+RSpec::Matchers.define_negated_matcher :a_string_excluding, :a_string_including
 RSpec::Matchers.define_negated_matcher :avoid_changing,   :change
 RSpec::Matchers.define_negated_matcher :a_hash_excluding, :include


### PR DESCRIPTION
The Runner.trap_interrupt method was missing a spec. My goal is to extend interrupt handling per tenderlove's feature request https://github.com/rspec/rspec-core/issues/2055, but I wanted to make sure there was a spec in place first.