### PR TITLE
Fix `--drb` option to not list DRb connection error as exception cause.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ Bug Fixes:
 
 * Fix `rspec --profile` when an example calls `abort` or `exit`.
   (Bradley Schaefer, #2144)
+* Fix `--drb` so that when no DRb server is running, it prevents
+  the DRb connection error from being listed as the cause of all
+  expectation failures. (Myron Marston, #2156)
 
 ### 3.4.1 / 2015-11-18
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.0...v3.4.1)

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -69,13 +69,13 @@ module RSpec
           require 'rspec/core/drb'
           begin
             DRbRunner.new(options).run(err, out)
+            return
           rescue DRb::DRbConnError
             err.puts "No DRb server is running. Running in local process instead ..."
-            new(options).run(err, out)
           end
-        else
-          new(options).run(err, out)
         end
+
+        new(options).run(err, out)
       end
 
       def initialize(options, configuration=RSpec.configuration, world=RSpec.world)

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -290,6 +290,24 @@ module RSpec::Core
 
             run_specs
           end
+
+          if RSpec::Support::RubyFeatures.supports_exception_cause?
+            it "prevents the DRb error from being listed as the cause of expectation failures" do
+              subclass = Class.new(RSpec::Core::Runner) do
+                include RSpec::Matchers
+
+                def run(err, out)
+                  expect(1).to eq(2)
+                end
+              end
+
+              expect {
+                subclass.run([], StringIO.new, StringIO.new)
+              }.to raise_error(RSpec::Expectations::ExpectationNotMetError) do |e|
+                expect(e.cause).to be_nil
+              end
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
If we start the spec run in a `rescue` block, ruby will set the
rescued exception to be the cause of all exceptions that occur
during the run.