### PR TITLE
Add failing specs for multi-line array/hash literal snippet extraction.

### DIFF
--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -264,6 +264,46 @@ module RSpec::Core::Formatters
         end
       end
 
+      context "when the failing expression is in the middle of a multi-line hash literal" do
+        let(:source) do
+          {
+            foo: 1,
+            bar: do_something_fail,
+            baz: 3
+          }
+        end
+
+        it 'returns the entire hash literal' do
+          expect(expression_lines).to eq([
+           '          {',
+           '            foo: 1,',
+           '            bar: do_something_fail,',
+           '            baz: 3',
+           '          }'
+          ])
+        end
+      end
+
+      context "when the failing expression is in the middle of a multi-line array literal" do
+        let(:source) do
+          [
+            1,
+            do_something_fail,
+            3
+          ]
+        end
+
+        it 'returns the entire array literal' do
+          expect(expression_lines).to eq([
+           '          [',
+           '            1,',
+           '            do_something_fail,',
+           '            3',
+           '          ]'
+          ])
+        end
+      end
+
       context 'when Ripper cannot parse the source (which can happen on JRuby -- see jruby/jruby#2427)', :isolated_directory do
         let(:file_path) { 'invalid_source.rb' }
 


### PR DESCRIPTION
@yujinakayama, I found another case where the snippet extractor does not return the entire expression: when the failure happens in the middle of a multi-line array or hash literal.  This time I was able to add failing specs for this case.  Can you take a look?

```
Failures:

  1) RSpec::Core::Formatters::SnippetExtractor in Ripper supported environment when the failing expression is in the middle of a multi-line hash literal returns the entire hash literal
     Failure/Error:
       expect(expression_lines).to eq([
        '          {',
        '            foo: 1,',
        '            bar: do_something_fail,',
        '            baz: 3',
        '          }'
       ])

       expected: ["          {", "            foo: 1,", "            bar: do_something_fail,", "            baz: 3", "          }"]
            got: ["            bar: do_something_fail,"]

       (compared using ==)
     # ./spec/rspec/core/formatters/snippet_extractor_spec.rb:277:in `block (4 levels) in <module:Formatters>'
     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'

  2) RSpec::Core::Formatters::SnippetExtractor in Ripper supported environment when the failing expression is in the middle of a multi-line array literal returns the entire array literal
     Failure/Error:
       expect(expression_lines).to eq([
        '          [',
        '            1,',
        '            do_something_fail,',
        '            3',
        '          ]'
       ])

       expected: ["          [", "            1,", "            do_something_fail,", "            3", "          ]"]
            got: ["            do_something_fail,"]

       (compared using ==)
     # ./spec/rspec/core/formatters/snippet_extractor_spec.rb:297:in `block (4 levels) in <module:Formatters>'
     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
```

BTW, nice work on the structure of the snippet extractor specs -- it was very easy to add these :).