### PR TITLE
Use optimized relative requires in rake_task.rb

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -49,6 +49,8 @@ Bug Fixes:
 * Fix regression in 3.3 that caused spec file names with square brackets in
   them (such as `1[]_spec.rb`) to not be loaded properly. (Myron Marston, #2041)
 * Fix output encoding issue caused by ASCII literal on 1.9.3 (Jon Rowe, #2072)
+* Fix requires in `rspec/core/rake_task.rb` to avoid double requires
+  seen by some users. (Myron Marston, #2101)
 
 ### 3.3.2 / 2015-07-15
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.3.1...v3.3.2)

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -1,8 +1,14 @@
 require 'rake'
 require 'rake/tasklib'
 require 'rspec/support'
-require 'rspec/support/ruby_features'
-require 'rspec/core/shell_escape'
+
+RSpec::Support.require_rspec_support "ruby_features"
+
+unless RSpec::Support.respond_to?(:require_rspec_core)
+  RSpec::Support.define_optimized_require_for_rspec(:core) { |f| require_relative "../#{f}" }
+end
+
+RSpec::Support.require_rspec_core "shell_escape"
 
 module RSpec
   module Core


### PR DESCRIPTION
This avoids a problem some users have seen where
files are double-required.

Fixes #2099.