### PR TITLE
Use Rake 10 on Ruby 1.8.x and 1.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,12 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
   end
 end
 
+if RUBY_VERSION >= '1.9.3'
+  gem 'rake', '>= 10.0.0'
+else
+  gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later
+end
+
 gem 'yard', '~> 0.8.7', :require => false
 
 ### deps for rdoc.info

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 
-  s.add_development_dependency "rake",     ">= 10.0.0"
   s.add_development_dependency "cucumber", "~> 1.3"
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7


### PR DESCRIPTION
Rake 11 requires Ruby 1.9.3 or later.