### PR TITLE
Add documentation for ExampleGroup#idempotently_define_singleton_method

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -33,6 +33,8 @@ module RSpec
       include Pending
       extend SharedExampleGroup
 
+      # Define a singleton method for the singleton class (remove the method if
+      # it's already been defined).
       # @private
       def self.idempotently_define_singleton_method(name, &definition)
         (class << self; self; end).module_exec do


### PR DESCRIPTION
It's hard to understand how the method works at first sight.