### PR TITLE
[2.14] Fix Rake last_comment deprecation

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -115,7 +115,7 @@ module RSpec
       def initialize(*args, &task_block)
         setup_ivars(args)
 
-        desc "Run RSpec code examples" unless ::Rake.application.last_comment
+        desc "Run RSpec code examples" unless ::Rake.application.last_description
 
         task name, *args do |_, task_args|
           RakeFileUtils.send(:verbose, verbose) do


### PR DESCRIPTION
This fixes a deprecation warning in recent rake versions:

```
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
```

Feel free to close if you no longer accept fixes for 2.14.