### PR TITLE
Remove unused arg

### DIFF
--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -34,8 +34,7 @@ module RSpec
         end
 
         def example_failed(failure)
-          output.puts failure_output(failure.example,
-                                     failure.example.execution_result.exception)
+          output.puts failure_output(failure.example)
         end
 
       private
@@ -50,7 +49,7 @@ module RSpec
                             :pending)
         end
 
-        def failure_output(example, _exception)
+        def failure_output(example)
           ConsoleCodes.wrap("#{current_indentation}#{example.description.strip} " \
                             "(FAILED - #{next_failure_index})",
                             :failure)


### PR DESCRIPTION
It seems like the `_exception` arg passed to `DocumentationFormatter#failure_output` is a relic of the past [1]. So I think it's safe to remove it.

1.) https://github.com/rspec/rspec-core/commit/79be9b301b43d9f50d04a8620d51621133d1515f#diff-6651211a081b5ea464e033bf7c8e061cL46