### PR TITLE
Fix failing specs caused by $SAFE incompatibility on MRI 2.3

### DIFF
--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,4 +1,6 @@
 module RSpecHelpers
+  SAFE_LEVEL_THAT_TRIGGERS_SECURITY_ERRORS = RUBY_VERSION >= '2.3' ? 1 : 3
+
   def relative_path(path)
     RSpec::Core::Metadata.relative_path(path)
   end
@@ -13,7 +15,7 @@ module RSpecHelpers
 
   def with_safe_set_to_level_that_triggers_security_errors
     Thread.new do
-      ignoring_warnings { $SAFE = 3 }
+      ignoring_warnings { $SAFE = SAFE_LEVEL_THAT_TRIGGERS_SECURITY_ERRORS }
       yield
     end.join
 


### PR DESCRIPTION
`$SAFE` level 2, 3, and 4 are no longer available on MRI 2.3.

https://bugs.ruby-lang.org/issues/5455#note-16

```
Failures:

  1) RSpec::Core::Formatters::HtmlSnippetExtractor falls back on a default message when it gets a security error
     Failure/Error: ignoring_warnings { $SAFE = 3 }
     
     ArgumentError:
       $SAFE=2 to 4 are obsolete
     # ./spec/support/helper_methods.rb:16:in `block (2 levels) in with_safe_set_to_level_that_triggers_security_errors'
     # ./spec/support/helper_methods.rb:9:in `ignoring_warnings'
     # ./spec/support/helper_methods.rb:16:in `block in with_safe_set_to_level_that_triggers_security_errors'
```