### PR TITLE
Spike to drop support for ruby 1.8.7

### DIFF
--- a/features/step_definitions/core_standalone_steps.rb
+++ b/features/step_definitions/core_standalone_steps.rb
@@ -1,9 +1,5 @@
 Given(/^only rspec-core is installed$/) do
-  if RUBY_VERSION.to_f >= 1.9 # --disable-gems is invalid on 1.8.7
-    # Ensure the gem versions of rspec-mocks and rspec-expectations
-    # won't be loaded if available on the developers machine.
-    set_env('RUBYOPT', ENV['RUBYOPT'] + ' --disable-gems')
-  end
+  set_env('RUBYOPT', ENV['RUBYOPT'] + ' --disable-gems')
 
   # This will make `require_expect_syntax_in_aruba_specs.rb` (loaded
   # automatically when the specs run) remove rspec-mocks and

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1937,24 +1937,12 @@ module RSpec
         end
       end
 
-      if RUBY_VERSION.to_f >= 1.9
-        def safe_include(mod, host)
-          host.__send__(:include, mod) unless host < mod
-        end
+      def safe_include(mod, host)
+        host.__send__(:include, mod) unless host < mod
+      end
 
-        def safe_extend(mod, host)
-          host.extend(mod) unless host.singleton_class < mod
-        end
-      else # for 1.8.7
-        # :nocov:
-        def safe_include(mod, host)
-          host.__send__(:include, mod) unless host.included_modules.include?(mod)
-        end
-
-        def safe_extend(mod, host)
-          host.extend(mod) unless (class << host; self; end).included_modules.include?(mod)
-        end
-        # :nocov:
+      def safe_extend(mod, host)
+        host.extend(mod) unless host.singleton_class < mod
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -527,28 +527,9 @@ module RSpec
         @currently_executing_a_context_hook = false
       end
 
-      if RUBY_VERSION.to_f >= 1.9
-        # @private
-        def self.superclass_before_context_ivars
-          superclass.before_context_ivars
-        end
-      else # 1.8.7
-        # :nocov:
-        # @private
-        def self.superclass_before_context_ivars
-          if superclass.respond_to?(:before_context_ivars)
-            superclass.before_context_ivars
-          else
-            # `self` must be the singleton class of an ExampleGroup instance.
-            # On 1.8.7, the superclass of a singleton class of an instance of A
-            # is A's singleton class. On 1.9+, it's A. On 1.8.7, the first ancestor
-            # is A, so we can mirror 1.8.7's behavior here. Note that we have to
-            # search for the first that responds to `before_context_ivars`
-            # in case a module has been included in the singleton class.
-            ancestors.find { |a| a.respond_to?(:before_context_ivars) }.before_context_ivars
-          end
-        end
-        # :nocov:
+      # @private
+      def self.superclass_before_context_ivars
+        superclass.before_context_ivars
       end
 
       # @private
@@ -679,15 +660,6 @@ module RSpec
       # @private
       def inspect
         "#<#{self.class} #{@__inspect_output}>"
-      end
-
-      unless method_defined?(:singleton_class) # for 1.8.7
-        # :nocov:
-        # @private
-        def singleton_class
-          class << self; self; end
-        end
-        # :nocov:
       end
 
       # Raised when an RSpec API is called in the wrong scope, such as `before`

--- a/lib/rspec/core/flat_map.rb
+++ b/lib/rspec/core/flat_map.rb
@@ -2,16 +2,8 @@ module RSpec
   module Core
     # @private
     module FlatMap
-      if [].respond_to?(:flat_map)
-        def flat_map(array, &block)
-          array.flat_map(&block)
-        end
-      else # for 1.8.7
-        # :nocov:
-        def flat_map(array, &block)
-          array.map(&block).flatten(1)
-        end
-        # :nocov:
+      def flat_map(array, &block)
+        array.flat_map(&block)
       end
 
       module_function :flat_map

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -102,23 +102,12 @@ module RSpec
           end
         end
 
-        if String.method_defined?(:encoding)
-          def encoding_of(string)
-            string.encoding
-          end
+        def encoding_of(string)
+          string.encoding
+        end
 
