### PR TITLE
Don't include default pattern when user specifies their own in Rake task.

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -102,6 +102,7 @@ module RSpec
         if ENV['SPEC']
           FileList[ENV['SPEC']].sort
         elsif String === pattern && !File.exist?(pattern)
+          return if rspec_opts =~ /--pattern/
           "--pattern #{escape pattern}"
         else
           # Before RSpec 3.1, we used `FileList` to get the list of matched

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -66,6 +66,13 @@ module RSpec::Core
         task.rspec_opts = "-Ifoo"
         expect(spec_command).to match(/#{task.rspec_path}.*-Ifoo/)
       end
+
+      it 'correctly excludes the default pattern if rspec_opts includes --pattern' do
+        task.rspec_opts = "--pattern some_specs"
+        expect(spec_command).to include("--pattern some_specs").and(
+          exclude(RSpec::Core::RakeTask::DEFAULT_PATTERN)
+        )
+      end
     end
 
     context "with pattern" do


### PR DESCRIPTION
When configuring rspec via Rake task and a developer specifies a pattern via rspec_opts, don't include the default pattern. Should fix #2303.