### PR TITLE
Core::Helper

### DIFF
--- a/lib/rspec/core/helper.rb
+++ b/lib/rspec/core/helper.rb
@@ -1,0 +1,38 @@
+module RSpec
+  module Core
+    # Extend helper with this module and specify cases when you want this filter
+    # to be available in.
+    #
+    #     module SignInHelper
+    #       extend RSpec::Core::Helper
+    #       register_helper :include, type: :controller
+    #       # ...
+    #     end
+    module Helper
+      class << self
+        def register(mod, *actions, **filter)
+          @modules ||= Hash.new { |h, k| h[k] = [] }
+          @modules[mod] << [actions, filter]
+        end
+
+        def apply(config)
+          @modules.each do |mod, rules|
+            rules.each do |(actions, filter)|
+              actions.each do |action|
+                config.public_send action, mod, filter
+              end
+            end
+            mod.applied(config)
+          end
+        end
+      end
+
+      def register_helper(*actions, **filter)
+        Helper.register self, *actions, filter
+      end
+
+      def applied(_config)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi!

When there are a lot of helpers all of them need to be repeated in `rails_helper.rb`/`spec_helper.rb`:
```ruby
config.include SpecHelper::One
config.include SpecHelper::Other type: :smth
config.extend SpecHelper::Another
# ...
```
I think it would be great if we could define this actions right inside helper and don't modify `spec_helper` all the time. Like this:
```ruby
module SpecHelper::One
  extend RSpec::Core::Helper
  register_helper :include, type: :smth
  # ...
end
```
Here is working implementation, but there are no test. I'll add them, if you like an idea. wdyt?