### PR TITLE
When filtering, do not consider declaration lines from other files.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ Bug Fixes:
 
 * Prevent a `TypeError` from occuring when running via the rake task when
   Ruby crashes. (Patrik Wenger, #2161)
+* Only consider example and group declaration lines from a specific file
+  when applying line number filtering, instead of considering all
+  declaration lines from all spec files. (Myron Marston, #2170)
 
 ### 3.5.0.beta1 / 2016-02-06
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.2...v3.5.0.beta1)

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -347,7 +347,7 @@ module RSpec
         @descendant_filtered_examples = nil
         @_descendants = nil
         @parent_groups = nil
-        @declaration_line_numbers = nil
+        @declaration_locations = nil
       end
 
       # Adds an example to the example group
@@ -613,10 +613,10 @@ module RSpec
       end
 
       # @private
-      def self.declaration_line_numbers
-        @declaration_line_numbers ||= [metadata[:line_number]] +
-          examples.map { |e| e.metadata[:line_number] } +
-          FlatMap.flat_map(children, &:declaration_line_numbers)
+      def self.declaration_locations
+        @declaration_locations ||= [Metadata.location_tuple_from(metadata)] +
+          examples.map { |e| Metadata.location_tuple_from(e.metadata) } +
+          FlatMap.flat_map(children, &:declaration_locations)
       end
 
       # @return [String] the unique id of this example group. Pass

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -107,6 +107,11 @@ module RSpec
       end
 
       # @private
+      def self.location_tuple_from(metadata)
+        [metadata[:absolute_file_path], metadata[:line_number]]
+      end
+
+      # @private
       # Used internally to populate metadata hashes with computed keys
       # managed by RSpec.
       class HashPopulator

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -54,7 +54,7 @@ module RSpec
             line_num  = meta[:line_number]
 
             locations[file_path].any? do |filter_line_num|
-              line_num == RSpec.world.preceding_declaration_line(filter_line_num)
+              line_num == RSpec.world.preceding_declaration_line(file_path, filter_line_num)
             end
           end
         end

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -15,9 +15,9 @@ module RSpec
         # @private
         def filter_applies?(key, value, metadata)
           silence_metadata_example_group_deprecations do
-            return location_filter_applies?(value, metadata)          if key == :locations
-            return id_filter_applies?(value, metadata)                if key == :ids
-            return filters_apply?(key, value, metadata)               if Hash === value
+            return location_filter_applies?(value, metadata) if key == :locations
+            return id_filter_applies?(value, metadata)       if key == :ids
+            return filters_apply?(key, value, metadata)      if Hash === value
 
             return false unless metadata.key?(key)
             return true if TrueClass === value && !!metadata[key]

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -96,7 +96,7 @@ module RSpec
       # @api private
       #
       # Find line number of previous declaration.
-      def preceding_declaration_line(filter_line)
+      def preceding_declaration_line(_file_name, filter_line)
         declaration_line_numbers.sort.inject(nil) do |highest_prior_declaration_line, line|
           line <= filter_line ? line : highest_prior_declaration_line
         end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -96,10 +96,12 @@ module RSpec
       # @api private
       #
       # Find line number of previous declaration.
-      def preceding_declaration_line(_file_name, filter_line)
-        declaration_line_numbers.sort.inject(nil) do |highest_prior_declaration_line, line|
-          line <= filter_line ? line : highest_prior_declaration_line
+      def preceding_declaration_line(absolute_file_name, filter_line)
+        line_numbers = descending_declaration_line_numbers_by_file.fetch(absolute_file_name) do
+          return nil
         end
+
+        line_numbers.find { |num| num <= filter_line }
       end
 
       # @private
@@ -179,8 +181,22 @@ module RSpec
 
     private
 
-      def declaration_line_numbers
-        @declaration_line_numbers ||= FlatMap.flat_map(example_groups, &:declaration_line_numbers)
+      def descending_declaration_line_numbers_by_file
+        @descending_declaration_line_numbers_by_file ||= begin
+          declaration_locations = FlatMap.flat_map(example_groups, &:declaration_locations)
+          hash_of_arrays = Hash.new { |h, k| h[k] = [] }
+
+          # TODO: change `inject` to `each_with_object` when we drop 1.8.7 support.
+          line_nums_by_file = declaration_locations.inject(hash_of_arrays) do |hash, (file_name, line_number)|
+            hash[file_name] << line_number
+            hash
+          end
+
+          line_nums_by_file.each_value do |list|
+            list.sort!
+            list.reverse!
+          end
+        end
       end
 
       def fail_if_config_and_cli_options_invalid

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1878,7 +1878,7 @@ module RSpec::Core
     def group_ids group
       ids = []
       ['descendant_filtered_examples', 'descendants',
-       'parent_groups', 'declaration_line_numbers', 'before_context_ivars'].each do |method|
+       'parent_groups', 'declaration_locations', 'before_context_ivars'].each do |method|
         ids << group.send(method).object_id
       end
       ids

