### PR TITLE
Avoid trying to apply `:suite` hooks to already defined example groups.

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1570,11 +1570,12 @@ module RSpec
       # @see #after
       # @see #append_after
       def before(scope=nil, *meta, &block)
-        on_existing_matching_groups({}) { |g| g.before(scope, *meta, &block) }
-
         handle_suite_hook(scope, meta) do
           @before_suite_hooks << Hooks::BeforeHook.new(block, {})
-        end || super(scope, *meta, &block)
+        end || begin
+          on_existing_matching_groups({}) { |g| g.before(scope, *meta, &block) }
+          super(scope, *meta, &block)
+        end
       end
       alias_method :append_before, :before
 
@@ -1592,11 +1593,12 @@ module RSpec
       # @see #after
       # @see #append_after
       def prepend_before(scope=nil, *meta, &block)
-        on_existing_matching_groups({}) { |g| g.prepend_before(scope, *meta, &block) }
-
         handle_suite_hook(scope, meta) do
           @before_suite_hooks.unshift Hooks::BeforeHook.new(block, {})
-        end || super(scope, *meta, &block)
+        end || begin
+          on_existing_matching_groups({}) { |g| g.prepend_before(scope, *meta, &block) }
+          super(scope, *meta, &block)
+        end
       end
 
       # Defines a `after` hook. See {Hooks#after} for full docs.
@@ -1609,11 +1611,12 @@ module RSpec
       # @see #before
       # @see #prepend_before
       def after(scope=nil, *meta, &block)
-        on_existing_matching_groups({}) { |g| g.after(scope, *meta, &block) }
-
         handle_suite_hook(scope, meta) do
           @after_suite_hooks.unshift Hooks::AfterHook.new(block, {})
-        end || super(scope, *meta, &block)
+        end || begin
+          on_existing_matching_groups({}) { |g| g.after(scope, *meta, &block) }
+          super(scope, *meta, &block)
+        end
       end
       alias_method :prepend_after, :after
 
@@ -1631,11 +1634,12 @@ module RSpec
       # @see #before
       # @see #prepend_before
       def append_after(scope=nil, *meta, &block)
-        on_existing_matching_groups({}) { |g| g.append_after(scope, *meta, &block) }
-
         handle_suite_hook(scope, meta) do
           @after_suite_hooks << Hooks::AfterHook.new(block, {})
-        end || super(scope, *meta, &block)
+        end || begin
+          on_existing_matching_groups({}) { |g| g.append_after(scope, *meta, &block) }
+          super(scope, *meta, &block)
+        end
       end
 
       # Registers `block` as an `around` hook.

--- a/spec/rspec/core/hooks_filtering_spec.rb
+++ b/spec/rspec/core/hooks_filtering_spec.rb
@@ -111,6 +111,24 @@ module RSpec::Core
           :around_before_ex, :before_ex_1, :before_ex_2, :ex_2, :after_ex_1, :after_ex_2, :around_after_ex,
         ]
       end
+
+      it "does not apply `suite` hooks to groups (or print warnings about suite hooks applied to example groups)" do
+        sequence = []
+
+        group = RSpec.describe do
+          example { sequence << :example }
+        end
+
+        RSpec.configure do |c|
+          c.before(:suite) { sequence << :before_suite }
+          c.prepend_before(:suite) { sequence << :prepended_before_suite }
+          c.after(:suite) { sequence << :after_suite }
+          c.append_after(:suite) { sequence << :appended_after_suite }
+        end
+
+        group.run
+        expect(sequence).to eq [:example]
+      end
     end
 
     describe "unfiltered hooks" do


### PR DESCRIPTION
This is a fix to #2189.