### PR TITLE
Delay formatter setup until reporter needs to notify something

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 Bug Fixes:
 
 * Include example id in the JSON formatter output. (#2369, Xavier Shay)
+* Delay formatter loading until the last minute to allow accessing the reporter
+  without triggering formatter setup. (Jon Rowe, #2243)
 
 ### 3.6.0.beta2 / 2016-12-12
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.6.0.beta1...v3.6.0.beta2)

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,10 @@ if RUBY_VERSION < '2.0.0' || RUBY_ENGINE == 'java'
   gem 'json', '< 2.0.0'
 end
 
+if RUBY_VERSION < '2.0.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
+  gem 'ffi', '< 1.9.15' # allow ffi to be installed on older rubies on windows
+end
+
 platforms :jruby do
   gem "jruby-openssl"
 end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -930,7 +930,7 @@ module RSpec
         @reporter_buffer || @reporter ||=
           begin
             @reporter_buffer = DeprecationReporterBuffer.new
-            formatter_loader.setup_default output_stream, deprecation_stream
+            formatter_loader.prepare_default output_stream, deprecation_stream
             @reporter_buffer.play_onto(formatter_loader.reporter)
             @reporter_buffer = nil
             formatter_loader.reporter

--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -116,6 +116,11 @@ module RSpec::Core::Formatters
     attr_accessor :default_formatter
 
     # @private
+    def prepare_default(output_stream, deprecation_stream)
+      reporter.prepare_default(self, output_stream, deprecation_stream)
+    end
+
+    # @private
     def setup_default(output_stream, deprecation_stream)
       add default_formatter, output_stream if @formatters.empty?
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1471,6 +1471,16 @@ module RSpec::Core
         expect(config.formatters).to be_empty
       end
 
+      it 'buffers deprecations until the reporter is ready' do
+        allow(config.formatter_loader).to receive(:prepare_default).and_wrap_original do |original, *args|
+          config.reporter.deprecation :message => 'Test deprecation'
+          original.call(*args)
+        end
+        expect {
+          config.reporter.notify :deprecation_summary, Notifications::NullNotification
+        }.to change { config.deprecation_stream.string }.to include 'Test deprecation'
+      end
+
       it 'allows registering listeners without doubling up formatters' do
         config.reporter.register_listener double(:message => nil), :message
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1465,7 +1465,7 @@ module RSpec::Core
         config.deprecation_stream = StringIO.new
       end
 
-      it 'doesnt immediately trigger formatter setup' do
+      it 'does not immediately trigger formatter setup' do
         config.reporter
 
         expect(config.formatters).to be_empty

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1488,6 +1488,8 @@ module RSpec::Core
           config.formatter = :documentation
         }.to change { config.formatters.size }.from(0).to(1)
 
+        # notify triggers the formatter setup, there are two due to the already configured
+        # documentation formatter and deprecation formatter
         expect {
           config.reporter.notify :message, double(:message => 'Triggers formatter setup')
         }.to change { config.formatters.size }.from(1).to(2)
@@ -1495,6 +1497,9 @@ module RSpec::Core
 
       it 'still configures a default formatter when none specified' do
         config.reporter.register_listener double(:message => nil), :message
+
+        # notify triggers the formatter setup, there are two due to the default
+        # (progress) and deprecation formatter
         expect {
           config.reporter.notify :message, double(:message => 'Triggers formatter setup')
         }.to change { config.formatters.size }.from(0).to(2)

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -35,6 +35,11 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
       expect(formatter_output.string).to match("1 example, 1 failure, 1 pending")
     end
 
+    it "with 1s outputs singular (only pending)" do
+      send_notification :dump_summary, summary_notification(1, examples(1), examples(0), examples(1), 0)
+      expect(formatter_output.string).to match("1 example, 0 failures, 1 pending")
+    end
+
     it "with 2s outputs pluralized (including pending)" do
       send_notification :dump_summary, summary_notification(2, examples(2), examples(2), examples(2), 0)
       expect(formatter_output.string).to match("2 examples, 2 failures, 2 pending")


### PR DESCRIPTION
By delaying formatter setup until the reporter needs to tell someone something we allow people to access reporter public apis without triggering doubling up on formatters.

Fixes #2224 
