### PR TITLE
Add `config.when_first_matching_example_defined`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ Enhancements:
   (Myron Marston, #2189)
 * `RSpec::Core::Configuration#reporter` is now public API under semver.
   (Jon Rowe, #2193)
+* Add new `config.when_first_matching_example_defined` hook. (Myron
+  Marston, #2175)
 
 ### 3.5.0.beta1 / 2016-02-06
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.3...v3.5.0.beta1)

--- a/features/.nav
+++ b/features/.nav
@@ -20,6 +20,7 @@
   - before_and_after_hooks.feature
   - around_hooks.feature
   - filtering.feature
+  - when_first_matching_example_defined.feature
 - subject:
   - implicit_subject.feature
   - explicit_subject.feature

--- a/features/hooks/when_first_matching_example_defined.feature
+++ b/features/hooks/when_first_matching_example_defined.feature
@@ -1,0 +1,70 @@
+Feature: `when_first_matching_example_defined` hook
+
+  In large projects that use RSpec, it's common to have some expensive setup logic
+  that is only needed when certain kinds of specs have been loaded. If that kind of
+  spec has not been loaded, you'd prefer to avoid the cost of doing the setup.
+
+  The `when_first_matching_example_defined` hook makes it easy to conditionally
+  perform some logic when the first example is defined with matching metadata,
+  allowing you to ensure the necessary setup is performed only when needed.
+
+  Background:
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.when_first_matching_example_defined(:db) do
+          require "support/db"
+        end
+      end
+      """
+    And a file named "spec/support/db.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.before(:suite) do
+          puts "Bootstrapped the DB."
+        end
+
+        config.around(:example, :db) do |example|
+          puts "Starting a DB transaction."
+          example.run
+          puts "Rolling back a DB transaction."
+        end
+      end
+      """
+    And a file named ".rspec" with:
+      """
+      --require spec_helper
+      """
+    And a file named "spec/unit_spec.rb" with:
+      """
+      RSpec.describe "A unit spec" do
+        it "does not require a database" do
+          puts "in unit example"
+        end
+      end
+      """
+    And a file named "spec/integration_spec.rb" with:
+      """
+      RSpec.describe "An integration spec", :db do
+        it "requires a database" do
+          puts "in integration example"
+        end
+      end
+      """
+
+  Scenario: Running the entire suite loads the DB setup
+    When I run `rspec`
+    Then it should pass with:
+      """
+      Bootstrapped the DB.
+      Starting a DB transaction.
+      in integration example
+      Rolling back a DB transaction.
+      .in unit example
+      .
+      """
+
+  Scenario: Running just the unit spec does not load the DB setup
+    When I run `rspec spec/unit_spec.rb`
+    Then the examples should all pass
+    And the output should not contain "DB"

--- a/lib/rspec/core/dsl.rb
+++ b/lib/rspec/core/dsl.rb
@@ -40,7 +40,9 @@ module RSpec
         example_group_aliases << name
 
         (class << RSpec; self; end).__send__(:define_method, name) do |*args, &example_group_block|
-          RSpec.world.register RSpec::Core::ExampleGroup.__send__(name, *args, &example_group_block)
+          group = RSpec::Core::ExampleGroup.__send__(name, *args, &example_group_block)
+          RSpec.world.record(group)
+          group
         end
 
         expose_example_group_alias_globally(name) if exposed_globally?

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -178,6 +178,16 @@ module RSpec
         @example_group_class = example_group_class
         @example_block       = example_block
 
+        # Register the example with the group before creating the metadata hash.
+        # This is necessary since creating the metadata hash triggers
+        # `when_first_matching_example_defined` callbacks, in which users can
+        # load RSpec support code which defines hooks. For that to work, the
+        # examples and example groups must be registered at the time the
+        # support code is called or be defined afterwards.
+        # Begin defined beforehand but registered afterwards causes hooks to
+        # not be applied where they should.
+        example_group_class.examples << self
+
         @metadata = Metadata::ExampleHash.create(
           @example_group_class.metadata, user_metadata,
           example_group_class.method(:next_runnable_index_for),

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -48,12 +48,10 @@ module RSpec
 
       # @api private
       #
-      # Register an example group.
-      def register(example_group)
+      # Records an example group.
+      def record(example_group)
         @configuration.on_example_group_definition_callbacks.each { |block| block.call(example_group) }
-        example_groups << example_group
         @example_group_counts_by_spec_file[example_group.metadata[:absolute_file_path]] += 1
-        example_group
       end
 
       # @private

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -21,19 +21,18 @@ module RSpec::Core
     end
 
     describe '#on_example_group_definition' do
-      let(:configuration) do
-        tmp_config = RSpec::Core::Configuration.new
-        tmp_config.on_example_group_definition do |example_group|
-          example_group.examples.first.metadata[:new_key] = :new_value
+      before do
+        RSpec.configure do |c|
+          c.on_example_group_definition do |example_group|
+            example_group.examples.first.metadata[:new_key] = :new_value
+          end
         end
-        tmp_config
       end
-      let(:world) { RSpec::Core::World.new(configuration) }
 
       it 'successfully invokes the block' do
         example_group = RSpec.describe("group") { it "example 1" do; end}
-        world.register(example_group)
-        example = world.example_groups.first.examples.first
+        RSpec.world.register(example_group)
+        example = RSpec.world.example_groups.first.examples.first
         expect(example.metadata[:new_key]).to eq(:new_value)
       end
     end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -359,11 +359,10 @@ module RSpec::Core
       end
 
       it "is not registered in world" do
-        world = RSpec::Core::World.new
         parent = RSpec.describe
-        world.register(parent)
         parent.describe
-        expect(world.example_groups).to eq([parent])
+
+        expect(RSpec.world.example_groups).to eq([parent])
       end
     end
 

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -4,8 +4,8 @@ class Foo; end
 module RSpec::Core
 
   RSpec.describe RSpec::Core::World do
-    let(:configuration) { RSpec::Core::Configuration.new }
-    let(:world) { RSpec::Core::World.new(configuration) }
+    let(:configuration) { RSpec.configuration }
+    let(:world) { RSpec.world }
 
     describe '#reset' do
       it 'clears #example_groups' do

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -18,7 +18,6 @@ module RSpec::Core
     describe "#example_groups" do
       it "contains all registered example groups" do
         example_group = RSpec.describe("group") {}
-        world.register(example_group)
         expect(world.example_groups).to include(example_group)
       end
     end
@@ -96,8 +95,6 @@ module RSpec::Core
       end
 
       context "with one example" do
-        before { world.register(group) }
-
         it "returns nil if no example or group precedes the line" do
           expect(preceding_declaration_line(group_declaration_line - 1)).to be_nil
         end
@@ -123,8 +120,8 @@ module RSpec::Core
         let(:second_group_declaration_line) { second_group.metadata[:line_number] }
 
         before do
-          world.register(second_group)
-          world.register(group)
+          world.record(second_group)
+          world.record(group)
         end
 
         it 'return line number of group if a group start on that line' do
@@ -146,8 +143,8 @@ module RSpec::Core
         end
 
         before do
-          world.register(group)
-          world.register(group_from_another_file)
+          world.record(group)
+          world.record(group_from_another_file)
         end
 
         it "returns nil if given a file name with no declarations" do


### PR DESCRIPTION
In working on implementing the solution for #1920, I realized that implementing it becomes trivial if we have a hook like `config.when_first_matching_example_defined` so I decided to start there.  We could stick with just this API -- focus filtering can be setup with the desired semantics with:

``` ruby
RSpec.configure do |config|
  config.when_first_matching_example_defined(:focus) do
    config.focus_run :focus
  end
end
```

It's probably still worth providing `config.filter_run_when_matching` for this common case, though.

Before merging this we at least need a cuke documenting it.

Thoughts, @rspec/rspec?