### PR TITLE
Remove nokogiri development dependency

### DIFF
--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -2,6 +2,10 @@ module RSpec
   module Core
     # Provides the main entry point to run a suite of RSpec examples.
     class Runner
+      # @attr_reader
+      # @private
+      attr_reader :options, :configuration, :world
+
       # Register an `at_exit` hook that runs the suite when the process exits.
       #
       # @note This is not generally needed. The `rspec` command takes care

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -42,7 +42,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
 
-  s.add_development_dependency "nokogiri", (RUBY_VERSION < '1.9.3' ? "1.5.2" : ["~> 1.5", "!= 1.6.6.3", "!= 1.6.6.4", "!=  1.6.7.1", "!= 1.6.7"])
   s.add_development_dependency "coderay",  "~> 1.0.9"
 
   s.add_development_dependency "mocha",        "~> 0.13.0"

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -1,10 +1,11 @@
-<html lang="en">
+<!DOCTYPE html>
+<html lang='en'>
 <head>
-<title>RSpec results</title>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta http-equiv="Expires" content="-1">
-<meta http-equiv="Pragma" content="no-cache">
-<style type="text/css">
+  <title>RSpec results</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta http-equiv="Expires" content="-1" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <style type="text/css">
   body {
     margin: 0;
     padding: 0;
@@ -12,7 +13,7 @@
     font-size: 80%;
   }
   </style>
-<script type="text/javascript">
+  <script type="text/javascript">
     // <![CDATA[
 
 function addClass(element_id, classname) {
@@ -90,7 +91,8 @@ function assign_display_style_for_group(classname, display_flag, subgroup_flag) 
 }
 
     // ]]>
-  </script><style type="text/css">
+  </script>
+  <style type="text/css">
 #rspec-header {
   background: #65C400; color: #fff; height: 4em;
 }
@@ -264,14 +266,14 @@ a {
   </div>
 
   <div id="display-filters">
-    <input id="passed_checkbox" name="passed_checkbox" type="checkbox" checked onchange="apply_filters()" value="1"><label for="passed_checkbox">Passed</label>
-    <input id="failed_checkbox" name="failed_checkbox" type="checkbox" checked onchange="apply_filters()" value="2"><label for="failed_checkbox">Failed</label>
-    <input id="pending_checkbox" name="pending_checkbox" type="checkbox" checked onchange="apply_filters()" value="3"><label for="pending_checkbox">Pending</label>
+    <input id="passed_checkbox"  name="passed_checkbox"  type="checkbox" checked="checked" onchange="apply_filters()" value="1" /> <label for="passed_checkbox">Passed</label>
+    <input id="failed_checkbox"  name="failed_checkbox"  type="checkbox" checked="checked" onchange="apply_filters()" value="2" /> <label for="failed_checkbox">Failed</label>
+    <input id="pending_checkbox" name="pending_checkbox" type="checkbox" checked="checked" onchange="apply_filters()" value="3" /> <label for="pending_checkbox">Pending</label>
   </div>
 
   <div id="summary">
-    <p id="totals"> </p>
-    <p id="duration"> </p>
+    <p id="totals">&#160;</p>
+    <p id="duration">&#160;</p>
   </div>
 </div>
 
@@ -279,33 +281,45 @@ a {
 <div class="results">
 <div id="div_group_1" class="example_group passed">
   <dl style="margin-left: 0px;">
-<dt id="example_group_1" class="passed">pending spec with no implementation</dt>
-    <script type="text/javascript">makeYellow('rspec-header');</script><script type="text/javascript">makeYellow('div_group_1');</script><script type="text/javascript">makeYellow('example_group_1');</script><script type="text/javascript">moveProgressBar('12.5');</script><dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: Not yet implemented)</span></dd>
+  <dt id="example_group_1" class="passed">pending spec with no implementation</dt>
+    <script type="text/javascript">makeYellow('rspec-header');</script>
+    <script type="text/javascript">makeYellow('div_group_1');</script>
+    <script type="text/javascript">makeYellow('example_group_1');</script>
+    <script type="text/javascript">moveProgressBar('12.5');</script>
+    <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: Not yet implemented)</span></dd>
   </dl>
 </div>
 <div id="div_group_2" class="example_group passed">
   <dl style="margin-left: 0px;">
