### PR TITLE
Shared example group inclusion changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Metrics/LineLength:
 
 # This should go down over time.
 Metrics/MethodLength:
-  Max: 40
+  Max: 37
 
 # This should go down over time.
 Metrics/CyclomaticComplexity:

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,9 @@ Enhancements:
   others in a one-off manner.  For example, `rspec spec/unit
   spec/acceptance --order defined` will run unit specs before acceptance
   specs. (Myron Marston, #2253)
+* Add new `config.include_context` API for configuring global or
+  filtered inclusion of shared contexts in example groups.
+  (Myron Marston, #2256)
 
 Bug Fixes:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,10 @@ Enhancements:
 * Add new `config.include_context` API for configuring global or
   filtered inclusion of shared contexts in example groups.
   (Myron Marston, #2256)
+* Add new `config.shared_context_metadata_behavior = :apply_to_host_groups`
+  option, which causes shared context metadata to be inherited by the
+  metadata hash of all host groups and examples instead of configuring
+  implicit auto-inclusion based on the passed metadata. (Myron Marston, #2256)
 
 Bug Fixes:
 

--- a/features/example_groups/shared_context.feature
+++ b/features/example_groups/shared_context.feature
@@ -1,15 +1,13 @@
 Feature: shared context
 
-  Use `shared_context` to define a block that will be evaluated in the context
-  of example groups either explicitly, using `include_context`, or implicitly by
-  matching metadata.
+  Use `shared_context` to define a block that will be evaluated in the context of example groups either locally, using `include_context` in an example group, or globally using `config.include_context`.
 
   When implicitly including shared contexts via matching metadata, the normal way is to define matching metadata on an example group, in which case the context is included in the entire group. However, you also have the option to include it in an individual example instead. RSpec treats every example as having a singleton example group (analogous to Ruby's singleton classes) containing just the one example.
 
   Background:
     Given a file named "shared_stuff.rb" with:
       """ruby
-      RSpec.shared_context "shared stuff", :a => :b do
+      RSpec.shared_context "shared stuff" do
         before { @some_var = :some_value }
         def shared_method
           "it works"
@@ -18,6 +16,10 @@ Feature: shared context
         subject do
           'this is the subject'
         end
+      end
+
+      RSpec.configure do |rspec|
+        rspec.include_context "shared stuff", :include_shared => true
       end
       """
 
@@ -72,7 +74,7 @@ Feature: shared context
       """ruby
       require "./shared_stuff.rb"
 
-      RSpec.describe "group that includes a shared context using metadata", :a => :b do
+      RSpec.describe "group that includes a shared context using metadata", :include_shared => true do
         it "has access to methods defined in shared context" do
           expect(shared_method).to eq("it works")
         end
@@ -103,7 +105,7 @@ Feature: shared context
           expect(self).not_to respond_to(:shared_method)
         end
 
-        it "has access to shared methods from examples with matching metadata", :a => :b do
+        it "has access to shared methods from examples with matching metadata", :include_shared => true do
           expect(shared_method).to eq("it works")
         end
       end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1304,6 +1304,8 @@ module RSpec
       # Used internally to extend a group with modules using `include`, `prepend` and/or
       # `extend`.
       def configure_group(group)
+        group.hooks.register_globals(group, hooks)
+
         configure_group_with group, @include_modules, :safe_include
         configure_group_with group, @extend_modules,  :safe_extend
         configure_group_with group, @prepend_modules, :safe_prepend
@@ -1313,7 +1315,8 @@ module RSpec
       #
       # Used internally to extend the singleton class of a single example's
       # example group instance with modules using `include` and/or `extend`.
-      def configure_example(example)
+      def configure_example(example, example_hooks)
+        example_hooks.register_global_singleton_context_hooks(example, hooks)
         singleton_group = example.example_group_instance.singleton_class
 
         # We replace the metadata so that SharedExampleGroupModule#included

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1219,8 +1219,8 @@ module RSpec
       #
       # @see #include
       def include_context(shared_group_name, *filters)
-        block = world.shared_example_group_registry.find([:main], shared_group_name)
-        include SharedExampleGroupModule.new(shared_group_name, block), *filters
+        shared_module = world.shared_example_group_registry.find([:main], shared_group_name)
+        include shared_module, *filters
       end
 
       # Tells RSpec to extend example groups with `mod`. Methods defined in

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -327,6 +327,59 @@ module RSpec
         )
       end
 
+      # @macro define_reader
+      # Configures how RSpec treats metadata passed as part of a shared example
+      # group definition. For example, given this shared example group definition:
+      #
+      #     RSpec.shared_context "uses DB", :db => true do
+      #       around(:example) do |ex|
+      #         MyORM.transaction(:rollback => true, &ex)
+      #       end
+      #     end
+      #
+      # ...there are two ways RSpec can treat the `:db => true` metadata, each
+      # of which has a corresponding config option:
+      #
+      # 1. `:trigger_inclusion`: this shared context will be implicitly included
+      #    in any groups (or examples) that have `:db => true` metadata.
+      # 2. `:apply_to_host_groups`: the metadata will be inherited by the metadata
+      #    hash of all host groups and examples.
+      #
+      # `:trigger_inclusion` is the legacy behavior from before RSpec 3.5 but should
+      # be considered deprecated. Instead, you can explicitly include a group with
+      # `include_context`:
+      #
+      #     RSpec.describe "My model" do
+      #       include_context "uses DB"
+      #     end
+      #
+      # ...or you can configure RSpec to include the context based on matching metadata
+      # using an API that mirrors configured module inclusion:
+      #
+      #     RSpec.configure do |rspec|
+      #       rspec.include_context "uses DB", :db => true
+      #     end
+      #
+      # `:apply_to_host_groups` is a new feature of RSpec 3.5 and will be the only
+      # supported behavior in RSpec 4.
+      #
+      # @overload shared_context_metadata_behavior
+      #   @return [:trigger_inclusion, :apply_to_host_groups] the configured behavior
+      # @overload shared_context_metadata_behavior=(value)
+      #   @param value [:trigger_inclusion, :apply_to_host_groups] sets the configured behavior
+      define_reader :shared_context_metadata_behavior
+      # @see shared_context_metadata_behavior
+      def shared_context_metadata_behavior=(value)
+        case value
+        when :trigger_inclusion, :apply_to_host_groups
+          @shared_context_metadata_behavior = value
+        else
+          raise ArgumentError, "Cannot set `RSpec.configuration." \
+            "shared_context_metadata_behavior` to `#{value.inspect}`. Only " \
+            "`:trigger_inclusion` and `:apply_to_host_groups` are valid values."
+        end
+      end
+
       # Record the start time of the spec suite to measure load time.
       add_setting :start_time
 
@@ -352,6 +405,7 @@ module RSpec
       attr_reader :backtrace_formatter, :ordering_manager, :loaded_spec_files
 
       # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/MethodLength
       def initialize
         # rubocop:disable Style/GlobalVars
         @start_time = $_rspec_core_load_started_at || ::RSpec::Core::Time.now
@@ -398,9 +452,11 @@ module RSpec
         @threadsafe = true
         @max_displayed_failure_line_count = 10
         @world = World::Null
+        @shared_context_metadata_behavior = :trigger_inclusion
 
         define_built_in_hooks
       end
+      # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize
 
       # @private

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1153,7 +1153,7 @@ module RSpec
       #     end
       #
       #     RSpec.configure do |config|
-      #       config.include(UserHelpers) # included in all modules
+      #       config.include(UserHelpers) # included in all groups
       #       config.include(AuthenticationHelpers, :type => :request)
       #     end
       #
@@ -1172,12 +1172,55 @@ module RSpec
       #   example has a singleton example group containing just the one
       #   example.
       #
+      # @see #include_context
       # @see #extend
       # @see #prepend
       def include(mod, *filters)
         define_mixed_in_module(mod, filters, @include_modules, :include) do |group|
           safe_include(mod, group)
         end
+      end
+
+      # Tells RSpec to include the named shared example group in example groups.
+      # Use `filters` to constrain the groups or examples in which to include
+      # the example group.
+      #
+      # @example
+      #
+      #     RSpec.shared_context "example users" do
+      #       let(:admin_user) { create_user(:admin) }
+      #       let(:guest_user) { create_user(:guest) }
+      #     end
+      #
+      #     RSpec.configure do |config|
+      #       config.include_context "example users", :type => :request
+      #     end
+      #
+      #     RSpec.describe "The admin page", :type => :request do
+      #       it "can be viewed by admins" do
+      #         login_with admin_user
+      #         get "/admin"
+      #         expect(response).to be_ok
+      #       end
+      #
+      #       it "cannot be viewed by guests" do
+      #         login_with guest_user
+      #         get "/admin"
+      #         expect(response).to be_forbidden
+      #       end
+      #     end
+      #
+      # @note Filtered context inclusions can also be applied to
+      #   individual examples that have matching metadata. Just like
+      #   Ruby's object model is that every object has a singleton class
+      #   which has only a single instance, RSpec's model is that every
+      #   example has a singleton example group containing just the one
+      #   example.
+      #
+      # @see #include
+      def include_context(shared_group_name, *filters)
+        block = world.shared_example_group_registry.find([:main], shared_group_name)
+        include SharedExampleGroupModule.new(shared_group_name, block), *filters
       end
 
       # Tells RSpec to extend example groups with `mod`. Methods defined in

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -229,8 +229,7 @@ module RSpec
       def run(example_group_instance, reporter)
         @example_group_instance = example_group_instance
         @reporter = reporter
-        hooks.register_global_singleton_context_hooks(self, RSpec.configuration.hooks)
-        RSpec.configuration.configure_example(self)
+        RSpec.configuration.configure_example(self, hooks)
         RSpec.current_example = self
 
         start(reporter)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -142,6 +142,13 @@ module RSpec
                     new_metadata, new_metadata[:block])
       end
 
+      # @private
+      def update_inherited_metadata(updates)
+        metadata.update(updates) do |_key, existing_example_value, _new_inherited_value|
+          existing_example_value
+        end
+      end
+
       # @attr_reader
       #
       # Returns the first exception raised in the context of running this

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -426,7 +426,6 @@ module RSpec
 
         @currently_executing_a_context_hook = false
 
-        hooks.register_globals(self, RSpec.configuration.hooks)
         RSpec.configuration.configure_group(self)
       end
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -364,16 +364,16 @@ module RSpec
 
       # @private
       def self.find_and_eval_shared(label, name, inclusion_location, *args, &customization_block)
-        shared_block = RSpec.world.shared_example_group_registry.find(parent_groups, name)
+        shared_module = RSpec.world.shared_example_group_registry.find(parent_groups, name)
 
-        unless shared_block
+        unless shared_module
           raise ArgumentError, "Could not find shared #{label} #{name.inspect}"
         end
 
-        SharedExampleGroupInclusionStackFrame.with_frame(name, Metadata.relative_path(inclusion_location)) do
-          module_exec(*args, &shared_block)
-          module_exec(&customization_block) if customization_block
-        end
+        shared_module.include_in(
+          self, Metadata.relative_path(inclusion_location),
+          args, customization_block
+        )
       end
 
       # @!endgroup

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -689,6 +689,17 @@ module RSpec
         # :nocov:
       end
 
+      # @private
+      def self.update_inherited_metadata(updates)
+        metadata.update(updates) do |_key, existing_group_value, _new_inherited_value|
+          existing_group_value
+        end
+
+        RSpec.configuration.configure_group(self)
+        examples.each { |ex| ex.update_inherited_metadata(updates) }
+        children.each { |group| group.update_inherited_metadata(updates) }
+      end
+
       # Raised when an RSpec API is called in the wrong scope, such as `before`
       # being called from within an example rather than from within an example
       # group block.

--- a/lib/rspec/core/project_initializer/spec/spec_helper.rb
+++ b/lib/rspec/core/project_initializer/spec/spec_helper.rb
@@ -40,6 +40,13 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -2414,6 +2414,31 @@ module RSpec::Core
       end
     end
 
+    describe "#shared_context_metadata_behavior" do
+      it "defaults to :trigger_inclusion for backwards compatibility" do
+        expect(config.shared_context_metadata_behavior).to eq :trigger_inclusion
+      end
+
+      it "can be set to :apply_to_host_groups" do
+        config.shared_context_metadata_behavior = :apply_to_host_groups
+        expect(config.shared_context_metadata_behavior).to eq :apply_to_host_groups
+      end
+
+      it "can be set to :trigger_inclusion explicitly" do
+        config.shared_context_metadata_behavior = :trigger_inclusion
+        expect(config.shared_context_metadata_behavior).to eq :trigger_inclusion
+      end
+
+      it "cannot be set to any other values" do
+        expect {
+          config.shared_context_metadata_behavior = :another_value
+        }.to raise_error(ArgumentError, a_string_including(
+          "shared_context_metadata_behavior",
+          ":another_value", ":trigger_inclusion", ":apply_to_host_groups"
+        ))
+      end
+    end
+
     # assigns files_or_directories_to_run and triggers post-processing
     # via `files_to_run`.
     def assign_files_or_directories_to_run(*value)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -914,6 +914,46 @@ module RSpec::Core
       end
     end
 
+    describe "#include_context" do
+      context "with no metadata filters" do
+        it 'includes the named shared example group in all groups' do
+          RSpec.shared_examples "shared group" do
+            let(:foo) { 17 }
+          end
+          RSpec.configuration.include_context "shared group"
+
+          expect(RSpec.describe.new.foo).to eq 17
+        end
+      end
+
+      context "with metadata filters" do
+        it 'includes the named shared example group in matching groups' do
+          RSpec.shared_examples "shared group" do
+            let(:foo) { 18 }
+          end
+          RSpec.configuration.include_context "shared group", :include_it
+
+          expect(RSpec.describe.new).not_to respond_to(:foo)
+          expect(RSpec.describe("", :include_it).new.foo).to eq 18
+        end
+
+        it 'includes the named shared example group in the singleton class of matching examples' do
+          RSpec.shared_examples "shared group" do
+            let(:foo) { 19 }
+          end
+          RSpec.configuration.include_context "shared group", :include_it
+
+          foo_value = nil
+          describe_successfully do
+            it { expect { self.foo }.to raise_error(NoMethodError) }
+            it("", :include_it) { foo_value = foo }
+          end
+
+          expect(foo_value).to eq 19
+        end
+      end
+    end
+
     describe "#include" do
       include_examples "warning of deprecated `:example_group` during filtering configuration", :include, Enumerable
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -901,6 +901,19 @@ module RSpec::Core
       end
     end
 
+    config_methods = %w[ include extend ]
+    config_methods << "prepend" if RSpec::Support::RubyFeatures.module_prepends_supported?
+    config_methods.each do |config_method|
+      it "raises an immediate `TypeError` when you attempt to `config.#{config_method}` with something besides a module" do
+        expect {
+          config.send(config_method, :not_a_module)
+        }.to raise_error(TypeError, a_string_including(
+          "configuration.#{config_method}",
+          "expects a module but got", "not_a_module"
+        ))
+      end
+    end
+
     describe "#include" do
       include_examples "warning of deprecated `:example_group` during filtering configuration", :include, Enumerable
 

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -44,6 +44,10 @@ module RSpec
             group.send(shared_method_name, *args, &block)
           end
 
+          def find_implementation_block(registry, scope, name)
+            registry.find([scope], name).definition
+          end
+
           it "is exposed to the global namespace when expose_dsl_globally is enabled" do
             in_sub_process do
               RSpec.configuration.expose_dsl_globally = true
@@ -98,7 +102,7 @@ module RSpec
               it "captures the given #{type} and block in the collection of shared example groups" do
                 implementation = lambda { }
                 define_shared_group(object, &implementation)
-                expect(registry.find([group], object)).to eq implementation
+                expect(find_implementation_block(registry, group, object)).to eq implementation
               end
             end
           end
@@ -120,7 +124,7 @@ module RSpec
             it "captures the given string and block in the World's collection of shared example groups" do
               implementation = lambda { }
               define_shared_group("name", :foo => :bar, &implementation)
-              expect(registry.find([group], "name")).to eq implementation
+              expect(find_implementation_block(registry, group, "name")).to eq implementation
             end
 
             it "delegates include on configuration" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,8 +38,8 @@ class RaiseOnFailuresReporter < RSpec::Core::NullReporter
 end
 
 module CommonHelpers
-  def describe_successfully(description="", &describe_body)
-    example_group    = RSpec.describe(description, &describe_body)
+  def describe_successfully(*args, &describe_body)
+    example_group    = RSpec.describe(*args, &describe_body)
     ran_successfully = example_group.run RaiseOnFailuresReporter
     expect(ran_successfully).to eq true
     example_group

--- a/spec/support/isolated_home_directory.rb
+++ b/spec/support/isolated_home_directory.rb
@@ -1,7 +1,7 @@
 require 'tmpdir'
 require 'fileutils'
 
-RSpec.shared_context "isolated home directory", :isolated_home => true do
+RSpec.shared_context "isolated home directory" do
   around do |ex|
     Dir.mktmpdir do |tmp_dir|
       original_home = ENV['HOME']
@@ -13,4 +13,8 @@ RSpec.shared_context "isolated home directory", :isolated_home => true do
       end
     end
   end
+end
+
+RSpec.configure do |c|
+  c.include_context "isolated home directory", :isolated_home => true
 end


### PR DESCRIPTION
This is the start of a number of changes for #1790.

Still TODO:

- [x] Add config option discussed in #1790 to toggle what metadata passed to `RSpec.shared_examples` does.