### PR TITLE
Fix filtering based on `:example_group` to work for example groups.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,8 @@ Bug Fixes:
 * Fix `--bisect` so it works on large spec suites that were previously triggering
   "Argument list too long errors" due to all the spec locations being passed as
   CLI args. (Matt Jones, #2223).
+* Fix deprecated `:example_group`-based filtering so that it properly
+  applies to matching example groups. (Myron Marston, #2234)
 
 ### 3.5.0.beta1 / 2016-02-06
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.4.3...v3.5.0.beta1)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -938,6 +938,16 @@ module RSpec::Core
           expect(group.new.you_call_this_a_blt?).to eq("egad man, where's the mayo?!?!?")
         end
 
+        it "includes in example groups that match a deprecated `:example_group` filter" do
+          RSpec.configure do |c|
+            c.include(InstanceLevelMethods, :example_group => { :file_path => /./ })
+          end
+
+          group = RSpec.describe('does like, stuff and junk')
+          expect(group).not_to respond_to(:you_call_this_a_blt?)
+          expect(group.new.you_call_this_a_blt?).to eq("egad man, where's the mayo?!?!?")
+        end
+
         it "includes the given module into each existing matching example group" do
           matching_group = RSpec.describe('does like, stuff and junk', :magic_key => :include) { }
           non_matching_group = RSpec.describe


### PR DESCRIPTION
This regressed in #1749. The changes there affected code like this:

``` ruby
RSpec.configure do |c|
  c.include Mod, :example_group => { :file_path => /./ }
end
```

In RSpec 2, and in RSpec 3 before #1749, this snippet would cause `Mod`
to be included in every example group (since `/./` matches all file
paths). After #1749, it would _not_ be included in any example groups.
Instead, it was included in the singleton class of every example.
In practice, this usually worked OK, as the methods from `Mod` were
available to be called very every example, but it had subtle problems:

* If the same method was defined in multiple included modules,
  the version of the method defined in a module included in this
  fashion would always get precedence due to the singleton class
  getting "first dibs" during method dispatch over the example group
  class. (This is the broken example given in #2232).
* I believe this broke `c.extend Mod, :example_group => {...}` since
  we don't extend onto singleton classes.

The reason is that the optimizations included in #1749 considered
only metadata keys that the groups and examples have in their metadata
hashes. In a group hash, `:example_group` is not a "real" metadata
key--instead it is created lazily on first access using a
`default_proc`. But example hashes still have it (it is a reference to
the metadata of their group), so it allowed example filtering to work
correctly, which in turn hid the bug.

Fixes #2232.