### PR TITLE
Handle errors in :suite hooks.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,8 @@ Bug Fixes:
   conflicting keys if the value in the host group was inherited from
   a parent group instead of being specified at that level.
   (Myron Marston, #2307)
+* Handle errors in `:suite` hooks and provided the same nicely formatted
+  output as errors that happen in examples. (Myron Marston, #2316)
 
 ### 3.5.2 / 2016-07-28
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.5.1...v3.5.2)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1835,12 +1835,11 @@ module RSpec
       def with_suite_hooks
         return yield if dry_run?
 
-        hook_context = SuiteHookContext.new
         begin
-          run_hooks_with(@before_suite_hooks, hook_context)
+          run_suite_hooks("a `before(:suite)` hook", @before_suite_hooks)
           yield
         ensure
-          run_hooks_with(@after_suite_hooks, hook_context)
+          run_suite_hooks("an `after(:suite)` hook", @after_suite_hooks)
         end
       end
 
@@ -1880,8 +1879,16 @@ module RSpec
         yield
       end
 
-      def run_hooks_with(hooks, hook_context)
-        hooks.each { |h| h.run(hook_context) }
+      def run_suite_hooks(hook_description, hooks)
+        context = SuiteHookContext.new(hook_description, reporter)
+
+        hooks.each do |hook|
+          begin
+            hook.run(context)
+          rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
+            context.set_exception(ex)
+          end
+        end
       end
 
       def get_files_to_run(paths)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1887,6 +1887,12 @@ module RSpec
             hook.run(context)
           rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
             context.set_exception(ex)
+
+            # Do not run subsequent `before` hooks if one fails.
+            # But for `after` hooks, we run them all so that all
+            # cleanup bits get a chance to complete, minimizing the
+            # chance that resources get left behind.
+            break if hooks.equal?(@before_suite_hooks)
           end
         end
       end

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -632,16 +632,16 @@ module RSpec
     # @private
     # Provides an execution context for before/after :suite hooks.
     class SuiteHookContext < Example
-      def initialize
-        super(AnonymousExampleGroup, "", {})
+      def initialize(hook_description, reporter)
+        super(AnonymousExampleGroup, hook_description, {})
         @example_group_instance = AnonymousExampleGroup.new
+        @reporter = reporter
       end
 
       # rubocop:disable Style/AccessorMethodName
-
-      # To ensure we don't silence errors.
       def set_exception(exception)
-        raise exception
+        reporter.notify_non_example_exception(exception, "An error occurred in #{description}.")
+        RSpec.world.wants_to_quit = true
       end
       # rubocop:enable Style/AccessorMethodName
     end

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -122,7 +122,8 @@ module RSpec
         end
 
         def indent_lines(lines, failure_number)
-          alignment_basis = "#{' ' * @indentation}#{failure_number}) "
+          alignment_basis = ' ' * @indentation
+          alignment_basis <<  "#{failure_number}) " if failure_number
           indentation = ' ' * alignment_basis.length
 
           lines.each_with_index.map do |line, index|

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -178,6 +178,7 @@ module RSpec
 
         def build_description_from(parent_description=nil, my_description=nil)
           return parent_description.to_s unless my_description
+          return my_description.to_s if parent_description.to_s == ''
           separator = description_separator(parent_description, my_description)
           (parent_description.to_s + separator) << my_description.to_s
         end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -51,8 +51,7 @@ module RSpec::Core
                   FailedExampleNotification
                 end
 
-        exception_presenter = Formatters::ExceptionPresenter::Factory.new(example).build
-        klass.new(example, exception_presenter)
+        klass.new(example)
       end
 
       private_class_method :new
@@ -202,7 +201,7 @@ module RSpec::Core
 
     private
 
-      def initialize(example, exception_presenter)
+      def initialize(example, exception_presenter=Formatters::ExceptionPresenter::Factory.new(example).build)
         @exception_presenter = exception_presenter
         super(example)
       end

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -156,6 +156,8 @@ module RSpec::Core
     # particular exception (such as an exception encountered in a :suite hook).
     # Exceptions will be formatted the same way they normally are.
     def notify_non_example_exception(exception, context_description)
+      @configuration.world.non_example_failure = true
+
       example = Example.new(AnonymousExampleGroup, context_description, {})
       presenter = Formatters::ExceptionPresenter.new(exception, example, :indentation => 0)
       message presenter.fully_formatted(nil)

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -152,6 +152,16 @@ module RSpec::Core
     end
 
     # @private
+    # Provides a way to notify of an exception that is not tied to any
+    # particular exception (such as an exception encountered in a :suite hook).
+    # Exceptions will be formatted the same way they normally are.
+    def notify_non_example_exception(exception, context_description)
+      example = Example.new(AnonymousExampleGroup, context_description, {})
+      presenter = Formatters::ExceptionPresenter.new(exception, example, :indentation => 0)
+      message presenter.fully_formatted(nil)
+    end
+
+    # @private
     def finish
       close_after do
         stop

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -153,7 +153,7 @@ module RSpec::Core
 
     # @private
     # Provides a way to notify of an exception that is not tied to any
-    # particular exception (such as an exception encountered in a :suite hook).
+    # particular example (such as an exception encountered in a :suite hook).
     # Exceptions will be formatted the same way they normally are.
     def notify_non_example_exception(exception, context_description)
       @configuration.world.non_example_failure = true

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -109,14 +109,17 @@ module RSpec
       #   failed.
       def run_specs(example_groups)
         examples_count = @world.example_count(example_groups)
-        @configuration.reporter.report(examples_count) do |reporter|
+        success = @configuration.reporter.report(examples_count) do |reporter|
           @configuration.with_suite_hooks do
             if examples_count == 0 && @configuration.fail_if_no_examples
               return @configuration.failure_exit_code
             end
-            example_groups.map { |g| g.run(reporter) }.all? ? 0 : @configuration.failure_exit_code
+
+            example_groups.map { |g| g.run(reporter) }.all?
           end
-        end
+        end && !@world.non_example_failure
+
+        success ? 0 : @configuration.failure_exit_code
       end
 
     private

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -10,6 +10,12 @@ module RSpec
       # Used internally to determine what to do when a SIGINT is received.
       attr_accessor :wants_to_quit
 
+      # Used internally to signal that a failure outside of an example
+      # has occurred, and that therefore the exit status should indicate
+      # the run failed.
+      # @private
+      attr_accessor :non_example_failure
+
       def initialize(configuration=RSpec.configuration)
         @configuration = configuration
         configuration.world = self
@@ -224,6 +230,9 @@ module RSpec
       # @private
       # Provides a null implementation for initial use by configuration.
       module Null
+        def self.non_example_failure; end
+        def self.non_example_failure=(_); end
+
         def self.registered_example_group_files
           []
         end

--- a/spec/integration/suite_hooks_errors_spec.rb
+++ b/spec/integration/suite_hooks_errors_spec.rb
@@ -1,0 +1,139 @@
+require 'support/aruba_support'
+require 'support/formatter_support'
+
+RSpec.describe 'Suite hook errors' do
+  include_context "aruba support"
+  include FormatterSupport
+
+  let(:failure_exit_code) { rand(97) + 2 } # 2..99
+
+  if RSpec::Support::Ruby.jruby_9000?
+    let(:spec_line_suffix) { ":in `block in (root)'" }
+  elsif RSpec::Support::Ruby.jruby?
+    let(:spec_line_suffix) { ":in `(root)'" }
+  elsif RUBY_VERSION == "1.8.7"
+    let(:spec_line_suffix) { "" }
+  else
+    let(:spec_line_suffix) { ":in `block (2 levels) in <top (required)>'" }
+  end
+
+  before do
+    # get out of `aruba` sub-dir so that `filter_gems_from_backtrace 'aruba'`
+    # below does not filter out our spec file.
+    expect(dirs.pop).to eq "aruba"
+
+    clean_current_dir
+
+    RSpec.configure do |c|
+      c.filter_gems_from_backtrace "aruba"
+      c.backtrace_exclusion_patterns << %r{/rspec-core/spec/} << %r{rspec_with_simplecov}
+      c.failure_exit_code = failure_exit_code
+    end
+  end
+
+  def run_spec_expecting_non_zero(before_or_after)
+    write_file "the_spec.rb", "
+      RSpec.configure do |c|
+        c.#{before_or_after}(:suite) do
+          raise 'boom'
+        end
+      end
+
+      RSpec.describe do
+        it { }
+      end
+    "
+
+    run_command "the_spec.rb"
+    expect(last_cmd_exit_status).to eq(failure_exit_code)
+    normalize_durations(last_cmd_stdout)
+  end
+
+  it 'nicely formats errors in `before(:suite)` hooks and exits with non-zero' do
+    output = run_spec_expecting_non_zero(:before)
+    expect(output).to eq unindent(<<-EOS)
+
+      An error occurred in a `before(:suite)` hook.
+      Failure/Error: raise 'boom'
+
+      RuntimeError:
+        boom
+      # ./the_spec.rb:4#{spec_line_suffix}
+
+
+      Finished in n.nnnn seconds (files took n.nnnn seconds to load)
+      0 examples, 0 failures
+    EOS
+  end
+
+  it 'nicely formats errors in `after(:suite)` hooks and exits with non-zero' do
+    output = run_spec_expecting_non_zero(:after)
+    expect(output).to eq unindent(<<-EOS)
+      .
+      An error occurred in an `after(:suite)` hook.
+      Failure/Error: raise 'boom'
+
+      RuntimeError:
+        boom
+      # ./the_spec.rb:4#{spec_line_suffix}
+
+
+      Finished in n.nnnn seconds (files took n.nnnn seconds to load)
+      1 example, 0 failures
+    EOS
+  end
+
+  it 'nicely formats errors from multiple :suite hooks of both types and exits with non-zero' do
+    write_file "the_spec.rb", "
+      RSpec.configure do |c|
+        c.before(:suite) { raise 'before 1' }
+        c.before(:suite) { raise 'before 2' }
+        c.after(:suite) { raise 'after 1' }
+        c.after(:suite) { raise 'after 2' }
+      end
+
+      RSpec.describe do
+        it { }
+      end
+    "
+
+    run_command "the_spec.rb"
+    expect(last_cmd_exit_status).to eq(failure_exit_code)
+    output = normalize_durations(last_cmd_stdout)
+
+    expect(output).to eq unindent(<<-EOS)
+
+      An error occurred in a `before(:suite)` hook.
+      Failure/Error: c.before(:suite) { raise 'before 1' }
+
+      RuntimeError:
+        before 1
+      # ./the_spec.rb:3#{spec_line_suffix}
+
+      An error occurred in a `before(:suite)` hook.
+      Failure/Error: c.before(:suite) { raise 'before 2' }
+
+      RuntimeError:
+        before 2
+      # ./the_spec.rb:4#{spec_line_suffix}
+
+      An error occurred in an `after(:suite)` hook.
+      Failure/Error: c.after(:suite) { raise 'after 2' }
+
+      RuntimeError:
+        after 2
+      # ./the_spec.rb:6#{spec_line_suffix}
+
+      An error occurred in an `after(:suite)` hook.
+      Failure/Error: c.after(:suite) { raise 'after 1' }
+
+      RuntimeError:
+        after 1
+      # ./the_spec.rb:5#{spec_line_suffix}
+
+
+      Finished in n.nnnn seconds (files took n.nnnn seconds to load)
+      0 examples, 0 failures
+    EOS
+  end
+end

--- a/spec/integration/suite_hooks_errors_spec.rb
+++ b/spec/integration/suite_hooks_errors_spec.rb
@@ -110,13 +110,6 @@ RSpec.describe 'Suite hook errors' do
         before 1
       # ./the_spec.rb:3#{spec_line_suffix}
 
-      An error occurred in a `before(:suite)` hook.
-      Failure/Error: c.before(:suite) { raise 'before 2' }
-
-      RuntimeError:
-        before 2
-      # ./the_spec.rb:4#{spec_line_suffix}
-
       An error occurred in an `after(:suite)` hook.
       Failure/Error: c.after(:suite) { raise 'after 2' }
 

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -51,6 +51,18 @@ module RSpec::Core
         EOS
       end
 
+      it "prints no identifier when no number argument is given" do
+        expect(presenter.fully_formatted(nil)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |  Example
+          |  Failure/Error: # The failure happened here!#{ encoding_check }
+          |
+          |    Boom
+          |    Bam
+          |  # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
+
       it "allows the caller to specify additional indentation" do
         the_presenter = Formatters::ExceptionPresenter.new(exception, example, :indentation => 4)
 

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -550,6 +550,26 @@ module RSpec
           end
         end
 
+        it "omits description from groups with a `nil` description" do
+          value = nil
+
+          RSpec.describe do
+            value = example("example").metadata[:full_description]
+          end
+
+          expect(value).to eq("example")
+        end
+
+        it "omits description from groups with a description of `''`" do
+          value = nil
+
+          RSpec.describe "" do
+            value = example("example").metadata[:full_description]
+          end
+
+          expect(value).to eq("example")
+        end
+
         it "concats nested example group descriptions" do
           group_value = example_value = nil
 

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -280,5 +280,27 @@ module RSpec::Core
         reporter.finish
       end
     end
+
+    describe "#notify_non_example_exception" do
+      it "sends a `message` notification that contains the formatted exception details" do
+        formatter_out = StringIO.new
+        formatter = Formatters::ProgressFormatter.new(formatter_out)
+        reporter.register_listener formatter, :message
+
+        line = __LINE__ + 1
+        exception = 1 / 0 rescue $!
+        reporter.notify_non_example_exception(exception, "NonExample Context")
+
+        expect(formatter_out.string).to start_with(<<-EOS.gsub(/^ +\|/, '').chomp)
+          |
+          |NonExample Context
+          |Failure/Error: exception = 1 / 0 rescue $!
+          |
+          |ZeroDivisionError:
+          |  divided by 0
+          |# #{Metadata.relative_path(__FILE__)}:#{line}
+        EOS
+      end
+    end
   end
 end

--- a/spec/rspec/core/suite_hooks_spec.rb
+++ b/spec/rspec/core/suite_hooks_spec.rb
@@ -41,10 +41,17 @@ module RSpec::Core
         end
 
         it 'allows access to rspec-expectation methods within the hook' do
-          RSpec.configuration.__send__(registration_method, :suite) { expect(true).to be false }
-          expect {
+          notified_failure = nil
+
+          RSpec::Support.with_failure_notifier(lambda { |e, _opts| notified_failure = e }) do
+            RSpec.configuration.__send__(registration_method, :suite) do
+              expect(true).to be false
+            end
+
             RSpec.configuration.with_suite_hooks { }
-          }.to raise_error RSpec::Expectations::ExpectationNotMetError
+          end
+
+          expect(notified_failure).to be_a(RSpec::Expectations::ExpectationNotMetError)
         end
 
         context "registered on an example group" do


### PR DESCRIPTION
Previously, we just allowed the error to propagate to the user, which was a subpar experience for a few reasons:

- The error would cause RSpec to crash, leading to a long stack trace containing lots of extraneous info the user did not see.
- The error was not formatted nicely like other errors that happen while RSpec runs.
- If the error happened in an `after(:suite)` hook, the test suite had finished running all specs but the summary of the results would not get printed since RSpec had crashed.

Now, we handle errors in :suite hooks and format the output the same way failures and errors are normally printed.

Notes/open questions:

- The first 4 commits are refactoring commits that pave the way for this change.  If desired, I can put those into a separate PR so it can be reviewed and merged separately, then this PR can be rebased on top. (Whoever reviews this, please let me know if you'd like me to do that).
- There are a few other things I'm thinking of giving this kind of treatment:
  - Errors raised while loading spec files: instead of crashing RSpec, have it print a nice failure like we do here.
  - Errors raised in `after(:context)` hooks.  Right now the output for these is not nice.  If we have errors there notify via the new reporter method I've added in this PR, it'll solve #2084 w/o the introduction of a config option as discussed there.  It could be considered a breaking change, though, although it would be reasonable to consider it a bug that RSpec exits with 0 when all specs pass and an `after(:context)` hook fails.
- I decided to hold off on these additional changes for now -- they can be in later PRs.
- The changes here (and in any followup PRs for `after(:context)` and load-time errors) are a bit ambiguous in terms of SemVer.  I could see an argument for treating them as bug fixes (e.g. RSpec didn't handle errors in these situations properly before, allowing them to crash RSpec) or as enhancements (we're improving error reporting in these situations) or as a breaking change (in the case of `after(:context)` -- it's a situation where the suite for some users currently passes but would be reported as failing if we make that change).  For now I put this as a bug fix in the changelog.
- This change was prompted by running into this for the new RSpec book I'm working on, and I need this in a release before the book is done (but not necessarily the changes for `after(:context` and load-time errors).  It'd be nice to get this in 3.5.x so I can update the book to take advantage right away, instead of waiting for 3.6.

/cc @rspec/rspec 