### PR TITLE
Support rake 11.x

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -88,7 +88,7 @@ module RSpec
 
       # @private
       def define(args, &task_block)
-        desc "Run RSpec code examples" unless ::Rake.application.last_comment
+        desc "Run RSpec code examples" unless ::Rake.application.last_description
 
         task name, *args do |_, task_args|
           RakeFileUtils.__send__(:verbose, verbose) do


### PR DESCRIPTION
The method `Rake.application.last_comment` has been removed
in favor of `Rake.application.last_description`

Removal commit from rake: https://github.com/ruby/rake/commit/e76242ce7ef94568399a50b69bda4b723dab7c75

`last_comment` has been deprecated in favor of `last_description` since 2007 (rake 0.7.4):
https://github.com/ruby/rake/commit/d1f89d7c62365633731850c8ec1ba76808d21cf8