--- a/spec/rspec/core/metadata_filter_spec.rb
+++ b/spec/rspec/core/metadata_filter_spec.rb
@@ -52,8 +52,8 @@ module RSpec
           }}
 
           before do
-            expect(world).to receive(:preceding_declaration_line).at_least(:once) do |v|
-              preceeding_declaration_lines[v]
+            expect(world).to receive(:preceding_declaration_line).at_least(:once) do |_file_name, line_num|
+              preceeding_declaration_lines[line_num]
             end
           end
 

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -115,7 +115,7 @@ module RSpec::Core
         end
       end
 
-      context "with two exaples and the second example is registre first" do
+      context "with two examples and the second example is registered first" do
         let(:second_group_declaration_line) { second_group.metadata[:line_number] }
 
         before do

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -119,7 +119,7 @@ module RSpec::Core
         end
       end
 
-      context "with two examples and the second example is registered first" do
+      context "with two groups and the second example is registered first" do
         let(:second_group_declaration_line) { second_group.metadata[:line_number] }
 
         before do
@@ -129,6 +129,40 @@ module RSpec::Core
 
         it 'return line number of group if a group start on that line' do
           expect(preceding_declaration_line(second_group_declaration_line)).to eq(second_group_declaration_line)
+        end
+      end
+
+      context "with groups from multiple files registered" do
+        another_file = File.join(__FILE__, "another_spec_file.rb")
+
+        let(:group_from_another_file) do
+          instance_eval <<-EOS, another_file, 1
+            RSpec.describe("third group") do
+
+              example("inside of a gropu")
+
+            end
+          EOS
+        end
+
+        before do
+          world.register(group)
+          world.register(group_from_another_file)
+        end
+
+        it "returns nil if given a file name with no declarations" do
+          expect(world.preceding_declaration_line("/some/other/file.rb", 100_000)).to eq(nil)
+        end
+
+        it "considers only declaration lines from the provided files", :aggregate_failures do
+          expect(world.preceding_declaration_line(another_file, 1)).to eq(1)
+          expect(world.preceding_declaration_line(another_file, 2)).to eq(1)
+          expect(world.preceding_declaration_line(another_file, 3)).to eq(3)
+          expect(world.preceding_declaration_line(another_file, 4)).to eq(3)
+          expect(world.preceding_declaration_line(another_file, 5)).to eq(3)
+          expect(world.preceding_declaration_line(another_file, 100_000)).to eq(3)
+
+          expect(world.preceding_declaration_line(__FILE__, group_declaration_line + 1)).to eq(group_declaration_line)
         end
       end
     end

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -91,27 +91,31 @@ module RSpec::Core
       let(:group_declaration_line) { group.metadata[:line_number] }
       let(:example_declaration_line) { group_declaration_line + 2 }
 
+      def preceding_declaration_line(line_num)
+        world.preceding_declaration_line(__FILE__, line_num)
+      end
+
       context "with one example" do
         before { world.register(group) }
 
         it "returns nil if no example or group precedes the line" do
-          expect(world.preceding_declaration_line(group_declaration_line - 1)).to be_nil
+          expect(preceding_declaration_line(group_declaration_line - 1)).to be_nil
         end
 
         it "returns the argument line number if a group starts on that line" do
-          expect(world.preceding_declaration_line(group_declaration_line)).to eq(group_declaration_line)
+          expect(preceding_declaration_line(group_declaration_line)).to eq(group_declaration_line)
         end
 
         it "returns the argument line number if an example starts on that line" do
-          expect(world.preceding_declaration_line(example_declaration_line)).to eq(example_declaration_line)
+          expect(preceding_declaration_line(example_declaration_line)).to eq(example_declaration_line)
         end
 
         it "returns line number of a group that immediately precedes the argument line" do
-          expect(world.preceding_declaration_line(group_declaration_line + 1)).to eq(group_declaration_line)
+          expect(preceding_declaration_line(group_declaration_line + 1)).to eq(group_declaration_line)
         end
 
         it "returns line number of an example that immediately precedes the argument line" do
-          expect(world.preceding_declaration_line(example_declaration_line + 1)).to eq(example_declaration_line)
+          expect(preceding_declaration_line(example_declaration_line + 1)).to eq(example_declaration_line)
         end
       end
 
@@ -124,7 +128,7 @@ module RSpec::Core
         end
 
         it 'return line number of group if a group start on that line' do
-          expect(world.preceding_declaration_line(second_group_declaration_line)).to eq(second_group_declaration_line)
+          expect(preceding_declaration_line(second_group_declaration_line)).to eq(second_group_declaration_line)
         end
       end
     end


### PR DESCRIPTION
Before this, our logic for line number filtering asked `RSpec.world`
for the preceding declaration line of a particular line number,
*without* passing it a file name, which meant that it looked at
the declaration line numbers from _all_ files. This was prone to
producing weird filtering behavior.

Fixes #2136.
