### PR TITLE
Fix `BacktraceFormatter` to handle `nil` backtraces.

### DIFF
--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -31,6 +31,7 @@ module RSpec
       end
 
       def format_backtrace(backtrace, options={})
+        return [] unless backtrace
         return backtrace if options[:full_backtrace] || backtrace.empty?
 
         backtrace.map { |l| backtrace_line(l) }.compact.

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -35,7 +35,7 @@ module RSpec
         end
 
         def formatted_backtrace(exception=@exception)
-          backtrace_formatter.format_backtrace((exception.backtrace || []), example.metadata) +
+          backtrace_formatter.format_backtrace(exception.backtrace, example.metadata) +
             formatted_cause(exception)
         end
 

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -132,10 +132,20 @@ module RSpec::Core
         end
       end
 
-      describe "an empty backtrace" do
+      describe "for an empty backtrace" do
         it "does not add the explanatory message about backtrace filtering" do
           formatter = BacktraceFormatter.new
           expect(formatter.format_backtrace([])).to eq([])
+        end
+      end
+
+      describe "for a `nil` backtrace (since exceptions can have no backtrace!)" do
+        it 'returns a blank array, with no explanatory message' do
+          exception = Exception.new
+          expect(exception.backtrace).to be_nil
+
+          formatter = BacktraceFormatter.new
+          expect(formatter.format_backtrace(exception.backtrace)).to eq([])
         end
       end
 


### PR DESCRIPTION
`Exception.new.backtrace` is `nil` so we can't count on
there always being a backtrace. Before now we relied
on the `format_backtrace` caller handling this (passing
`ex.backtrace || []`), but with #2074 now also including
the `exception.cause` in failure output, the code there
did not guard the `format_backtrace` call with `|| []`
and is causing users to get a `NoMethodError`. It's
easiest if `format_backtrace just handles the `nil` case
so each caller does not have to remember to handle it.

Fixes #2117.