### PR TITLE
Make wording more accurate.

### DIFF
--- a/lib/rspec/core/formatters/bisect_progress_formatter.rb
+++ b/lib/rspec/core/formatters/bisect_progress_formatter.rb
@@ -39,7 +39,7 @@ module RSpec
         end
 
         def bisect_dependency_check_failed(_notification)
-          output.puts " failure is not order-dependent"
+          output.puts " failure(s) do not require any non-failures to run first"
         end
 
         def bisect_round_started(notification, include_trailing_space=true)

--- a/spec/rspec/core/bisect/coordinator_spec.rb
+++ b/spec/rspec/core/bisect/coordinator_spec.rb
@@ -108,7 +108,7 @@ module RSpec::Core
           |Bisect started using options: ""
           |Running suite to find failures... (n.nnnn seconds)
           |Starting bisect with 1 failing example and 7 non-failing examples.
-          |Checking that failure(s) are order-dependent... failure is not order-dependent
+          |Checking that failure(s) are order-dependent... failure(s) do not require any non-failures to run first
           |
           |Bisect complete! Reduced necessary non-failing examples from 7 to 0 in n.nnnn seconds.
           |


### PR DESCRIPTION
The existing wording was confusing for this situation:

* You have two specs, a and b.
* Spec a always fails.
* Spec b fails only if a runs first.

In such a situation, your failures are order dependent,
but our bisector printed "failure is not order dependent",
which was quite confusing. The new wording,
"failures(s) do not require any non-failures to run first"
is more accurate.