-<dt id="example_group_2" class="passed">pending command with block format</dt>
+  <dt id="example_group_2" class="passed">pending command with block format</dt>
   </dl>
 </div>
 <div id="div_group_3" class="example_group passed">
   <dl style="margin-left: 15px;">
-<dt id="example_group_3" class="passed">with content that would fail</dt>
-    <script type="text/javascript">makeYellow('rspec-header');</script><script type="text/javascript">makeYellow('div_group_3');</script><script type="text/javascript">makeYellow('example_group_3');</script><script type="text/javascript">moveProgressBar('25.0');</script><dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: No reason given)</span></dd>
+  <dt id="example_group_3" class="passed">with content that would fail</dt>
+    <script type="text/javascript">makeYellow('rspec-header');</script>
+    <script type="text/javascript">makeYellow('div_group_3');</script>
+    <script type="text/javascript">makeYellow('example_group_3');</script>
+    <script type="text/javascript">moveProgressBar('25.0');</script>
+    <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: No reason given)</span></dd>
   </dl>
 </div>
 <div id="div_group_4" class="example_group passed">
   <dl style="margin-left: 15px;">
-<dt id="example_group_4" class="passed">behaves like shared</dt>
-    <script type="text/javascript">makeRed('rspec-header');</script><script type="text/javascript">makeRed('div_group_4');</script><script type="text/javascript">makeRed('example_group_4');</script><script type="text/javascript">moveProgressBar('37.5');</script><dd class="example pending_fixed">
+  <dt id="example_group_4" class="passed">behaves like shared</dt>
+    <script type="text/javascript">makeRed('rspec-header');</script>
+    <script type="text/javascript">makeRed('div_group_4');</script>
+    <script type="text/javascript">makeRed('example_group_4');</script>
+    <script type="text/javascript">moveProgressBar('37.5');</script>
+    <dd class="example pending_fixed">
       <span class="failed_spec_name">is marked as pending but passes</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_1">
         <div class="message"><pre>Expected example to fail since it is pending, but it passed.</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:4</pre></div>
     <pre class="ruby"><code><span class="linenum">2</span>
-<span class="linenum">3</span><span class="constant">RSpec</span>.shared_examples_for <span class="string"><span class="delimiter">"</span><span class="content">shared</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
-<span class="offending"><span class="linenum">4</span>  it <span class="string"><span class="delimiter">"</span><span class="content">is marked as pending but passes</span><span class="delimiter">"</span></span> <span class="keyword">do</span></span>
+<span class="linenum">3</span><span class="constant">RSpec</span>.shared_examples_for <span class="string"><span class="delimiter">&quot;</span><span class="content">shared</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="offending"><span class="linenum">4</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">is marked as pending but passes</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span></span>
 <span class="linenum">5</span>    pending
 <span class="linenum">6</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">1</span>)</code></pre>
       </div>
