### PR TITLE
Remove default val provided to arg `exception_presenter`

### DIFF
--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -202,7 +202,7 @@ module RSpec::Core
 
     private
 
-      def initialize(example, exception_presenter=Formatters::ExceptionPresenter.new(example.execution_result.exception, example))
+      def initialize(example, exception_presenter)
         @exception_presenter = exception_presenter
         super(example)
       end

--- a/spec/rspec/core/failed_example_notification_spec.rb
+++ b/spec/rspec/core/failed_example_notification_spec.rb
@@ -15,7 +15,8 @@ module RSpec::Core::Notifications
         it_behaves_like "a"
       end
       group.run
-      fne = FailedExampleNotification.new(example)
+      exception_presenter= RSpec::Core::Formatters::ExceptionPresenter.new(example.execution_result.exception, example)
+      fne = FailedExampleNotification.new(example, exception_presenter)
       lines = fne.colorized_message_lines
       expect(lines).to include(match("\\e\\[37mShared Example Group:"))
     end


### PR DESCRIPTION
When initializing a new instance of `FailedExampleNotification` in [1] we always
use [2] to provide a correctly configured instance of `ExceptionPresenter`. Yet
we pass the `exception_presenter` as a default value when instantianting
`FailedExampleNotification`.

It seems like this default value is only used to help us write a spec for
`FailedExampleNotification`.

In this commit I've removed the default value we provide to
`FailedExampleNotification` (since) it's redundant and simply instantiated a
new instance of the `ExceptionPresenter` in the spec for it to use.

1.) http://bit.ly/1X4NIlU
2.) http://bit.ly/1qn32Qv