### PR TITLE
Fix drb weirdness

### DIFF
--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -212,7 +212,6 @@ module RSpec::Core
         it { should be_falsey }
       end
 
-
       context "when no drb server is running" do
         let(:drb_server) do
           raise ::DRb::DRbServerNotFound

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -192,18 +192,6 @@ module RSpec::Core
         it { should be_truthy }
       end
 
-      context "when drb server is started with another local ip address" do
-        let(:drb_server) do
-          instance_double(::DRb::DRbServer, :uri => "druby://192.168.0.1:0000/", :alive? => true)
-        end
-
-        before do
-          allow(::IPSocket).to receive(:getaddress).and_return("192.168.0.1")
-        end
-
-        it { should be_truthy }
-      end
-
       context "when drb server is started with 127.0.0.1 but not alive" do
         let(:drb_server) do
           instance_double(::DRb::DRbServer, :uri => "druby://127.0.0.1:0000/", :alive? => false)


### PR DESCRIPTION
Fix DRb specs that are failing for me locally.

As the comment explains, I have had to configure my network
adapter in a non-standard way, and it causes
`IPSocket.getaddress(Socket.gethostname)` to raise an error
for me.

A couple of the DRb specs were failing as a result. The use of
`return` from `ensure` caused the error to be ignored (the fact
that `local_drb` was not set caused it to return false). This was
confusing, and using `return` from `ensure` is a horrible practice. I have refactored to avoid the issue, rescuing
errors explicitly.