### PR TITLE
Support rake 11.x for rspec-core 2.99

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -140,7 +140,7 @@ module RSpec
       def initialize(*args, &task_block)
         setup_ivars(args)
 
-        desc "Run RSpec code examples" unless ::Rake.application.last_comment
+        desc "Run RSpec code examples" unless ::Rake.application.last_description
 
         task name, *args do |_, task_args|
           RakeFileUtils.send(:verbose, verbose) do

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_path     = "lib"
 
-  s.add_development_dependency "rake",     "~> 10.0.0"
+  s.add_development_dependency "rake",     ">= 10.0.0"
   s.add_development_dependency "cucumber", "~> 1.1.9"
   s.add_development_dependency "minitest", "~> 4.7"
   s.add_development_dependency "aruba",    "0.6.1"


### PR DESCRIPTION
This is the same fixes with https://github.com/rspec/rspec-core/pull/2197 for [2-99-maintenance](https://github.com/rspec/rspec-core/tree/2-99-maintenance)  branch.