### PR TITLE
Relax rake dependency

### DIFF
--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 
-  s.add_development_dependency "rake",     "~> 10.0.0"
+  s.add_development_dependency "rake",     ">= 10.0.0"
   s.add_development_dependency "cucumber", "~> 1.3"
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7


### PR DESCRIPTION
... so that we can notice when any breaking change is introduced in a major version bump of rake.

Ref: #2197