### PR TITLE
Get failure message from `exception_presenter`

### DIFF
--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -71,7 +71,7 @@ module RSpec
           exception = failure.exception
           exception_details = if exception
                                 {
-                                  :message => exception.message,
+                                  :message => failure.message_lines.join("\n"),
                                   :backtrace => failure.formatted_backtrace.join("\n")
                                 }
                               end

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -315,7 +315,8 @@ a {
       <span class="failed_spec_name">is marked as pending but passes</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_1">
-        <div class="message"><pre>Expected example to fail since it is pending, but it passed.</pre></div>
+        <div class="message"><pre>Expected pending &#39;No reason given&#39; to fail. No Error was raised.
+Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources/formatter_specs.rb:22</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:4</pre></div>
     <pre class="ruby"><code><span class="linenum">2</span>
 <span class="linenum">3</span><span class="constant">RSpec</span>.shared_examples_for <span class="string"><span class="delimiter">&quot;</span><span class="content">shared</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
@@ -343,12 +344,12 @@ a {
       <span class="failed_spec_name">fails</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_2">
-        <div class="message"><pre>
-expected: 2
-     got: 1
+        <div class="message"><pre>Failure/Error: expect(1).to eq(2)
 
-(compared using ==)
-</pre></div>
+  expected: 2
+       got: 1
+
+  (compared using ==)</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
     <pre class="ruby"><code><span class="linenum">31</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="linenum">32</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
@@ -369,7 +370,10 @@ expected: 2
       <span class="failed_spec_name">fails with a backtrace that has no file</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_3">
-        <div class="message"><pre>foo</pre></div>
+        <div class="message"><pre>Failure/Error: ERB.new(&quot;&lt;%= raise &#39;foo&#39; %&gt;&quot;).result
+
+RuntimeError:
+  foo</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
     <pre class="ruby"><code><span class="linenum">39</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
 <span class="linenum">40</span>
@@ -382,7 +386,10 @@ expected: 2
       <span class="failed_spec_name">fails with a backtrace containing an erb file</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_4">
-        <div class="message"><pre>Exception</pre></div>
+        <div class="message"><pre>Failure/Error: Unable to find /foo.html.erb to read failed line
+
+Exception:
+  Exception</pre></div>
         <div class="backtrace"><pre>/foo.html.erb:1:in `&lt;main&gt;&#39;: foo (RuntimeError)
    from /lib/ruby/1.9.1/erb.rb:753:in `eval&#39;
 
@@ -404,7 +411,10 @@ expected: 2
       <span class="failed_spec_name">raises</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_5">
-        <div class="message"><pre>boom</pre></div>
+        <div class="message"><pre>Failure/Error: Unable to find matching line from backtrace
+
+RuntimeError:
+  boom</pre></div>
         <div class="backtrace"><pre></pre></div>
     <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for </span></code></pre>
       </div>


### PR DESCRIPTION
Spike to see if this is the correct way to get failure message from the
exception presenter. Currently a few of the formatters get their failure message
directly from the exception[1].

This commit changes the HTML formatter and gets the failure message from the
`FailedExampleNotification#message_lines`, which delegates this message to the
`ExceptionPresenter#message_lines`.

The specs are currently failing as this is a spike, for us to discuss. If we
decide to go forward with this approach I'll restart this work and use TDD.

1.) http://bit.ly/1PNf22l