### PR TITLE
Filter bundler stackframes by default.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,9 @@ Enhancements:
 * Add new `config.filter_run_when_matching` API, intended to replace
   the combination of `config.filter_run` and
   `config.run_all_when_everything_filtered` (Myron Marston, #2206)
+* Filter out bundler stackframes from backtraces by default, since
+  Bundler 1.12 now includes its own frames in stack traces produced
+  by using `bundle exec`. (Myron Marston, #2240)
 
 Bug Fixes:
 

--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -8,7 +8,7 @@ module RSpec
       def initialize
         @full_backtrace = false
 
-        patterns = %w[ /lib\d*/ruby/ bin/ exe/rspec ]
+        patterns = %w[ /lib\d*/ruby/ bin/ exe/rspec /lib/bundler/ /exe/bundle: ]
         patterns << "org/jruby/" if RUBY_PLATFORM == 'java'
         patterns.map! { |s| Regexp.new(s.gsub("/", File::SEPARATOR)) }
 

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -113,6 +113,28 @@ module RSpec::Core
         expect(BacktraceFormatter.new.format_backtrace(backtrace)).to eq(["./my_spec.rb:5"])
       end
 
+      it "excludes lines from bundler by default, since Bundler 1.12 now includes its stackframes in all stacktraces when you `bundle exec`" do
+        bundler_trace = [
+          "/some/other/file.rb:13",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/cli/exec.rb:63:in `load'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/cli/exec.rb:63:in `kernel_load'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/cli/exec.rb:24:in `run'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/cli.rb:304:in `exec'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/cli.rb:11:in `start'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/exe/bundle:27:in `block in <top (required)>'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/lib/bundler/friendly_errors.rb:98:in `with_friendly_errors'",
+          "/Users/myron/.gem/ruby/2.3.0/gems/bundler-1.12.3/exe/bundle:19:in `<top (required)>'",
+          "/Users/myron/.gem/ruby/2.3.0/bin/bundle:23:in `load'",
+          "/Users/myron/.gem/ruby/2.3.0/bin/bundle:23:in `<main>'"
+        ]
+
+        expect(BacktraceFormatter.new.format_backtrace(bundler_trace)).to eq ["/some/other/file.rb:13"]
+      end
+
       context "when every line is filtered out" do
         let(:backtrace) do
           [


### PR DESCRIPTION
In bundler/bundler#4271 (first included in Bundler 1.12),
`bundle exec` now uses `load` to run the named executable,
which means the stackframes from bundler (from before `load rspec`)
are included in stacktraces. These stack frames are largely just noise
and it makes for a better user experience if we filter them by default.