### PR TITLE
(refactor): Avoid calling superclass.method

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -180,7 +180,7 @@ module RSpec
 
         @metadata = Metadata::ExampleHash.create(
           @example_group_class.metadata, user_metadata,
-          example_group_class.method(:next_runnable_index_for),
+          lambda { |file| example_group_class.next_runnable_index_for(file) },
           description, example_block
         )
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -409,7 +409,7 @@ module RSpec
 
         @metadata = Metadata::ExampleGroupHash.create(
           superclass_metadata, user_metadata,
-          superclass.method(:next_runnable_index_for),
+          lambda { |file| superclass.next_runnable_index_for(file) },
           description, *args, &example_group_block
         )
         ExampleGroups.assign_const(self)

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1912,5 +1912,23 @@ module RSpec::Core
       expect(group.examples.length).to eq(0)
       expect(original_ids).to_not eq(group_ids(group))
     end
+
+    it 'allows extensions to add `method` to the DSL without causing problems' do
+      http_testing_extension = Module.new do
+        attr_reader :http_method
+        def method(meth); @http_method = meth; end
+      end
+
+      describe_successfully do
+        extend http_testing_extension
+        method :get
+
+        describe('group') do
+          it "allows `method` to specify the HTTP method" do
+            expect(self.class.http_method).to eq(:get)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -797,4 +797,20 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       expect(example.reporter).to be reporter
     end
   end
+
+  it 'allows extensions to add `method` to the DSL without causing problems' do
+    http_testing_extension = Module.new do
+      attr_reader :http_method
+      def method(meth); @http_method = meth; end
+    end
+
+    describe_successfully do
+      extend http_testing_extension
+      method :get
+
+      it "allows `method` to specify the HTTP method" do
+        expect(self.class.http_method).to eq(:get)
+      end
+    end
+  end
 end


### PR DESCRIPTION
...in favour of using a lambda.

This addresses https://github.com/rspec/rspec-core/issues/2008

But really, any third party code which causes problems with the original
code is probably doing something a bit dodgy (e.g. overriding the `method` method on an
object).

Core test suite passes locally, but I haven't been able to run the travis build locally because of the following (unrelated) error:

```shell
» script/run_build
============= Starting binstub check ===============
Checking required binstubs
============= Ending binstub check ===============
============= Starting specs ===============
/Users/dxwduncan/dev/ruby_and_rails/rspec-core/bin/rspec
script/rspec_with_simplecov:17:in `require': cannot load such file -- bundler/setup (LoadError)
        from script/rspec_with_simplecov:17:in `<main>'
```

(I'm using bundler 1.10.6)