### PR TITLE
Fill in execution_status before reporting example_finished.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ Enhancements:
 * Warn when duplicate shared exmaples definitions are loaded due to being
   defined in files matching the spec pattern (e.g. `_spec.rb`) (#2278, Devon Estes)
 
+Bug Fixes:
+
+* Wait to report `example_finished` until the example's `execution_result`
+  has been completely filled in. (Myron Marston, #2291)
+
 ### 3.5.1 / 2016-07-06
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.5.0...v3.5.1)
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -461,15 +461,14 @@ module RSpec
       def finish(reporter)
         pending_message = execution_result.pending_message
 
-        reporter.example_finished(self)
         if @exception
-          record_finished :failed
           execution_result.exception = @exception
+          record_finished :failed
           reporter.example_failed self
           false
         elsif pending_message
-          record_finished :pending
           execution_result.pending_message = pending_message
+          record_finished :pending
           reporter.example_pending self
           true
         else
@@ -481,6 +480,7 @@ module RSpec
 
       def record_finished(status)
         execution_result.record_finished(status, clock.now)
+        reporter.example_finished(self)
       end
 
       def run_before_example


### PR DESCRIPTION
Fixes #2290.