### PR TITLE
Fix issue causing our spec suite to run much slower.

### DIFF
--- a/spec/rspec/core/invocations_spec.rb
+++ b/spec/rspec/core/invocations_spec.rb
@@ -131,6 +131,11 @@ module RSpec::Core
     end
 
     describe Invocations::PrintVersion do
+      before do
+        allow(subject).to receive(:require).and_call_original
+        allow(subject).to receive(:require).with("rspec/rails/version").and_raise(LoadError)
+      end
+
       it "prints the major.minor version of RSpec as a whole" do
         stub_const("RSpec::Core::Version::STRING", "9.18.23")
         run_invocation
@@ -162,8 +167,6 @@ module RSpec::Core
       end
 
       it "indicates a part is not installed if it cannot be loaded" do
-        expect { require 'rspec/rails/version' }.to raise_error(LoadError)
-
         run_invocation
 
         expect(out.string).not_to include("rspec-rails")


### PR DESCRIPTION
Before this change:

```
$ bin/rspec | egrep 'Finished|(examples.*failure)'
Finished in 45.99 seconds (files took 0.89765 seconds to load)
2014 examples, 4 failures, 1 pending
```

After this change:

```
$ bin/rspec | egrep 'Finished|(examples.*failure)'
Finished in 11.16 seconds (files took 1.16 seconds to load)
2014 examples, 4 failures, 1 pending
```

I believe the issue was requiring 'rspec/rails/version'. Since
rspec-rails is not available, rubygems would exhaustively search
all my installed gems before raising `LoadError`. I have ~300 gems
installed and this was quite slow.

It's better to just force it to raise `LoadError` and not wait on
RubyGems to do the same thing.