### PR TITLE
Followups from #2065.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -49,6 +49,9 @@ Enhancements:
   (Yuji Nakayama, #2083)
 * Add `max_displayed_failure_line_count` configuration option
   (defaults to 10). (Yuji Nakayama, #2083)
+* Enhance `fail_fast` option so it can take a number (e.g. `--fail-fast=3`)
+  to force the run to abort after the specified number of failures.
+  (Jack Scotti, #2065)
 
 Bug Fixes:
 

--- a/features/configuration/fail_fast.feature
+++ b/features/configuration/fail_fast.feature
@@ -1,6 +1,6 @@
 Feature: fail fast
 
-  Use the `fail_fast` option to tell RSpec to abort the run on after N failures:
+  Use the `fail_fast` option to tell RSpec to abort the run after N failures:
 
   Scenario: `fail_fast` with no failures (runs all examples)
     Given a file named "spec/spec_helper.rb" with:

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -187,7 +187,7 @@ module RSpec
 
       # @macro add_setting
       # If specified, indicates the number of failures required before cleaning
-      # up and exit (default: `false`).
+      # up and exit (default: `nil`).
       add_setting :fail_fast
 
       # @macro add_setting

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -547,8 +547,8 @@ module RSpec
           for_filtered_examples(reporter) { |example| example.skip_with_exception(reporter, ex) }
           true
         rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
-          RSpec.world.wants_to_quit = true if fail_fast?
           for_filtered_examples(reporter) { |example| example.fail_with_exception(reporter, ex) }
+          RSpec.world.wants_to_quit = true if reporter.fail_fast_limit_met?
           false
         ensure
           run_after_context_hooks(new('after(:context) hook')) if should_run_context_hooks
@@ -579,7 +579,7 @@ module RSpec
           instance = new(example.inspect_output)
           set_ivars(instance, before_context_ivars)
           succeeded = example.run(instance, reporter)
-          if !succeeded && fail_fast? && reporter.fail_fast_limit_met?
+          if !succeeded && reporter.fail_fast_limit_met?
             RSpec.world.wants_to_quit = true
           end
           succeeded
@@ -596,11 +596,6 @@ module RSpec
           reporter.example_group_finished(child)
         end
         false
-      end
-
-      # @private
-      def self.fail_fast?
-        RSpec.configuration.fail_fast?
       end
 
       # @private

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -80,7 +80,7 @@ module RSpec::Core
             begin
               value = Integer(argument)
             rescue ArgumentError
-              RSpec.warning "Non integer specified as fail count."
+              RSpec.warning "Expected an integer value for `--fail-fast`, got: #{argument.inspect}", :call_site => nil
             end
           end
           set_fail_fast(options, value)

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -199,12 +199,13 @@ module RSpec::Core
 
     # @private
     def fail_fast_limit_met?
-      failures_required <= @failed_examples.size
-    end
+      return false unless (fail_fast = @configuration.fail_fast)
 
-    # @private
-    def failures_required
-      @configuration.fail_fast == true ? 1 : @configuration.fail_fast
+      if fail_fast == true
+        @failed_examples.any?
+      else
+        fail_fast <= @failed_examples.size
+      end
     end
 
   private
@@ -216,7 +217,7 @@ module RSpec::Core
     def mute_profile_output?
       # Don't print out profiled info if there are failures and `--fail-fast` is
       # used, it just clutters the output.
-      !@configuration.profile_examples? || (@configuration.fail_fast? && @failed_examples.size > 0)
+      !@configuration.profile_examples? || fail_fast_limit_met?
     end
 
     def seed_used?

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -36,6 +36,12 @@ module RSpec::Core
       end
     end
 
+    describe "#fail_fast" do
+      it "defaults to `nil`" do
+        expect(RSpec::Core::Configuration.new.fail_fast).to be(nil)
+      end
+    end
+
     describe '#deprecation_stream' do
       it 'defaults to standard error' do
         expect($rspec_core_without_stderr_monkey_patch.deprecation_stream).to eq STDERR

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -343,9 +343,7 @@ module RSpec::Core
 
     describe '--fail-fast' do
       it 'warns when a non-integer is specified as fail count' do
-        expect(::Kernel).to receive(:warn) do |message|
-          expect(message).to match "Non integer specified as fail count"
-        end
+        expect_warning_without_call_site a_string_including("--fail-fast", "three")
         Parser.parse(%w[--fail-fast=three])
       end
     end

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -279,22 +279,5 @@ module RSpec::Core
         reporter.finish
       end
     end
-
-    describe "#failures_required" do
-      it "returns 1 when RSpec.configuration.fail_fast == true" do
-        config.fail_fast = true
-        expect(reporter.failures_required).to eq 1
-      end
-
-      it "returns 1 when RSpec.configuration.fail_fast == 1" do
-        config.fail_fast = 1
-        expect(reporter.failures_required).to eq 1
-      end
-
-      it "returns RSpec.configuration.fail_fast when RSpec.configuration.fail_fast > 1" do
-        config.fail_fast = 3
-        expect(reporter.failures_required).to eq 3
-      end
-    end
   end
 end


### PR DESCRIPTION
- Better warning when an invalid value is passed
  for `--fail-fast` (including silencing call site
  since it will not be in user code).
- No need to stub `reporter.failures_required`.
- No need for the `failures_required` method at all.
- Use `fail_fast_limit_met?` in more situations.
- Remove unneeded `ExampleGroup.fail_fast?` method.