### PR TITLE
Extract def-end snippets ending with "end"-only line properly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,9 @@ Bug Fixes:
 
 * Use the encoded string logic for source extraction. (Jon Rowe, #2183)
 * Fix rounding issue in duration formatting helper. (Fabersky, Jon Rowe, #2208)
+* Fix failure snippet extraction so that `def-end` snippets
+  ending with `end`-only line can be extracted properly.
+  (Yuji Nakayama, #2215)
 
 ### 3.5.0.beta1 / 2016-02-06
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.3...v3.5.0.beta1)

--- a/lib/rspec/core/source/token.rb
+++ b/lib/rspec/core/source/token.rb
@@ -14,7 +14,8 @@ module RSpec
         }.freeze
 
         CLOSING_KEYWORDS_BY_OPENING_KEYWORD = {
-          'do' => 'end'
+          'def' => 'end',
+          'do'  => 'end',
         }.freeze
 
         attr_reader :token


### PR DESCRIPTION
This fixes snippet extraction so that missing `end` line in `def-end` snippet can be extracted properly (similar issue with #2167).

```ruby
RSpec.describe 'def-end snippet extraction with ArgumentError' do
  def foo(arg)
    p arg
  end

  it 'cannot extract the last `end` line' do
    foo
  end
end
```

```
Failures:

  1) def-end snippet extraction with ArgumentError cannot extract the last `end` line
     Failure/Error:
       def foo(arg)
         p arg

     ArgumentError:
       wrong number of arguments (given 0, expected 1)
```
