### PR TITLE
Fixed typo in features/hooks/filtering.feature

### DIFF
--- a/features/hooks/filtering.feature
+++ b/features/hooks/filtering.feature
@@ -413,7 +413,7 @@ Feature: filters
             expect(invoked_hooks).to be_empty
           end
 
-          it "does not run the hook if the coerced values match", :foo => 'bar' do
+          it "runs the hook if the coerced values match", :foo => 'bar' do
             expect(invoked_hooks).to eq([:before_example_foo_bar])
           end
         end


### PR DESCRIPTION
Old text: does not run the hook if the coerced values match
New text: runs the hook if the coerced values match

I'm pretty sure the text is wrong based upon other examples in the area and also the test.
