### PR TITLE
Remove logged messages

### DIFF
--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -175,7 +175,7 @@ module RSpec
           exit!(1)
         else
           RSpec.world.wants_to_quit = true
-          STDERR.puts "\nRSpec is shutting down and will print the summary report... Interrupt again to force quit."
+          $stderr.puts "\nRSpec is shutting down and will print the summary report... Interrupt again to force quit."
         end
       end
     end

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -115,7 +115,7 @@ module RSpec::Core
       let(:interrupt_handlers) { [] }
 
       before do
-        allow(Object).to receive(:trap).with("INT", any_args) do |&block|
+        allow(Runner).to receive(:trap).with("INT", any_args) do |&block|
           interrupt_handlers << block
         end
       end
@@ -139,8 +139,8 @@ module RSpec::Core
 
         it "does not exit immediately" do
           Runner.send(:trap_interrupt)
-          expect_any_instance_of(Object).not_to receive(:exit)
-          expect_any_instance_of(Object).not_to receive(:exit!)
+          expect(Runner).not_to receive(:exit)
+          expect(Runner).not_to receive(:exit!)
           interrupt
         end
       end
@@ -148,7 +148,7 @@ module RSpec::Core
       context "with SIGINT twice" do
         it "exits immediately" do
           Runner.send(:trap_interrupt)
-          expect_any_instance_of(Object).to receive(:exit!).with(1)
+          expect(Runner).to receive(:exit!).with(1)
           interrupt
           interrupt
         end

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -137,11 +137,12 @@ module RSpec::Core
           interrupt
         end
 
-        it "does not exit immediately" do
+        it "does not exit immediately, but notifies the user" do
           Runner.send(:trap_interrupt)
           expect(Runner).not_to receive(:exit)
           expect(Runner).not_to receive(:exit!)
-          interrupt
+
+          expect { interrupt }.to output(/RSpec is shutting down/).to_stderr
         end
       end
 
@@ -149,7 +150,7 @@ module RSpec::Core
         it "exits immediately" do
           Runner.send(:trap_interrupt)
           expect(Runner).to receive(:exit!).with(1)
-          interrupt
+          expect { interrupt }.to output(//).to_stderr
           interrupt
         end
       end


### PR DESCRIPTION
Avoid logged messages showing up as part of our spec suite output.

Before this change, `rspec --seed 31448` would result in some extra
messages showing up as part of the output of our spec suite:

> RSpec is shutting down and will print the summary report... Interrupt again to force quit.

This fixes the issue, expecting the output instead.
