### PR TITLE
Fix order dependent spec on JRuby

### DIFF
--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -152,7 +152,7 @@ module RSpec
       # @private
       # rubocop:disable Lint/EnsureReturn
       def self.running_in_drb?
-        if defined?(DRb) && DRb.current_server
+        if defined?(DRb) && DRb.current_server && DRb.current_server.alive?
           require 'socket'
           require 'uri'
           local_ipv4 = IPSocket.getaddress(Socket.gethostname)

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -158,29 +158,67 @@ module RSpec::Core
     # This is intermittently slow because this method calls out to the network
     # interface.
     describe ".running_in_drb?", :slow do
-      it "returns true if drb server is started with 127.0.0.1" do
-        allow(::DRb).to receive(:current_server).and_return(double(:uri => "druby://127.0.0.1:0000/"))
+      subject { RSpec::Core::Runner.running_in_drb? }
 
-        expect(RSpec::Core::Runner.running_in_drb?).to be_truthy
+      before do
+        allow(::DRb).to receive(:current_server) { drb_server }
       end
 
-      it "returns true if drb server is started with localhost" do
-        allow(::DRb).to receive(:current_server).and_return(double(:uri => "druby://localhost:0000/"))
+      context "when drb server is started with 127.0.0.1" do
+        let(:drb_server) do
+          instance_double(::DRb::DRbServer, :uri => "druby://127.0.0.1:0000/", :alive? => true)
+        end
 
-        expect(RSpec::Core::Runner.running_in_drb?).to be_truthy
+        it { should be_truthy }
       end
 
-      it "returns true if drb server is started with another local ip address" do
-        allow(::DRb).to receive(:current_server).and_return(double(:uri => "druby://192.168.0.1:0000/"))
-        allow(::IPSocket).to receive(:getaddress).and_return("192.168.0.1")
+      context "when drb server is started with localhost" do
+        let(:drb_server) do
+          instance_double(::DRb::DRbServer, :uri => "druby://localhost:0000/", :alive? => true)
+        end
 
-        expect(RSpec::Core::Runner.running_in_drb?).to be_truthy
+        it { should be_truthy }
       end
 
-      it "returns false if no drb server is running" do
-        allow(::DRb).to receive(:current_server).and_raise(::DRb::DRbServerNotFound)
+      context "when drb server is started with another local ip address" do
+        let(:drb_server) do
+          instance_double(::DRb::DRbServer, :uri => "druby://192.168.0.1:0000/", :alive? => true)
+        end
 
-        expect(RSpec::Core::Runner.running_in_drb?).to be_falsey
+        before do
+          allow(::IPSocket).to receive(:getaddress).and_return("192.168.0.1")
+        end
+
+        it { should be_truthy }
+      end
+
+      context "when drb server is started with another local ip address" do
+        let(:drb_server) do
+          instance_double(::DRb::DRbServer, :uri => "druby://192.168.0.1:0000/", :alive? => true)
+        end
+
+        before do
+          allow(::IPSocket).to receive(:getaddress).and_return("192.168.0.1")
+        end
+
+        it { should be_truthy }
+      end
+
+      context "when drb server is started with 127.0.0.1 but not alive" do
+        let(:drb_server) do
+          instance_double(::DRb::DRbServer, :uri => "druby://127.0.0.1:0000/", :alive? => false)
+        end
+
+        it { should be_falsey }
+      end
+
+
+      context "when no drb server is running" do
+        let(:drb_server) do
+          raise ::DRb::DRbServerNotFound
+        end
+
+        it { should be_falsey }
       end
     end
 


### PR DESCRIPTION
The bisect feature internally uses DRb server. It properly stops the server after the processing, but `DRb.current_server` won't be `nil` even after invoking `DRbServer#stop_service`. Thus [`Runner.running_in_drb?`](https://github.com/rspec/rspec-core/blob/v3.4.1/lib/rspec/core/runner.rb#L150-L151) will unintentionally continue returning `true` once `Bisect::Server.run` is invoked in the process. In that case we need to check `DRbServer.alive?`.

```bash
$ ruby --version
jruby 1.7.22 (1.9.3p551) 2015-08-20 c28f492 on Java HotSpot(TM) 64-Bit Server VM 1.8.0_25-b17 +jit [darwin-x86_64]
$ bundle exec rspec './spec/integration/bisect_spec.rb[1:2:1]' './spec/rspec/core/configuration_spec.rb[1:13:13:3]' --seed 36379 --format doc

Randomized with seed 36379

Bisect
  when the spec ordering is inconsistent
    stops bisecting and surfaces the problem to the user

RSpec::Core::Configuration
  #files_to_run
    with default default_path
      does not load files in the default path when run by ruby (FAILED - 1)

Failures:

  1) RSpec::Core::Configuration#files_to_run with default default_path does not load files in the default path when run by ruby
     Failure/Error: expect(config.files_to_run).to be_empty
       expected `["/Users/nkymyj/Projects/rspec-dev/repos/rspec-core/spec/integration/bisect_spec.rb", "/Users/nkymyj/...ec/core/world_spec.rb", "/Users/nkymyj/Projects/rspec-dev/repos/rspec-core/spec/rspec/core_spec.rb"].empty?` to return true, got false
     # ./spec/rspec/core/configuration_spec.rb:553:in `Core'
     # ./spec/support/sandboxing.rb:14:in `(root)'
     # ./spec/support/sandboxing.rb:7:in `(root)'
```