@@ -314,16 +328,18 @@ a {
 </div>
 <div id="div_group_5" class="example_group passed">
   <dl style="margin-left: 0px;">
-<dt id="example_group_5" class="passed">passing spec</dt>
-    <script type="text/javascript">moveProgressBar('50.0');</script><dd class="example passed">
-<span class="passed_spec_name">passes</span><span class="duration">n.nnnns</span>
-</dd>
+  <dt id="example_group_5" class="passed">passing spec</dt>
+    <script type="text/javascript">moveProgressBar('50.0');</script>
+    <dd class="example passed"><span class="passed_spec_name">passes</span><span class='duration'>n.nnnns</span></dd>
   </dl>
 </div>
 <div id="div_group_6" class="example_group passed">
   <dl style="margin-left: 0px;">
-<dt id="example_group_6" class="passed">failing spec</dt>
-    <script type="text/javascript">makeRed('div_group_6');</script><script type="text/javascript">makeRed('example_group_6');</script><script type="text/javascript">moveProgressBar('62.5');</script><dd class="example failed">
+  <dt id="example_group_6" class="passed">failing spec</dt>
+    <script type="text/javascript">makeRed('div_group_6');</script>
+    <script type="text/javascript">makeRed('example_group_6');</script>
+    <script type="text/javascript">moveProgressBar('62.5');</script>
+    <dd class="example failed">
       <span class="failed_spec_name">fails</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_2">
@@ -333,9 +349,9 @@ expected: 2
 
 (compared using ==)
 </pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:33</pre></div>
-    <pre class="ruby"><code><span class="linenum">31</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">"</span><span class="content">failing spec</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
-<span class="linenum">32</span>  it <span class="string"><span class="delimiter">"</span><span class="content">fails</span><span class="delimiter">"</span></span> <span class="keyword">do</span>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">31</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="linenum">32</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="offending"><span class="linenum">33</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
 <span class="linenum">34</span>  <span class="keyword">end</span>
 <span class="linenum">35</span><span class="keyword">end</span></code></pre>
@@ -345,31 +361,46 @@ expected: 2
 </div>
 <div id="div_group_7" class="example_group passed">
   <dl style="margin-left: 0px;">
-<dt id="example_group_7" class="passed">a failing spec with odd backtraces</dt>
-    <script type="text/javascript">makeRed('div_group_7');</script><script type="text/javascript">makeRed('example_group_7');</script><script type="text/javascript">moveProgressBar('75.0');</script><dd class="example failed">
+  <dt id="example_group_7" class="passed">a failing spec with odd backtraces</dt>
+    <script type="text/javascript">makeRed('div_group_7');</script>
+    <script type="text/javascript">makeRed('example_group_7');</script>
+    <script type="text/javascript">moveProgressBar('75.0');</script>
+    <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace that has no file</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_3">
         <div class="message"><pre>foo</pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:41</pre></div>
-    <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for (erb)</span></code></pre>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">39</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
+<span class="linenum">40</span>
+<span class="offending"><span class="linenum">41</span>    <span class="constant">ERB</span>.new(<span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;%= raise 'foo' %&gt;</span><span class="delimiter">&quot;</span></span>).result</span>
+<span class="linenum">42</span>  <span class="keyword">end</span></code></pre>
       </div>
     </dd>
-    <script type="text/javascript">moveProgressBar('87.5');</script><dd class="example failed">
+    <script type="text/javascript">moveProgressBar('87.5');</script>
+    <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace containing an erb file</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_4">
         <div class="message"><pre>Exception</pre></div>
-        <div class="backtrace"><pre></pre></div>
-    <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for /foo.html.erb</span></code></pre>
+        <div class="backtrace"><pre>/foo.html.erb:1:in `&lt;main&gt;&#39;: foo (RuntimeError)
+   from /lib/ruby/1.9.1/erb.rb:753:in `eval&#39;
+
+  Showing full backtrace because every line was filtered out.
+  See docs for RSpec::Configuration#backtrace_exclusion_patterns and
+  RSpec::Configuration#backtrace_inclusion_patterns for more information.</pre></div>
+    <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for </span></code></pre>
       </div>
     </dd>
   </dl>
 </div>
 <div id="div_group_8" class="example_group passed">
   <dl style="margin-left: 15px;">
-<dt id="example_group_8" class="passed">with a `nil` backtrace</dt>
-    <script type="text/javascript">makeRed('div_group_8');</script><script type="text/javascript">makeRed('example_group_8');</script><script type="text/javascript">moveProgressBar('100.0');</script><dd class="example failed">
+  <dt id="example_group_8" class="passed">with a `nil` backtrace</dt>
+    <script type="text/javascript">makeRed('div_group_8');</script>
+    <script type="text/javascript">makeRed('example_group_8');</script>
+    <script type="text/javascript">moveProgressBar('100.0');</script>
+    <dd class="example failed">
       <span class="failed_spec_name">raises</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_5">
@@ -380,7 +411,8 @@ expected: 2
     </dd>
   </dl>
 </div>
-<script type="text/javascript">document.getElementById('duration').innerHTML = "Finished in <strong>n.nnnn seconds</strong>";</script><script type="text/javascript">document.getElementById('totals').innerHTML = "8 examples, 5 failures, 2 pending";</script>
+<script type="text/javascript">document.getElementById('duration').innerHTML = "Finished in <strong>n.nnnn seconds</strong>";</script>
+<script type="text/javascript">document.getElementById('totals').innerHTML = "8 examples, 5 failures, 2 pending";</script>
 </div>
 </div>
 </body>

--- a/spec/rspec/core/formatters/html_formatter_spec.rb
+++ b/spec/rspec/core/formatters/html_formatter_spec.rb
@@ -1,46 +1,32 @@
 # encoding: utf-8
 require 'rspec/core/formatters/html_formatter'
 
-# For some reason we get load errors when loading nokogiri on AppVeyor
-# on Ruby 2.1.  On 1.9.3 it works just fine. No idea why.
-require 'nokogiri' unless ENV['APPVEYOR'] && RUBY_VERSION.to_f >= 2.1
-
 module RSpec
   module Core
     module Formatters
-      RSpec.describe HtmlFormatter, :failing_on_appveyor => (RUBY_VERSION.to_f >= 2.1) do
+      RSpec.describe HtmlFormatter do
         include FormatterSupport
 
         let(:root) { File.expand_path("#{File.dirname(__FILE__)}/../../../..") }
+
         let(:expected_file) do
           "#{File.dirname(__FILE__)}/html_formatted.html"
         end
 
-        let(:generated_html) do
-          html = run_example_specs_with_formatter('html')
+        let(:actual_html) do
+          run_example_specs_with_formatter('html') do |runner|
+            allow(runner.configuration).to receive(:load_spec_files) do
+              runner.configuration.files_to_run.map { |f| load File.expand_path(f) }
+            end
 
-          actual_doc = Nokogiri::HTML(html, &:noblanks)
-          actual_doc.css("div.backtrace pre").each do |elem|
-            # This is to minimize churn on backtrace lines that we do not
-            # assert on anyway.
-            backtrace = elem.inner_html.lines.
-              select {|e| e =~ /formatter_specs\.rb/ }.
-              map {|x| x.chomp.split(":")[0..1].join(':') }.
-              join("\n")
-
-            elem.inner_html = backtrace
+            # This is to minimize churn on backtrace lines
+            runner.configuration.backtrace_exclusion_patterns << /.*/
+            runner.configuration.backtrace_inclusion_patterns << /formatter_specs\.rb/
           end
-          actual_doc.inner_html
         end
 
         let(:expected_html) do
           File.read(expected_file)
-        end
-
-        before do
-          allow(RSpec.configuration).to receive(:load_spec_files) do
-            RSpec.configuration.files_to_run.map {|f| load File.expand_path(f) }
-          end
         end
 
         # Uncomment this group temporarily in order to overwrite the expected
@@ -48,7 +34,7 @@ module RSpec
         describe "file generator", :if => ENV['GENERATE'] do
           it "generates a new comparison file" do
             Dir.chdir(root) do
-              File.open(expected_file, 'w') {|io| io.write(generated_html)}
+              File.open(expected_file, 'w') {|io| io.write(actual_html)}
             end
           end
         end
@@ -67,43 +53,22 @@ module RSpec
           # least runs we can be reasonably confident the output is right since
           # behaviour variances that we care about across versions is neglible.
           it 'is present' do
-            expect(generated_html).to be
+            expect(actual_html).to be
           end
         end
 
         describe 'produced HTML', :slow, :if => RUBY_VERSION >= '2.0.0' do
-          def build_and_verify_formatter_output
-            Dir.chdir(root) do
-              actual_doc = Nokogiri::HTML(generated_html, &:noblanks)
-              actual_backtraces = extract_backtrace_from(actual_doc)
-              actual_doc.css("div.backtrace").remove
-
-              expected_doc = Nokogiri::HTML(expected_html, &:noblanks)
-              expected_backtraces = extract_backtrace_from(expected_doc)
-              expected_doc.search("div.backtrace").remove
-
-              expect(actual_doc.inner_html).to eq(expected_doc.inner_html)
-
-              expected_backtraces.each_with_index do |expected_line, i|
-                expected_path, expected_line_number, expected_suffix = expected_line.split(':')
-                actual_path, actual_line_number, actual_suffix = actual_backtraces[i].split(':')
-
-                expect(File.expand_path(actual_path)).to eq(File.expand_path(expected_path))
-                expect(actual_line_number).to eq(expected_line_number)
-                expect(actual_suffix).to eq(expected_suffix)
-              end
-            end
-          end
-
           it "is identical to the one we designed manually", :pending => (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby') do
-            build_and_verify_formatter_output
+            expect(actual_html).to eq(expected_html)
           end
 
           context 'with mathn loaded' do
             include MathnIntegrationSupport
 
             it "is identical to the one we designed manually", :slow, :pending => (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby') do
-              with_mathn_loaded { build_and_verify_formatter_output }
+              with_mathn_loaded do
+                expect(actual_html).to eq(expected_html)
+              end
             end
           end
         end

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -6,9 +6,11 @@ module FormatterSupport
     err.set_encoding("utf-8") if err.respond_to?(:set_encoding)
 
     runner = RSpec::Core::Runner.new(options)
-    configuration = runner.instance_variable_get("@configuration")
+    configuration = runner.configuration
     configuration.backtrace_formatter.exclusion_patterns << /rspec_with_simplecov/
     configuration.backtrace_formatter.inclusion_patterns = []
+
+    yield runner if block_given?
 
     runner.run(err, out)
 
@@ -55,7 +57,7 @@ module FormatterSupport
         |
         |       (compared using ==)
         |     # ./spec/rspec/core/resources/formatter_specs.rb:18
-        |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
+        |     # ./spec/support/formatter_support.rb:15:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14
         |     # ./spec/support/sandboxing.rb:7
         |
@@ -74,7 +76,7 @@ module FormatterSupport
         |
         |       (compared using ==)
         |     # ./spec/rspec/core/resources/formatter_specs.rb:33
-        |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
+        |     # ./spec/support/formatter_support.rb:15:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14
         |     # ./spec/support/sandboxing.rb:7
         |
@@ -128,7 +130,7 @@ module FormatterSupport
         |
         |       (compared using ==)
         |     # ./spec/rspec/core/resources/formatter_specs.rb:18:in `block (3 levels) in <top (required)>'
-        |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
+        |     # ./spec/support/formatter_support.rb:15:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
@@ -147,7 +149,7 @@ module FormatterSupport
         |
         |       (compared using ==)
         |     # ./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in <top (required)>'
-        |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
+        |     # ./spec/support/formatter_support.rb:15:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
@@ -158,7 +160,7 @@ module FormatterSupport
         |       foo
         |     # (erb):1:in `<main>'
         |     # ./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in <top (required)>'
-        |     # ./spec/support/formatter_support.rb:13:in `run_example_specs_with_formatter'
+        |     # ./spec/support/formatter_support.rb:15:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |


### PR DESCRIPTION
Background: https://github.com/rspec/rspec-expectations/pull/882

It's only used to filter backtrace in HtmlFormatter spec but it can be replaced and simplified with the backtrace filtering API.