### PR TITLE
Followups to #2223.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,9 @@ Bug Fixes:
 * Fix failure snippet extraction so that `def-end` snippets
   ending with `end`-only line can be extracted properly.
   (Yuji Nakayama, #2215)
+* Fix `--bisect` so it works on large spec suites that were previously triggering
+  "Argument list too long errors" due to all the spec locations being passed as
+  CLI args. (Matt Jones, #2223).
 
 ### 3.5.0.beta1 / 2016-02-06
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.3...v3.5.0.beta1)

--- a/spec/rspec/core/bisect/runner_spec.rb
+++ b/spec/rspec/core/bisect/runner_spec.rb
@@ -223,7 +223,7 @@ module RSpec::Core
         end
       end
 
-      it "runs the suite with the seed from the original CLI args" do
+      it "runs the suite with the original CLI options" do
         runner.original_results
         expect(Open3).to have_received(open3_method).with(a_string_including("--seed 1234"))
       end

--- a/spec/rspec/core/bisect/server_spec.rb
+++ b/spec/rspec/core/bisect/server_spec.rb
@@ -55,7 +55,7 @@ module RSpec::Core
 
       def run_formatter_specs
         RSpec.configuration.drb_port = server.drb_port
-        run_example_specs_with_formatter("bisect")
+        run_rspec_with_formatter("bisect")
       end
 
       it 'receives suite results' do

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
   include FormatterSupport
 
   it "can be loaded via `--format json`" do
-    output = run_example_specs_with_formatter("json", false)
+    output = run_example_specs_with_formatter("json", :normalize_output => false)
     parsed = JSON.parse(output)
     expect(parsed.keys).to include("examples", "summary", "summary_line")
   end


### PR DESCRIPTION
- Add changelog entry.
- Make doc string in bisect/runner_spec.rb more accurate
  (it is not just `--seed` that is passed along when running
  the suite, it's all CLI options, but `--seed` is the example).
- Extract `run_rspec_with_formatter` helper method that does not
  include spec files in args list. This better supports
  `bisect/server_spec.rb` since bisect passes along locations via
  DRb now.  (See discussion on #2223 for background).