### PR TITLE
Use ExampleGroup.descendant_filtered_examples to count example to be run

### DIFF
--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -78,8 +78,7 @@ module RSpec
       #
       # Get count of examples to be run.
       def example_count(groups=example_groups)
-        FlatMap.flat_map(groups) { |g| g.descendants }.
-          inject(0) { |a, e| a + e.filtered_examples.size }
+        FlatMap.flat_map(groups).inject(0) { |a, e| a + e.descendant_filtered_examples.size }
       end
 
       # @private

--- a/spec/rspec/core/suite_hooks_spec.rb
+++ b/spec/rspec/core/suite_hooks_spec.rb
@@ -84,7 +84,7 @@ module RSpec::Core
       include_context "Runner support"
 
       def define_and_run_example_group(&block)
-        example_group = class_double(ExampleGroup, :descendants => [])
+        example_group = class_double(ExampleGroup, :descendant_filtered_examples => [])
 
         allow(example_group).to receive(:run, &block)
         allow(world).to receive_messages(:ordered_example_groups => [example_group])

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -22,6 +22,30 @@ module RSpec::Core
       end
     end
 
+    describe "#examples_count" do
+      before do
+        configuration.filter_run_including :foo => "bar"
+      end
+
+      it "returns examples count that includes shared examples" do
+        RSpec.describe "eg1" do
+          shared_context "sc1", :foo do
+          end
+
+          shared_examples "se1" do
+            example("ex1")
+            example("ex2", :foo => "bar")
+          end
+
+          context "nested" do
+            include_examples "se1"
+          end
+        end
+
+        expect(RSpec.world.example_count).to eq 1
+      end
+    end
+
     describe "#all_example_groups" do
       it "contains all example groups from all levels of nesting" do
         RSpec.describe "eg1" do


### PR DESCRIPTION
`RSpec.world.example_count` returns smaller number for this pull request's `spec/rspec/core/world_spec.rb` case.

`RSpec.world.example_count` is used in create StartNotification.
When `RSpec.world.example_count` returns smaller number than actual examples count, I've got [fuubar](https://github.com/thekompanee/fuubar) reporter warning like below:

> WARNING: Your progress bar is currently at 6 out of 6 and cannot be incremented. In v2.0.0 this will become a ProgressBar::InvalidProgressError.
>  6/6 |====================================== 100 ======================================>| Time: 00:00:03
