### PR TITLE
Adding 2 spec formatters, ReRunFriendlyFormatter and ImmediateFeedbackFormatter

### DIFF
--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -74,6 +74,8 @@ module RSpec::Core::Formatters
   autoload :JsonFormatter,            'rspec/core/formatters/json_formatter'
   autoload :BisectFormatter,          'rspec/core/formatters/bisect_formatter'
   autoload :ExceptionPresenter,       'rspec/core/formatters/exception_presenter'
+  autoload :ReRunFriendlyFormatter,   'rspec/core/formatters/re_run_friendly_formatter'
+  autoload :ImmediateFeedbackFormatter, 'rspec/core/formatters/immediate_feedback_formatter'
 
   # Register the formatter class
   # @param formatter_class [Class] formatter class to register
@@ -203,6 +205,8 @@ module RSpec::Core::Formatters
         JsonFormatter
       when 'bisect'
         BisectFormatter
+      when 'ReRunFriendlyFormatter'
+        ReRunFriendlyFormatter
       end
     end
 

--- a/lib/rspec/core/formatters/immediate_feedback_formatter.rb
+++ b/lib/rspec/core/formatters/immediate_feedback_formatter.rb
@@ -1,0 +1,77 @@
+RSpec::Support.require_rspec_core "formatters/base_text_formatter"
+
+# Code is based on standard documentation formatter, but:
+#
+# 1. It will print full error details as soon as they are found.
+# 2. It prints a full descriptive ine for each spec run, including the duration of each spec.
+#
+class ImmediateFeedbackFormatter < RSpec::Core::Formatters::BaseTextFormatter
+  RSpec::Core::Formatters.register(self, :example_started, :example_passed, :example_pending,
+                                   :example_failed )
+  @@RUNNING_EXAMPLES_HASH = {}
+
+  def dump_pending(notification)
+    # Noop. Don't need to see this again.
+  end
+
+  def dump_summary(summary)
+    super
+    @@RUNNING_EXAMPLES_HASH.clear()
+  end
+
+  def example_started(notification)
+    example_id = notification.example.id
+    current_time = Time.now
+    @@RUNNING_EXAMPLES_HASH[example_id] = current_time
+  end
+
+  def add_example_group(example_group)
+    super
+    @current_group = example_group.description
+  end
+
+  def example_failed(example_notification)
+    failure_line = "#{example_description(example_notification)} "\
+      "[#{RSpec::Core::Metadata::relative_path(example_notification.example.file_path)}]"
+    colored_failure_line = RSpec::Core::Formatters::ConsoleCodes.wrap(failure_line, RSpec.configuration.failure_color)
+    output.puts colored_failure_line
+    unless ENV['TRACE'] && %w(0 no false).include?(ENV['TRACE'])
+      puts example_notification.fully_formatted(next_failure_index)
+    end
+    output.flush
+  end
+
+  def example_passed(example_notification)
+    output.puts("#{example_description(example_notification)} #{example_duration(example_notification)}")
+    output.flush
+  end
+
+  def example_pending(example_notification, message = '')
+    line = RSpec::Core::Formatters::ConsoleCodes.
+      wrap("#{example_description(example_notification)} (Pending) #{message}",
+           RSpec.configuration.pending_color)
+    output.puts line
+    output.flush
+  end
+
+  private
+
+  def example_duration(example_notification)
+    time_then = @@RUNNING_EXAMPLES_HASH[example_notification.example.id]
+    time_then ? "(#{(Time.now - time_then).round(4)} s)" : "(duration missing)"
+  end
+
+  def example_description(example_notification)
+    example_group_description(example_notification).strip + ' ' +
+      example_notification.example.description.strip
+  end
+
+  def example_group_description(_example_notification)
+    example_group.parent_groups.collect(&:description).reverse.join(' ')
+  end
+
+  def next_failure_index
+    @next_failure_index ||= 0
+    @next_failure_index += 1
+  end
+end

--- a/lib/rspec/core/formatters/re_run_friendly_formatter.rb
+++ b/lib/rspec/core/formatters/re_run_friendly_formatter.rb
@@ -1,0 +1,76 @@
+RSpec::Support.require_rspec_core "formatters/immediate_feedback_formatter"
+
+# This formatter extends the ImmediateFeedbackFormatter so that you get a nice set of commands to
+# either re-run:
+# 1. Individual failing tests, one per line.
+# 2. All individual failing tests, in one rspec command.
+# 3. All failing test files
+class ReRunFriendlyFormatter < ImmediateFeedbackFormatter
+  RSpec::Core::Formatters.register self, :dump_summary
+
+  def dump_summary(summary)
+    failed_files = failed_files(summary)
+
+    unless summary.failed_examples.empty?
+      output.puts summary.colorized_rerun_commands
+
+      output.puts
+      output.puts "Rerun all failed examples:"
+      output.puts
+
+      output.puts failure_colored("rspec #{failed_examples_line(summary)}")
+
+      output.puts
+      output.puts "Rerun all files containing failures:"
+      output.puts
+
+      output.puts failure_colored("rspec #{failed_files.join(" ")}")
+
+      output.puts
+    end
+
+    output.puts "\nFinished in #{summary.formatted_duration} " \
+                    "(files took #{summary.formatted_load_time} to load)\n" \
+                    "#{summary.colorized_totals_line}\n"
+  end
+
+  private
+
+  include RSpec::Core::ShellEscape
+
+  def failed_files(summary)
+    summary.failed_examples.map do |example|
+      location_with_line_etc = example.location_rerun_argument
+      location_with_line_etc.match(/(.*\.rb).*$/)[1]
+    end.uniq
+  end
+
+  def failed_examples_line(summary)
+    summary.failed_examples.map do |example|
+      rerun_argument_for(example)
+    end.join(" ")
+  end
+
+  def rerun_argument_for(example)
+    location = example.location_rerun_argument
+    return location unless duplicate_rerun_locations.include?(location)
+    conditionally_quote(example.id)
+  end
+
+  def duplicate_rerun_locations
+    @duplicate_rerun_locations ||= begin
+      locations = RSpec.world.all_examples.map(&:location_rerun_argument)
+
+      result = Set.new.tap do |s|
+        locations.group_by { |l| l }.each do |l, ls|
+          s << l if ls.count > 1
+        end
+      end
+      result
+    end
+  end
+
+  def failure_colored(str)
+    RSpec::Core::Formatters::ConsoleCodes.wrap(str, :failure)
+  end
+end


### PR DESCRIPTION
1. re_run_friend_formatter: print copy/paste line to re-run failing
   tests in one command.
2. rspec_immediate_feedback_formatter: prints full description for each
   test, including time elapsed, and prints error messages immediately.

Please let me know if you like the formatter code. We used this on a big commercial project, and it's all extremely useful. If you don't want this enhancement, I can put this into a separate github repo. If you do want it, I'll add tests like the other formatter specs.
