### PR TITLE
Ensure ExecutionResult timing is always populated

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### Development
+[Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.1...master)
+
+Bug Fixes:
+
+* Fix `rspec --profile` when an example calls `abort` or `exit`.
+  (Bradley Schaefer, #2144)
+
 ### 3.4.1 / 2015-11-18
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.0...v3.4.1)
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -9,7 +9,7 @@ module RSpec
     #
     # This allows us to provide rich metadata about each individual
     # example without adding tons of methods directly to the ExampleGroup
-    # that users may inadvertantly redefine.
+    # that users may inadvertently redefine.
     #
     # Useful for configuring logging and/or taking some action based
     # on the state of an example's metadata.

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -260,6 +260,7 @@ module RSpec
 
         finish(reporter)
       ensure
+        execution_result.ensure_timing_set(clock)
         RSpec.current_example = nil
       end
 
@@ -565,12 +566,22 @@ module RSpec
         # @api private
         # Records the finished status of the example.
         def record_finished(status, finished_at)
-          self.status      = status
-          self.finished_at = finished_at
-          self.run_time    = (finished_at - started_at).to_f
+          self.status = status
+          calculate_run_time(finished_at)
+        end
+
+        # @api private
+        # Populates finished_at and run_time if it has not yet been set
+        def ensure_timing_set(clock)
+          calculate_run_time(clock.now) unless finished_at
         end
 
       private
+
+        def calculate_run_time(finished_at)
+          self.finished_at = finished_at
+          self.run_time    = (finished_at - started_at).to_f
+        end
 
         # For backwards compatibility we present `status` as a string
         # when presenting the legacy hash interface.

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -796,7 +796,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
   end
 
   describe "exposing the examples reporter" do
-    it "returns a null reporter when the example hasnt run yet" do
+    it "returns a null reporter when the example has not run yet" do
       example = RSpec.describe.example
       expect(example.reporter).to be RSpec::Core::NullReporter
     end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
     end
   end
 
+  it "captures example timing even for exceptions unhandled by RSpec" do
+    unhandled = RSpec::Support::AllExceptionsExceptOnesWeMustNotRescue::AVOID_RESCUING.first
+    example = example_group.example { raise unhandled }
+
+    begin
+      example_group.run
+    rescue unhandled
+      # no-op, prevent from bubbling up
+    end
+    expect(example.execution_result.finished_at).not_to be_nil
+  end
+
   describe "#exception" do
     it "supplies the exception raised, if there is one" do
       example = example_group.example { raise "first" }


### PR DESCRIPTION
In the case where RSpec does not handle an error (e.g. `SystemExit`), we still need to capture the example timing data in order not to break profiling information that may get generated via `--profile` using those values.