-          def encoded_string(string)
-            RSpec::Support::EncodedString.new(string, Encoding.default_external)
-          end
-        else # for 1.8.7
-          # :nocov:
-          def encoding_of(_string)
-          end
-
-          def encoded_string(string)
-            RSpec::Support::EncodedString.new(string)
-          end
-          # :nocov:
+        def encoded_string(string)
+          RSpec::Support::EncodedString.new(string, Encoding.default_external)
         end
 
         def indent_lines(lines, failure_number)

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -385,16 +385,8 @@ EOS
                                 "#{hook_description} did not execute the example")
         end
 
-        if Proc.method_defined?(:source_location)
-          def hook_description
-            "around hook at #{Metadata.relative_path(block.source_location.join(':'))}"
-          end
-        else # for 1.8.7
-          # :nocov:
-          def hook_description
-            "around hook"
-          end
-          # :nocov:
+        def hook_description
+          "around hook at #{Metadata.relative_path(block.source_location.join(':'))}"
         end
       end
 

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -122,19 +122,6 @@ module RSpec
                                  MetadataFilter.apply?(@applies_predicate, item_meta, request_meta)
           end
         end
-
-        unless [].respond_to?(:each_with_object) # For 1.8.7
-          # :nocov:
-          undef items_for
-          def items_for(request_meta)
-            @items_and_filters.inject([]) do |to_return, (item, item_meta)|
-              to_return << item if item_meta.empty? ||
-                                   MetadataFilter.apply?(@applies_predicate, item_meta, request_meta)
-              to_return
-            end
-          end
-          # :nocov:
-        end
       end
 
       # This implementation is much more complex, and is optimized for
@@ -224,18 +211,6 @@ module RSpec
           metadata.each_with_object([]) do |(key, value), to_return|
             to_return << key if Proc === value
           end
-        end
-
-        unless [].respond_to?(:each_with_object) # For 1.8.7
-          # :nocov:
-          undef proc_keys_from
-          def proc_keys_from(metadata)
-            metadata.inject([]) do |to_return, (key, value)|
-              to_return << key if Proc === value
-              to_return
-            end
-          end
-          # :nocov:
         end
       end
     end

--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -141,8 +141,6 @@ module RSpec
       # @private
       class Registry
         def add(context, name, *metadata_args, &block)
-          ensure_block_has_source_location(block) { CallerFilter.first_non_rspec_line }
-
           if valid_name?(name)
             warn_if_key_taken context, name, block
             shared_example_groups[context][name] = block
@@ -192,17 +190,6 @@ module RSpec
 
         def formatted_location(block)
           block.source_location.join ":"
-        end
-
-        if Proc.method_defined?(:source_location)
-          def ensure_block_has_source_location(_block); end
-        else # for 1.8.7
-          # :nocov:
-          def ensure_block_has_source_location(block)
-            source_location = yield.split(':')
-            block.extend Module.new { define_method(:source_location) { source_location } }
-          end
-          # :nocov:
         end
       end
     end

--- a/lib/rspec/core/source.rb
+++ b/lib/rspec/core/source.rb
@@ -15,18 +15,9 @@ module RSpec
         new(source, path)
       end
 
-      if String.method_defined?(:encoding)
-        def initialize(source_string, path=nil)
-          @source = RSpec::Support::EncodedString.new(source_string, Encoding.default_external)
-          @path = path ? File.expand_path(path) : '(string)'
-        end
-      else # for 1.8.7
-        # :nocov:
-        def initialize(source_string, path=nil)
-          @source = RSpec::Support::EncodedString.new(source_string)
-          @path = path ? File.expand_path(path) : '(string)'
-        end
-        # :nocov:
+      def initialize(source_string, path=nil)
+        @source = RSpec::Support::EncodedString.new(source_string, Encoding.default_external)
+        @path = path ? File.expand_path(path) : '(string)'
       end
 
       def lines

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -185,10 +185,8 @@ module RSpec
           declaration_locations = FlatMap.flat_map(example_groups, &:declaration_locations)
           hash_of_arrays = Hash.new { |h, k| h[k] = [] }
 
