### PR TITLE
Set the exit status to non-zero for `after(:context)` errors.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,8 +19,10 @@ Bug Fixes:
   conflicting keys if the value in the host group was inherited from
   a parent group instead of being specified at that level.
   (Myron Marston, #2307)
-* Handle errors in `:suite` hooks and provided the same nicely formatted
+* Handle errors in `:suite` hooks and provide the same nicely formatted
   output as errors that happen in examples. (Myron Marston, #2316)
+* Set the exit status to non-zero when an error occurs in an
+  `after(:context)` hook. (Myron Marston, #2320)
 
 ### 3.5.2 / 2016-07-28
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.5.1...v3.5.2)

--- a/features/hooks/before_and_after_hooks.feature
+++ b/features/hooks/before_and_after_hooks.feature
@@ -174,11 +174,14 @@ Feature: `before` and `after` hooks
       end
       """
     When I run `rspec after_context_spec.rb`
-    Then the examples should all pass
-    And the output should contain:
+    Then it should fail with:
       """
       An error occurred in an `after(:context)` hook.
-        StandardError: Boom!
+      Failure/Error: raise StandardError.new("Boom!")
+
+      StandardError:
+        Boom!
+      # ./after_context_spec.rb:3
       """
 
   Scenario: Define `before` and `after` blocks in configuration

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -365,14 +365,7 @@ module RSpec
         def run(example)
           example.instance_exec(example, &block)
         rescue Support::AllExceptionsExceptOnesWeMustNotRescue => e
-          # TODO: Come up with a better solution for this.
-          RSpec.configuration.reporter.message <<-EOS
-
-An error occurred in an `after(:context)` hook.
-  #{e.class}: #{e.message}
-  occurred at #{e.backtrace.first}
-
-EOS
+          RSpec.configuration.reporter.notify_non_example_exception(e, "An error occurred in an `after(:context)` hook.")
         end
       end
 

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1014,6 +1014,12 @@ module RSpec::Core
           self.group.run
           expect(hooks_run).to eq [:two,:one]
         end
+
+        it "sets `world.non_example_failure` so the exit status will be non-zero" do
+          expect {
+            self.group.run
+          }.to change { RSpec.world.non_example_failure }.from(a_falsey_value).to(true)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #2084.