### PR TITLE
Add helpful warning message for shared example groups

### DIFF
--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -69,7 +69,7 @@ module RSpec
             expect(Kernel).to_not respond_to(shared_method_name)
           end
 
-          it "displays a warning when adding a second shared example group with the same name" do
+          it 'displays a warning when adding a second shared example group with the same name' do
             group.send(shared_method_name, 'some shared group') {}
             original_declaration = [__FILE__, __LINE__ - 1].join(':')
 
@@ -79,6 +79,22 @@ module RSpec
             group.send(shared_method_name, 'some shared group') {}
             second_declaration = [__FILE__, __LINE__ - 1].join(':')
             expect(warning).to include('some shared group', original_declaration, second_declaration)
+            expect(warning).to_not include 'Called from'
+          end
+
+          it 'displays a helpful message when you define a shared example group in *_spec.rb file' do
+            warning = nil
+            allow(::Kernel).to receive(:warn) { |msg| warning = msg }
+            declaration = nil
+
+            2.times do
+              group.send(shared_method_name, 'some shared group') {}
+              declaration = [__FILE__, __LINE__ - 1].join(':')
+              RSpec.configuration.loaded_spec_files << declaration
+            end
+
+            better_error = 'was automatically loaded by RSpec because the file name'
+            expect(warning).to include('some shared group', declaration, better_error)
             expect(warning).to_not include 'Called from'
           end
 


### PR DESCRIPTION
I found myself with a strange warning message not long ago saying the following:
```
WARNING: Shared example group 'a flagger_or_tagger' has been previously defined
at:
  /Users/devoncestes/esh/IRT/spec/services/shared_examples/flagger_or_tagger_spec.rb:10
...and you are now defining it at:
  /Users/devoncestes/esh/IRT/spec/services/shared_examples/flagger_or_tagger_spec.rb:10
The new definition will overwrite the original one.
```

Turns out that this was happening because the file in which we defined our
shared example group ended in `_spec.rb`, which triggered the Rspec auto
loading, thus creating the strange warning. I had no idea how this could happen
until I opened up an issue (#2277) and @myronmarston pointed out the error.
I figured that a helpful warning message that could guide the user to fixing
this warning themselves might be good to add, so I've done so here!