-          # TODO: change `inject` to `each_with_object` when we drop 1.8.7 support.
-          line_nums_by_file = declaration_locations.inject(hash_of_arrays) do |hash, (file_name, line_number)|
+          line_nums_by_file = declaration_locations.each_with_object(hash_of_arrays) do |(file_name, line_number), hash|
             hash[file_name] << line_number
-            hash
           end
 
           line_nums_by_file.each_value do |list|

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_path     = "lib"
 
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.9'
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "cucumber", "~> 1.3"
   s.add_development_dependency "minitest", "~> 5.3"
-  s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
+  s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7 ###I need to look at this before shipping my PR
 
   s.add_development_dependency "coderay",  "~> 1.0.9"
 

--- a/script/regen_fixtures.sh
+++ b/script/regen_fixtures.sh
@@ -21,8 +21,7 @@ for ruby in \
   1.9.3-p392 \
   2.0.0-p247 \
   2.1.0-p0 \
-  rbx-2.2.3 \
-  ree-1.8.7-2012.02;
+  rbx-2.2.3;
 do
   switch_ruby $ruby
   ruby -v

--- a/spec/rspec/core/example_execution_result_spec.rb
+++ b/spec/rspec/core/example_execution_result_spec.rb
@@ -85,13 +85,10 @@ module RSpec
             expect(er.fetch(:foo) { 3 }).to eq(3)
           end
 
-          # It's IndexError on 1.8.7, KeyError on 1.9+
-          fetch_not_found_error_class = defined?(::KeyError) ? ::KeyError : ::IndexError
-
           specify '#fetch treats unset properties the same as a hash does' do
             allow_deprecation
             er = ExecutionResult.new
-            expect { er.fetch(:pending_message) }.to raise_error(fetch_not_found_error_class)
+            expect { er.fetch(:pending_message) }.to raise_error(::KeyError)
             er.pending_message = "some msg"
             expect(er.fetch(:pending_message)).to eq("some msg")
           end

--- a/spec/rspec/core/example_status_persister_spec.rb
+++ b/spec/rspec/core/example_status_persister_spec.rb
@@ -283,16 +283,6 @@ module RSpec::Core
         ./spec/integration/foo_spec.rb[1:2] | failed  |
       EOS
 
-      if RUBY_VERSION == '1.8.7' # unordered hashes :(.
-        produce_expected_output |= eq(unindent(<<-EOS))
-          status  | example_id                          |
-          ------- | ----------------------------------- |
-          passed  | ./spec/unit/foo_spec.rb[1:1]        |
-          pending | ./spec/unit/foo_spec.rb[1:2]        |
-          failed  | ./spec/integration/foo_spec.rb[1:2] |
-        EOS
-      end
-
       expect(dump(examples)).to produce_expected_output
     end
 
@@ -308,15 +298,6 @@ module RSpec::Core
         12       | 20 |
         120      | 2  |
       EOS
-
-      if RUBY_VERSION == '1.8.7' # unordered hashes :(.
-        produce_expected_output |= eq(unindent(<<-EOS))
-           a  | long_key |
-           -- | -------- |
-           20 | 12       |
-           2  | 120      |
-        EOS
-      end
 
       expect(dump(examples)).to produce_expected_output
     end

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -33,8 +33,7 @@ module RSpec::Core
           if @original_ivars.key?(ivar)
             Runner.instance_variable_set(ivar, @original_ivars[ivar])
           else
-            # send is necessary for 1.8.7
-            Runner.send(:remove_instance_variable, ivar)
+            Runner.remove_instance_variable(ivar)
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ Dir['./spec/support/**/*.rb'].map do |file|
 
   # Ensure requires are relative to `spec`, which is on the
   # load path. This helps prevent double requires on 1.8.7.
-  require file.gsub("./spec/support", "support")
+  require file
 end
 
 class RaiseOnFailuresReporter < RSpec::Core::NullReporter


### PR DESCRIPTION
Quick spike that drops support[1] for Ruby 1.8.7 in rspec-core.

1.) https://github.com/rspec/rspec-core/issues/2124