### PR TITLE
Include SPEC_OPTS in bisect reproduction command

### DIFF
--- a/features/command_line/bisect.feature
+++ b/features/command_line/bisect.feature
@@ -1,3 +1,4 @@
+@with-clean-spec-opts
 Feature: Bisect
 
   RSpec's `--order random` and `--seed` options help surface flickering examples that only fail when one or more other examples are executed first. It can be very difficult to isolate the exact combination of examples that triggers the failure. The `--bisect` flag helps solve that problem.

--- a/features/support/require_expect_syntax_in_aruba_specs.rb
+++ b/features/support/require_expect_syntax_in_aruba_specs.rb
@@ -1,6 +1,6 @@
 if defined?(Cucumber)
   require 'shellwords'
-  Before('~@allow-should-syntax') do
+  Before('~@allow-should-syntax', '~@with-clean-spec-opts') do
     set_env('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
   end
 

--- a/lib/rspec/core/bisect/runner.rb
+++ b/lib/rspec/core/bisect/runner.rb
@@ -38,6 +38,7 @@ module RSpec
         def repro_command_from(locations)
           parts = []
 
+          parts.concat environment_repro_parts
           parts << "rspec"
           parts.concat Formatters::Helpers.organize_ids(locations)
           parts.concat original_cli_args_without_locations
@@ -100,6 +101,12 @@ module RSpec
             { 'SPEC_OPTS' => spec_opts_without_bisect }
           else
             {}
+          end
+        end
+
+        def environment_repro_parts
+          bisect_environment_hash.map do |k, v|
+            %Q(#{k}="#{v}")
           end
         end
 

--- a/spec/rspec/core/bisect/runner_spec.rb
+++ b/spec/rspec/core/bisect/runner_spec.rb
@@ -167,6 +167,13 @@ module RSpec::Core
         expect(cmd).to include("--seed 1234").and exclude("spec/unit ")
       end
 
+      it 'includes the original SPEC_OPTS but excludes the --bisect flag' do
+        with_env_vars('SPEC_OPTS' => '--bisect --seed 1234') do
+          cmd = repro_command_from(%w[ ./spec/unit/1_spec.rb[1:1] ])
+          expect(cmd).to include('SPEC_OPTS="--seed 1234"').and exclude("--bisect")
+        end
+      end
+
       it 'includes original options that `command_for` excludes' do
         original_cli_args << "--format" << "progress"
         expect(runner.command_for(%w[ ./foo.rb[1:1] ])).to exclude("--format progress")


### PR DESCRIPTION
Previously the following command:

    SPEC_OPTS="--bisect --seed 123" rspec blah_spec.rb

would return a repro command something like:

    rspec blah_spec.rb[1:2,1:5]

To reliably run in the correct order, we need to include the seed from SPEC_OPTS - this patch adds this to the repro command, to now return:

    SPEC_OPTS="--seed 123" rspec blah_spec.rb[1:2,1:5]

To keep the cukes passing I've had to exclude the bisect feature from the `should`/`should_not` prevention; this uses SPEC_OPTS to load a support file, which then shows up in the repro command produced by the cukes.

Rather than add the `@allow-should-syntax` tag to these cukes I've introduced a new `@with-clean-spec-opts` tag to try to communicate the intention better, even though it just controls the same hook as the existing tag. Does that seem reasonable?