### PR TITLE
Handle syntax error in Ripper

### DIFF
--- a/lib/rspec/core/formatters/snippet_extractor.rb
+++ b/lib/rspec/core/formatters/snippet_extractor.rb
@@ -55,7 +55,7 @@ module RSpec
             end
 
             source.lines[(line_range.begin - 1)..(line_range.end - 1)]
-          rescue NoExpressionAtLineError
+          rescue SyntaxError, NoExpressionAtLineError
             [self.class.extract_line_at(source.path, beginning_line_number)]
           end
 

--- a/lib/rspec/core/source.rb
+++ b/lib/rspec/core/source.rb
@@ -26,6 +26,7 @@ module RSpec
         @ast ||= begin
           require 'ripper'
           sexp = Ripper.sexp(source)
+          raise SyntaxError unless sexp
           Node.new(sexp)
         end
       end

--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -250,6 +250,28 @@ module RSpec::Core::Formatters
         end
       end
 
+      context 'when Ripper cannot parse the source (which can happen on JRuby -- see jruby/jruby#2427)', :isolated_directory do
+        let(:file_path) { 'invalid_source.rb' }
+
+        let(:line_number) { 1 }
+
+        let(:source) { <<-EOS.gsub(/^ +\|/, '') }
+          |expect("some string").to include(
+          |  "some", "string"
+          |]
+        EOS
+
+        before do
+          File.open(file_path, 'w') { |file| file.write(source) }
+        end
+
+        it 'returns the line by falling back to the simple single line extraction' do
+          expect(expression_lines).to eq([
+            'expect("some string").to include('
+          ])
+        end
+      end
+
       context 'when max line count is given' do
         let(:max_line_count) do
           2


### PR DESCRIPTION
Ripper might fail to parse a Ruby source even if the current runtime parsed it properly, because some versions of JRuby have different implementation of runtime parser and Ripper parser.

https://github.com/jruby/jruby/issues/2427

So we handle the syntax error in Ripper and fall back to the simple single line extraction in that case.