### PR TITLE
Load spec files in the order that files and dirs were specified in the CLI.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,11 @@ Enhancements:
   by using `bundle exec`. (Myron Marston, #2240)
 * HTML Formatter uses exception presenter to get failure message
   for consistency with other formatters. (@mrageh, #2222)
+* Load spec files in the order of the directories or files passed
+  at the command line, making it easy to make some specs run before
+  others in a one-off manner.  For example, `rspec spec/unit
+  spec/acceptance --order defined` will run unit specs before acceptance
+  specs. (Myron Marston, #2253)
 
 Bug Fixes:
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1782,7 +1782,7 @@ module RSpec
         files = FlatMap.flat_map(paths_to_check(paths)) do |path|
           path = path.gsub(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
           File.directory?(path) ? gather_directories(path) : extract_location(path)
-        end.sort.uniq
+        end.uniq
 
         return files unless only_failures?
         relative_files = files.map { |f| Metadata.relative_path(File.expand_path f) }
@@ -1802,11 +1802,12 @@ module RSpec
       def gather_directories(path)
         include_files = get_matching_files(path, pattern)
         exclude_files = get_matching_files(path, exclude_pattern)
-        (include_files - exclude_files).sort.uniq
+        (include_files - exclude_files).uniq
       end
 
       def get_matching_files(path, pattern)
-        Dir[file_glob_from(path, pattern)].map { |file| File.expand_path(file) }
+        raw_files = Dir[file_glob_from(path, pattern)]
+        raw_files.map { |file| File.expand_path(file) }.sort
       end
 
       def file_glob_from(path, pattern)
@@ -1846,7 +1847,7 @@ module RSpec
         end
 
         return [] if path == default_path
-        path
+        File.expand_path(path)
       end
 
       def command

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -167,7 +167,7 @@ module RSpec::Core
     context "with SPEC env var set" do
       it "sets files to run" do
         with_env_vars 'SPEC' => 'path/to/file' do
-          expect(loaded_files).to eq(["path/to/file"])
+          expect(loaded_files).to contain_files("path/to/file")
         end
       end
 
@@ -346,7 +346,7 @@ module RSpec::Core
         it "loads the files from the FileList" do
           task.pattern = FileList["spec/rspec/core/resources/**/*_spec.rb"]
 
-          expect(loaded_files).to contain_exactly(
+          expect(loaded_files).to contain_files(
             "spec/rspec/core/resources/a_spec.rb",
             "spec/rspec/core/resources/acceptance/foo_spec.rb"
           )


### PR DESCRIPTION
This fixes #2247 and addresses some of the feedback from #2251.