### PR TITLE
Improve output from `rspec -v`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Enhancements:
 * Improve metadata filtering so that it can match against any object
   that implements `===` instead of treating regular expressions as
   special. (Myron Marston, #2294)
+* Improve `rspec -v` so that it prints out the versions of each part of
+  RSpec to prevent confusion. (Myron Marston, #2304)
 
 Bug Fixes:
 

--- a/lib/rspec/core/invocations.rb
+++ b/lib/rspec/core/invocations.rb
@@ -49,7 +49,25 @@ module RSpec
       # @private
       class PrintVersion
         def call(_options, _err, out)
-          out.puts RSpec::Core::Version::STRING
+          overall_version = RSpec::Core::Version::STRING
+          unless overall_version =~ /[a-zA-Z]+/
+            overall_version = overall_version.split('.').first(2).join('.')
+          end
+
+          out.puts "RSpec #{overall_version}"
+
+          [:Core, :Expectations, :Mocks, :Rails, :Support].each do |const_name|
+            lib_name = const_name.to_s.downcase
+            begin
+              require "rspec/#{lib_name}/version"
+            rescue LoadError
+              # Not worth mentioning libs that are not installed
+              nil
+            else
+              out.puts "  - rspec-#{lib_name} #{RSpec.const_get(const_name)::Version::STRING}"
+            end
+          end
+
           0
         end
       end


### PR DESCRIPTION
Before this change, this confusing thing could happen:

```
$ gem install rspec -v 3.5.0 > /dev/null; rspec -v
3.5.1
```

The user installed RSpec 3.5.0 but `rspec -v` prints 3.5.1.
This happened because 3.5.0 of the rspec gem depends on 3.5.x
of all the sub-gems, and 3.5.1 is the latest rspec-core.

With this change, it now prints something like:

```
$ rspec -v
RSpec 3.5
  - rspec-core 3.5.1
  - rspec-expectations 3.5.0
  - rspec-mocks 3.5.0
  - rspec-rails not installed
  - rspec-support 3.5.0
```