### PR TITLE
avoid TypeError when exiting

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -81,7 +81,7 @@ module RSpec
 
         return unless fail_on_error
         $stderr.puts "#{command} failed" if verbose
-        exit $?.exitstatus
+        exit $?.exitstatus || 1
       end
 
     private


### PR DESCRIPTION
I'm developing a binding based on FFI, and frequently the C library asserts. That's okay. But then, instead of just reporting that failure, rspec crashes with a `TypeError` while exiting:

```
[...]
  #configure
    with support for UDP broadcasts
      sends correct message to actor
    no support for UDP broadcasts
      raises
  #publish
    with data
      sends correct message to actor
    with data too long
      raises
  #silence
Assertion failed: (self->handle), function zsock_new_checked, file src/zsock.c, line 69.
/Users/paddor/.rubies/ruby-2.3.0/bin/ruby -I/Users/paddor/.gem/ruby/2.3.0/gems/rspec-support-3.4.1/lib:/Users/paddor/.gem/ruby/2.3.0/gems/rspec-core-3.4.1/lib /Users/paddor/.gem/ruby/2.3.0/gems/rspec-core-3.4.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
rake aborted!
TypeError: no implicit conversion from nil to integer
/Users/paddor/.gem/ruby/2.3.0/gems/rspec-core-3.4.1/lib/rspec/core/rake_task.rb:84:in `exit'
/Users/paddor/.gem/ruby/2.3.0/gems/rspec-core-3.4.1/lib/rspec/core/rake_task.rb:84:in `run_task'
/Users/paddor/.gem/ruby/2.3.0/gems/rspec-core-3.4.1/lib/rspec/core/rake_task.rb:96:in `block (2 levels) in define'
/Users/paddor/.gem/ruby/2.3.0/gems/rspec-core-3.4.1/lib/rspec/core/rake_task.rb:94:in `block in define'
Tasks: TOP => default => spec
(See full trace by running task with --trace)
```

This leads to confusion when not used to seeing this failure. This PR solves this annoyance. 