### PR TITLE
Send files for bisection over DRb instead of ARGV

### DIFF
--- a/lib/rspec/core/bisect/runner.rb
+++ b/lib/rspec/core/bisect/runner.rb
@@ -27,6 +27,7 @@ module RSpec
 
           parts << "--format"   << "bisect"
           parts << "--drb-port" << @server.drb_port
+
           parts.concat reusable_cli_options
           parts.concat locations.map { |l| open3_safe_escape(l) }
 
@@ -60,9 +61,9 @@ module RSpec
           alias open3_safe_escape escape
         end
 
-        def run_locations(locations, *capture_args)
+        def run_locations(*capture_args)
           @server.capture_run_results(*capture_args) do
-            run_command command_for(locations)
+            run_command command_for([])
           end
         end
 

--- a/lib/rspec/core/bisect/server.rb
+++ b/lib/rspec/core/bisect/server.rb
@@ -20,8 +20,9 @@ module RSpec
           server.stop
         end
 
-        def capture_run_results(expected_failures=[])
+        def capture_run_results(files_or_directories_to_run=[], expected_failures=[])
           self.expected_failures  = expected_failures
+          self.files_or_directories_to_run = files_or_directories_to_run
           self.latest_run_results = nil
           run_output = yield
           latest_run_results || raise_bisect_failed(run_output)
@@ -48,6 +49,9 @@ module RSpec
 
         # Set via DRb by the BisectFormatter with the results of the run.
         attr_accessor :latest_run_results
+
+        # Fetched via DRb to tell clients which files to run
+        attr_accessor :files_or_directories_to_run
 
       private
 

--- a/lib/rspec/core/formatters/bisect_formatter.rb
+++ b/lib/rspec/core/formatters/bisect_formatter.rb
@@ -16,12 +16,13 @@ module RSpec
                             :example_failed, :example_passed, :example_pending
 
         def initialize(_output)
-          port                = RSpec.configuration.drb_port
-          drb_uri             = "druby://localhost:#{port}"
-          @all_example_ids    = []
+          port = RSpec.configuration.drb_port
+          drb_uri = "druby://localhost:#{port}"
+          @all_example_ids = []
           @failed_example_ids = []
-          @bisect_server      = DRbObject.new_with_uri(drb_uri)
+          @bisect_server = DRbObject.new_with_uri(drb_uri)
           @remaining_failures = []
+          RSpec.configuration.files_or_directories_to_run = @bisect_server.files_or_directories_to_run
         end
 
         def start(_notification)

--- a/spec/rspec/core/bisect/server_spec.rb
+++ b/spec/rspec/core/bisect/server_spec.rb
@@ -59,7 +59,7 @@ module RSpec::Core
       end
 
       it 'receives suite results' do
-        results = server.capture_run_results do
+        results = server.capture_run_results(['spec/rspec/core/resources/formatter_specs.rb']) do
           run_formatter_specs
         end
 
@@ -92,7 +92,7 @@ module RSpec::Core
             ./spec/rspec/core/resources/formatter_specs.rb[4:1]
           ]
 
-          results = server.capture_run_results(expected_failures) do
+          results = server.capture_run_results(['spec/rspec/core/resources/formatter_specs.rb'], expected_failures) do
             run_formatter_specs
           end
 
@@ -115,7 +115,7 @@ module RSpec::Core
           passing_example       = "./spec/rspec/core/resources/formatter_specs.rb[3:1]"
           later_failing_example = "./spec/rspec/core/resources/formatter_specs.rb[4:1]"
 
-          results = server.capture_run_results([passing_example, later_failing_example]) do
+          results = server.capture_run_results(['spec/rspec/core/resources/formatter_specs.rb'], [passing_example, later_failing_example]) do
             run_formatter_specs
           end
 
@@ -136,7 +136,7 @@ module RSpec::Core
           pending_example       = "./spec/rspec/core/resources/formatter_specs.rb[1:1]"
           later_failing_example = "./spec/rspec/core/resources/formatter_specs.rb[4:1]"
 
-          results = server.capture_run_results([pending_example, later_failing_example]) do
+          results = server.capture_run_results(['spec/rspec/core/resources/formatter_specs.rb'], [pending_example, later_failing_example]) do
             run_formatter_specs
           end
 


### PR DESCRIPTION
(Addresses #2145)

When bisecting a large set of specs, the maximum argument length for `open3` can be exceeded. To work around this issue, pass the list of files and directories via the DRb connection.

There are a couple things that I'm not entirely happy with in this:

* some of the specs didn't make as much sense anymore. In particular, it wasn't clear to me what `spec/rspec/core/bisect/runner_spec.rb:226` should be checking now that files aren't passed on the command line.

* the bisect mechanism isn't particularly isolated from the rest of the system. The check in `Rspec::Core::Configuration#files_or_directories_to_run` works but seems messy.

* `run_formatter_specs` sets up an odd not-entirely-realistic scenario (files passed on the command line AND via DRb). Cleaning that up would require a sizable refactor of that helper method.

* client vs server naming is not clear. I can't decide if introducing `RSpec::Core::Bisect::Client` makes the situation worse or better.

* there are now two slightly-different ways to specify the spec files to be run over DRb (via the `--drb` switch and via the bisect plumbing added here). They serve distinct purposes, so I'm unsure if the duplication is a problem or not.

A more significant refactor might solve some of these issues. Perhaps instead of `--files-over-drb`, a flag like `--bisect-client` that activates an alternative runner? That runner could handle setting the formatter to `bisect` and pulling files from DRb.