### PR TITLE
Turn a #map into #each where the return value is unused

### DIFF
--- a/lib/rspec/core/ruby_project.rb
+++ b/lib/rspec/core/ruby_project.rb
@@ -6,7 +6,7 @@ module RSpec
     # @private
     module RubyProject
       def add_to_load_path(*dirs)
-        dirs.map { |dir| add_dir_to_load_path(File.join(root, dir)) }
+        dirs.each { |dir| add_dir_to_load_path(File.join(root, dir)) }
       end
 
       def add_dir_to_load_path(dir)


### PR DESCRIPTION
The return value of `RubyProject.add_to_load_path` is neither useful nor used anywhere. In this case, `#each` communicates intent better than `#map`.

Shout out to @scottmatthewman for highlighting this method at the [November 2015 meeting](http://lrug.org/meetings/2015/november/) of the [London Ruby User Group](http://lrug.org).