### PR TITLE
Fix NoMethodError for NilClass for Java backtraces

### DIFF
--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -204,7 +204,13 @@ module RSpec
             return ["Unable to find matching line from backtrace"]
           end
 
-          file_path, line_number = matching_line.match(/(.+?):(\d+)(|:\d+)/)[1..2]
+          file_and_line_number = matching_line.match(/(.+?):(\d+)(|:\d+)/)
+
+          unless file_and_line_number
+            return ["Unable to infer file and line number from backtrace"]
+          end
+
+          file_path, line_number = file_and_line_number[1..2]
           max_line_count = RSpec.configuration.max_displayed_failure_line_count
           lines = SnippetExtractor.extract_expression_lines_at(file_path, line_number.to_i, max_line_count)
           RSpec.world.source_cache.syntax_highlighter.highlight(lines)

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -478,6 +478,14 @@ module RSpec::Core
         end
       end
 
+      context "when the stack trace is from a java exception" do
+        let(:exception) { instance_double(Exception, :backtrace => [ "org.jruby.SomeJavaException(Unknown Source)"]) }
+
+        it "reports that it was unable to infer a code location from the backtrace" do
+          expect(read_failed_lines.first).to include("Unable to infer file and line number from backtrace")
+        end
+      end
+
       context "when ruby reports a file that does not exist" do
         let(:file) { "#{__FILE__}/blah.rb" }
         let(:exception) { instance_double(Exception, :backtrace => [ "#{file}:1"]) }


### PR DESCRIPTION
On JRuby, the source of the error can come from Java code (JRuby internals). 
In that case the line format is not guaranteed to follow the Ruby format, making the Regex fail.
In that case, let's handle that gracefully instead of raising an exception that hides the original cause.