### PR TITLE
Revise how conflicted metadata is handled when applying shared group metadata

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,13 @@ Enhancements:
 * Add `config.fail_if_no_examples` option which causes RSpec to fail if
   no examples are found. (Ewa Czechowska, #2302)
 
+Bug Fixes:
+
+* When applying shared group metadata to a host group, overwrite
+  conflicting keys if the value in the host group was inherited from
+  a parent group instead of being specified at that level.
+  (Myron Marston, #2307)
+
 ### 3.5.2 / 2016-07-28
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.5.1...v3.5.2)
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -415,10 +415,10 @@ module RSpec
         # not be applied where they should.
         registration_collection << self
 
-        user_metadata = Metadata.build_hash_from(args)
+        @user_metadata = Metadata.build_hash_from(args)
 
         @metadata = Metadata::ExampleGroupHash.create(
-          superclass_metadata, user_metadata,
+          superclass_metadata, @user_metadata,
           superclass.method(:next_runnable_index_for),
           description, *args, &example_group_block
         )
@@ -705,8 +705,8 @@ module RSpec
 
       # @private
       def self.update_inherited_metadata(updates)
-        metadata.update(updates) do |_key, existing_group_value, _new_inherited_value|
-          existing_group_value
+        metadata.update(updates) do |key, existing_group_value, new_inherited_value|
+          @user_metadata.key?(key) ? existing_group_value : new_inherited_value
         end
 
         RSpec.configuration.configure_group(self)

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1542,12 +1542,24 @@ module RSpec::Core
         expect(group.metadata).to include(:foo => 1, :bar => 2)
       end
 
-      it "does not overwrite existing metadata since group metadata takes precedence over inherited metadata" do
+      it "does not overwrite existing metadata originating from that level" do
         group = RSpec.describe("group", :foo => 1)
 
         expect {
           group.update_inherited_metadata(:foo => 2)
         }.not_to change { group.metadata[:foo] }.from(1)
+      end
+
+      it "overwrites metadata originating from a parent" do
+        group = nil
+        RSpec.describe("group", :foo => 1) do
+          group = context do
+          end
+        end
+
+        expect {
+          group.update_inherited_metadata(:foo => 2)
+        }.to change { group.metadata[:foo] }.from(1).to(2)
       end
 
       it "does not replace the existing metadata object with a new one or change its default proc" do

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -458,7 +458,7 @@ module RSpec
             expect(value).to be(String)
           end
 
-          it "can override a parent group's described class using metdata" do
+          it "can override a parent group's described class using metadata" do
             parent_value = child_value = grandchild_value = nil
 
             RSpec.describe(String) do

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -221,7 +221,7 @@ module RSpec
               ))
             end
 
-            it "does not overwrite existing metdata values set at that level when included via `include_context`" do
+            it "does not overwrite existing metadata values set at that level when included via `include_context`" do
               shared_ex_metadata = nil
               host_ex_metadata = nil
 
@@ -238,7 +238,7 @@ module RSpec
               expect(shared_ex_metadata[:foo]).to eq :host
             end
 
-            it "overwrites existing metdata values set at a parent level when included via `include_context`" do
+            it "overwrites existing metadata values set at a parent level when included via `include_context`" do
               shared_ex_metadata = nil
               host_ex_metadata = nil
 

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -220,6 +220,59 @@ module RSpec
                 {:foo => 1}.inspect
               ))
             end
+
+            it "does not overwrite existing metdata values set at that level when included via `include_context`" do
+              shared_ex_metadata = nil
+              host_ex_metadata = nil
+
+              define_top_level_shared_group("name", :foo => :shared) do
+                it { |ex| shared_ex_metadata = ex.metadata }
+              end
+
+              describe_successfully("Group", :foo => :host) do
+                include_context "name"
+                it { |ex| host_ex_metadata = ex.metadata }
+              end
+
+              expect(host_ex_metadata[:foo]).to eq :host
+              expect(shared_ex_metadata[:foo]).to eq :host
+            end
+
+            it "overwrites existing metdata values set at a parent level when included via `include_context`" do
+              shared_ex_metadata = nil
+              host_ex_metadata = nil
+
+              define_top_level_shared_group("name", :foo => :shared) do
+                it { |ex| shared_ex_metadata = ex.metadata }
+              end
+
+              describe_successfully("Group", :foo => :host) do
+                context "nested" do
+                  include_context "name"
+                  it { |ex| host_ex_metadata = ex.metadata }
+                end
+              end
+
+              expect(host_ex_metadata[:foo]).to eq :shared
+              expect(shared_ex_metadata[:foo]).to eq :shared
+            end
+
+            it "propagates conflicted metadata to examples defined in the shared group when included via `it_behaves_like` since it makes a nested group" do
+              shared_ex_metadata = nil
+              host_ex_metadata = nil
+
+              define_top_level_shared_group("name", :foo => :shared) do
+                it { |ex| shared_ex_metadata = ex.metadata }
+              end
+
+              describe_successfully("Group", :foo => :host) do
+                it_behaves_like "name"
+                it { |ex| host_ex_metadata = ex.metadata }
+              end
+
+              expect(host_ex_metadata[:foo]).to eq :host
+              expect(shared_ex_metadata[:foo]).to eq :shared
+            end
           end
 
           context "when the group is included via `config.include_context` and matching metadata" do


### PR DESCRIPTION
Previously, when applying shared group metadata to a host, if there were
any conflicts, the host group metadata would take precedence, but this
created some counterintuitive behavior.  For example, in a case like
this:

``` ruby
RSpec.shared_examples_for "model stuff", db: true do
  it "does something using the DB" do
    # ...
  end
end

RSpec.describe "Some cross cutting concern", db: false do
  it_behaves_like "model stuff"
end
```

...the example from the shared group would NOT have `db: true` metadata
in spite of the fact that `it_behaves_like` creates a nested group and
if you manually created a nested group at that spot with `:db`, it would
take precedence over the outer `db: false` metadata.

With this change, metadata applied from a shared group takes precedence
over host group metadata if the conflicted value was inherited from a
parent group. If the conflicted value was set directly on the host
group, it still takes precedence.

Fixes #2306.

@rspec/rspec: there's definitely room for interpretation in how this should work and I'm not 100% sure this is the behavior we want but I think it's the most reasonable and the most consistent with our metadata inheritance usually works.  Thoughts?