### PR TITLE
Clarify one-liner syntax cannot be used with block matchers

### DIFF
--- a/features/subject/one_liner_syntax.feature
+++ b/features/subject/one_liner_syntax.feature
@@ -22,6 +22,7 @@ Feature: One-liner syntax
 
     * This feature is only available when using rspec-expectations.
     * Examples defined using this one-liner syntax cannot be directly selected from the command line using the [`--example` option](../command-line/example-option).
+    * The one-liner syntax only works with non-block expectations (e.g. `expect(obj).to eq`, etc) and it cannot be used with block expectations (e.g. `expect { object }`).
 
   Scenario: Implicit subject
     Given a file named "example_spec.rb" with:


### PR DESCRIPTION
Users sometimes try to use the one-liner syntax with block matchers,
which can cause RSpec to behave in strange ways. This behaviour is not
supported in RSpec because the complexity of implementing it would
greatly outweigh the benefits.

This commit just clarifies in the documentation that the one-liner
syntax does not support block matchers.

Possible fix for https://github.com/rspec/rspec-expectations/issues/805