### PR TITLE
Extract snippets containing do-end block and ending with "end"-only line

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@ Bug Fixes:
 * Only consider example and group declaration lines from a specific file
   when applying line number filtering, instead of considering all
   declaration lines from all spec files. (Myron Marston, #2170)
+* Fix failure snippet extraction so that snippets that contain `do-end` style
+  block and end with `end`-only line can be extracted properly.
+  (Yuji Nakayama, #2173)
 
 ### 3.5.0.beta1 / 2016-02-06
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.2...v3.5.0.beta1)

--- a/lib/rspec/core/formatters/snippet_extractor.rb
+++ b/lib/rspec/core/formatters/snippet_extractor.rb
@@ -23,13 +23,6 @@ module RSpec
         if RSpec::Support::RubyFeatures.ripper_supported?
           NoExpressionAtLineError = Class.new(StandardError)
 
-          PAREN_TOKEN_TYPE_PAIRS = {
-            :on_lbracket    => :on_rbracket,
-            :on_lparen      => :on_rparen,
-            :on_lbrace      => :on_rbrace,
-            :on_heredoc_beg => :on_heredoc_end
-          }
-
           attr_reader :source, :beginning_line_number, :max_line_count
 
           def self.extract_expression_lines_at(file_path, beginning_line_number, max_line_count=nil)
@@ -64,29 +57,29 @@ module RSpec
           def line_range_of_expression
             @line_range_of_expression ||= begin
               line_range = line_range_of_location_nodes_in_expression
-              initial_unclosed_parens = unclosed_paren_tokens_in_line_range(line_range)
-              unclosed_parens = initial_unclosed_parens
+              initial_unclosed_tokens = unclosed_tokens_in_line_range(line_range)
+              unclosed_tokens = initial_unclosed_tokens
 
-              until (initial_unclosed_parens & unclosed_parens).empty?
+              until (initial_unclosed_tokens & unclosed_tokens).empty?
                 line_range = (line_range.begin)..(line_range.end + 1)
-                unclosed_parens = unclosed_paren_tokens_in_line_range(line_range)
+                unclosed_tokens = unclosed_tokens_in_line_range(line_range)
               end
 
               line_range
             end
           end
 
-          def unclosed_paren_tokens_in_line_range(line_range)
+          def unclosed_tokens_in_line_range(line_range)
             tokens = FlatMap.flat_map(line_range) do |line_number|
               source.tokens_by_line_number[line_number]
             end
 
             tokens.each_with_object([]) do |token, unclosed_tokens|
-              if PAREN_TOKEN_TYPE_PAIRS.keys.include?(token.type)
+              if token.opening?
                 unclosed_tokens << token
               else
                 index = unclosed_tokens.rindex do |unclosed_token|
-                  PAREN_TOKEN_TYPE_PAIRS[unclosed_token.type] == token.type
+                  unclosed_token.closed_by?(token)
                 end
                 unclosed_tokens.delete_at(index) if index
               end

--- a/lib/rspec/core/source/token.rb
+++ b/lib/rspec/core/source/token.rb
@@ -6,6 +6,17 @@ module RSpec
       # @private
       # A wrapper for Ripper token which is generated with `Ripper.lex`.
       class Token
+        CLOSING_TYPES_BY_OPENING_TYPE = {
+          :on_lbracket    => :on_rbracket,
+          :on_lparen      => :on_rparen,
+          :on_lbrace      => :on_rbrace,
+          :on_heredoc_beg => :on_heredoc_end
+        }.freeze
+
+        CLOSING_KEYWORDS_BY_OPENING_KEYWORD = {
+          'do' => 'end'
+        }.freeze
+
         attr_reader :token
 
         def self.tokens_from_ripper_tokens(ripper_tokens)
@@ -36,6 +47,38 @@ module RSpec
 
         def inspect
           "#<#{self.class} #{type} #{string.inspect}>"
+        end
+
+        def keyword?
+          type == :on_kw
+        end
+
+        def opening?
+          opening_delimiter? || opening_keyword?
+        end
+
+        def closed_by?(other)
+          closed_by_delimiter?(other) || closed_by_keyword?(other)
+        end
+
+        private
+
+        def opening_delimiter?
+          CLOSING_TYPES_BY_OPENING_TYPE.key?(type)
+        end
+
+        def opening_keyword?
+          return false unless keyword?
+          CLOSING_KEYWORDS_BY_OPENING_KEYWORD.key?(string)
+        end
+
+        def closed_by_delimiter?(other)
+          other.type == CLOSING_TYPES_BY_OPENING_TYPE[type]
+        end
+
+        def closed_by_keyword?(other)
+          return false unless other.keyword?
+          other.string == CLOSING_KEYWORDS_BY_OPENING_KEYWORD[string]
         end
       end
     end

--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -149,6 +149,20 @@ module RSpec::Core::Formatters
         end
       end
 
+      context 'when the expression contains do-end block and ends with "end"-only line' do
+        let(:source) do
+          do_something_fail do
+          end
+        end
+
+        it 'returns all the lines' do
+          expect(expression_lines).to eq([
+            '          do_something_fail do',
+            '          end'
+          ])
+        end
+      end
+
       context "when the expression ends with multiple paren-only lines of same type" do
         let(:source) do
           do_something_fail(:foo, (:bar


### PR DESCRIPTION
This fixes #2167.