### PR TITLE
Improve and simplify metadata filtering.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ Enhancements:
 
 * Warn when duplicate shared exmaples definitions are loaded due to being
   defined in files matching the spec pattern (e.g. `_spec.rb`) (#2278, Devon Estes)
+* Improve metadata filtering so that it can match against any object
+  that implements `===` instead of treating regular expressions as
+  special. (Myron Marston, #2294)
 
 Bug Fixes:
 

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -13,24 +13,19 @@ module RSpec
         end
 
         # @private
-        def filter_applies?(key, value, metadata)
+        def filter_applies?(key, filter_value, metadata)
           silence_metadata_example_group_deprecations do
-            return location_filter_applies?(value, metadata) if key == :locations
-            return id_filter_applies?(value, metadata)       if key == :ids
-            return filters_apply?(key, value, metadata)      if Hash === value
+            return location_filter_applies?(filter_value, metadata) if key == :locations
+            return id_filter_applies?(filter_value, metadata)       if key == :ids
+            return filters_apply?(key, filter_value, metadata)      if Hash === filter_value
 
-            return false unless metadata.key?(key)
-            return true if TrueClass === value && !!metadata[key]
-            return filter_applies_to_any_value?(key, value, metadata) if Array === metadata[key] && !(Proc === value)
+            meta_value = metadata.fetch(key) { return false }
 
-            case value
-            when Regexp
-              metadata[key] =~ value
-            when Proc
-              proc_filter_applies?(key, value, metadata)
-            else
-              metadata[key].to_s == value.to_s
-            end
+            return true if TrueClass === filter_value && !!meta_value
+            return proc_filter_applies?(key, filter_value, metadata) if Proc === filter_value
+            return filter_applies_to_any_value?(key, filter_value, metadata) if Array === meta_value
+
+            filter_value === meta_value || filter_value.to_s == meta_value.to_s
           end
         end
 

--- a/spec/rspec/core/metadata_filter_spec.rb
+++ b/spec/rspec/core/metadata_filter_spec.rb
@@ -107,6 +107,16 @@ module RSpec
           }.to raise_error(ArgumentError)
         end
 
+        it "matches an arbitrary object that has implemented `===` for matching" do
+          matcher = Object.new
+          def matcher.===(str)
+            str.include?("T")
+          end
+
+          expect(filter_applies?(:foo, matcher, {:foo => "a sing"})).to be false
+          expect(filter_applies?(:foo, matcher, {:foo => "a sTring"})).to be true
+        end
+
         context "with an :ids filter" do
           it 'matches examples with a matching id and rerun_file_path' do
             metadata = { :scoped_id => "1:2", :rerun_file_path => "some/file" }


### PR DESCRIPTION
- Get the value from the metadata hash only once instead of
  multiple times using `metadata[key]`.
- Try `===` method instead of treating regular expressions
  as special.