### PR TITLE
Deal with circular relationship between world and config

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -83,7 +83,6 @@ module RSpec
   def self.configuration
     @configuration ||= RSpec::Core::Configuration.new
   end
-  configuration.expose_dsl_globally = true
 
   # Yields the global configuration to a block.
   # @yield [Configuration] global configuration
@@ -178,4 +177,7 @@ module RSpec
     require MODULES_TO_AUTOLOAD.fetch(name) { return super }
     ::RSpec.const_get(name)
   end
+
+  Core::DSL.expose_globally!
+  Core::SharedExampleGroup::TopLevelDSL.expose_globally!
 end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -12,6 +12,7 @@ module RSpec
 
       def initialize(configuration=RSpec.configuration)
         @configuration = configuration
+        configuration.world = self
         @example_groups = []
         @example_group_counts_by_spec_file = Hash.new(0)
         @filtered_examples = Hash.new do |hash, group|
@@ -207,6 +208,24 @@ module RSpec
           "`config.example_status_persistence_file_path`.",
           1 # exit code
         )
+      end
+
+      # @private
+      # Provides a null implementation for initial use by configuration.
+      module Null
+        def self.registered_example_group_files
+          []
+        end
+
+        # :nocov:
+        def self.example_groups
+          []
+        end
+
+        def self.all_example_groups
+          []
+        end
+        # :nocov:
       end
     end
   end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -10,6 +10,8 @@ module RSpec::Core
     let(:exclusion_filter) { config.exclusion_filter.rules }
     let(:inclusion_filter) { config.inclusion_filter.rules }
 
+    before { config.world = RSpec.world }
+
     shared_examples_for "warning of deprecated `:example_group` during filtering configuration" do |method, *args|
       it "issues a deprecation warning when filtering by `:example_group`" do
         args << { :example_group => { :file_location => /spec\/unit/ } }


### PR DESCRIPTION
`RSpec::World#initialize` references `RSpec.configuration`
and `RSpec::Configuration` references `RSpec.world` in a few
places. This circular dependency is not ideal and has triggered
infinite recursion during some recent changes I've tried to make.
It would be nice to get rid of it entirely, but for now, this is
the simplest change I can make it solve my immediate problems.
