### PR TITLE
Prevent `MultipleExceptionError#add` from allowing self to be added to the list of `all_exceptions`

### DIFF
--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -408,6 +408,8 @@ module RSpec
           # ignore it.
           return if Pending::PendingExampleFixedError === exception
 
+          return if exception == self
+
           all_exceptions << exception
 
           if exception.class.name =~ /RSpec/

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -695,6 +695,12 @@ module RSpec::Core
       end
     end
 
+    it "does not let you add itself to the list of all_exceptions" do
+      m = MultipleExceptionError.new
+      m.add(m)
+      expect(m.all_exceptions).to_not include(m)
+    end
+
     it 'supports the same interface as `RSpec::Expectations::MultipleExpectationsNotMetError`' do
       skip "Skipping to allow an rspec-expectations PR to add a new method and remain green" if ENV['NEW_MUTLI_EXCEPTION_METHOD']
 


### PR DESCRIPTION


This was exposed by https://github.com/rspec/rspec-core/pull/2112 which
contains a spec which uses `describe_successfully` which seems to somehow
add the existing `MultipleExceptionError` to itself when it fails. This
**does not happen** if the example passes (presumably because an error
is not generated).

When we format the exception
[here](https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/formatters/exception_presenter.rb#L330)
we use FlatMap, which is going to continuously unpack the exception,
causing infinite recursion.

This patch prevents `MultipleExceptionError::InterfaceTag#add` from
allowing `self` to be included in the `all_exceptions` array. This fixes
the problem.

As far as I can tell from running our suite, the `self` being added case
never actually happens during normal RSpec execution and so adding this
is fine. I added a spec which demonstrates this behaviour in case that
turns out to be problematic in the future. I can't imagine that
happening though as this will precisely cause the same infinite
recursion bug.