### PR TITLE
Make syntax highlighting work when the coderay gem is installed but n…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@ Bug Fixes:
 * Fix `--drb` so that when no DRb server is running, it prevents
   the DRb connection error from being listed as the cause of all
   expectation failures. (Myron Marston, #2156)
+* Fix syntax highlighter so that it works when the `coderay` gem is
+  installed as a rubygem but not already available on your load path
+  (as happens when you use bundler). (Myron Marston, #2159)
 
 ### 3.4.1 / 2015-11-18
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.0...v3.4.1)

--- a/lib/rspec/core/source/syntax_highlighter.rb
+++ b/lib/rspec/core/source/syntax_highlighter.rb
@@ -30,7 +30,7 @@ module RSpec
 
         def color_enabled_implementation
           @color_enabled_implementation ||= begin
-            ::Kernel.require 'coderay'
+            require 'coderay'
             CodeRayImplementation
           rescue LoadError
             NoSyntaxHighlightingImplementation

--- a/spec/rspec/core/source/syntax_highlighter_spec.rb
+++ b/spec/rspec/core/source/syntax_highlighter_spec.rb
@@ -47,7 +47,7 @@ class RSpec::Core::Source
 
     context "when CodeRay is unavailable" do
       before do
-        allow(::Kernel).to receive(:require).with("coderay").and_raise(LoadError)
+        allow(highlighter).to receive(:require).with("coderay").and_raise(LoadError)
       end
 
       it 'does not highlight the syntax' do


### PR DESCRIPTION
…ot on your path.

Apparently, `::Kernel.require` is _only_ ruby's built-in require
(based on the `$LOAD_PATH`) and does not get the enhanced capabilities
of rubygems when rubygems is loaded. Rubygems only monkey patches
`::Kernel#require`, not `::Kernel.require`.

Originally, I had used `::Kernel.require` to load coderay to make
it easier to stub `require` to simulate coderay not being available,
as it allowed me to treat coderay as a collaborator. Using bare
`require` instead forces me to stub the object-under-test, which is
a bit smelly, but it fixes things so that you can get syntax
highlighting without using something like bundler to manage your
project and setup load paths.

Compare:

```
$ ruby -rubygems -e "p method(:require).source_location"
["/Users/myron/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb", 38]
```

vs

```
$ ruby -rubygems -e "p ::Kernel.method(:require).source_location"
nil
```