### PR TITLE
Add --force-color flag

### DIFF
--- a/features/command_line/init.feature
+++ b/features/command_line/init.feature
@@ -17,7 +17,7 @@ Feature: `--init` option
   Scenario: `.rspec` file already exists
     Given a file named ".rspec" with:
       """
-      --color
+      --force-color
       """
     When I run `rspec --init`
     Then the output should contain "exist   .rspec"

--- a/features/configuration/read_options_from_file.feature
+++ b/features/configuration/read_options_from_file.feature
@@ -19,18 +19,12 @@ Feature: read command line configuration options from files
   Scenario: Color set in `.rspec`
     Given a file named ".rspec" with:
       """
-      --color
+      --force-color
       """
     And a file named "spec/example_spec.rb" with:
       """ruby
       RSpec.describe "color_enabled?" do
         context "when set with RSpec.configure" do
-          before do
-            # color is disabled for non-tty output, so stub the output stream
-            # to say it is tty, even though we're running this with cucumber
-            allow(RSpec.configuration.output_stream).to receive(:tty?) { true }
-          end
-
           it "is true" do
             expect(RSpec.configuration).to be_color_enabled
           end
@@ -64,13 +58,13 @@ Feature: read command line configuration options from files
       """
     And a file named ".rspec" with:
       """
-      --color
+      --no-color
       """
     And a file named "spec/example_spec.rb" with:
       """ruby
       RSpec.describe "custom options file" do
         it "causes .rspec to be ignored" do
-          expect(RSpec.configuration.color).to be_falsey
+          expect(RSpec.configuration.color_mode).to eq(:automatic)
         end
       end
       """

--- a/features/formatters/configurable_colors.feature
+++ b/features/formatters/configurable_colors.feature
@@ -18,8 +18,7 @@ Feature: Configurable colors
       """ruby
       RSpec.configure do |config|
         config.failure_color = :magenta
-        config.tty = true
-        config.color = true
+        config.color_mode = :on
       end
 
       RSpec.describe "failure" do

--- a/lib/rspec/core/drb.rb
+++ b/lib/rspec/core/drb.rb
@@ -41,6 +41,8 @@ module RSpec
       def options
         argv = []
         argv << "--color"        if @submitted_options[:color]
+        argv << "--force-color"  if @submitted_options[:color_mode] == :on
+        argv << "--no-color"     if @submitted_options[:color_mode] == :off
         argv << "--profile"      if @submitted_options[:profile_examples]
         argv << "--backtrace"    if @submitted_options[:full_backtrace]
         argv << "--tty"          if @submitted_options[:tty]

--- a/lib/rspec/core/invocations.rb
+++ b/lib/rspec/core/invocations.rb
@@ -73,10 +73,10 @@ module RSpec
       end
 
       # @private
-      PrintHelp = Struct.new(:parser, :invalid_options) do
+      PrintHelp = Struct.new(:parser, :hidden_options) do
         def call(_options, _err, out)
-          # Removing the blank invalid options from the output.
-          out.puts parser.to_s.gsub(/^\s+(#{invalid_options.join('|')})\s*$\n/, '')
+          # Removing the hidden options from the output.
+          out.puts parser.to_s.gsub(/^\s+(#{hidden_options.join('|')})\b.*$\n/, '')
           0
         end
       end

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -39,6 +39,8 @@ module RSpec::Core
     # rubocop:disable PerceivedComplexity
     def parser(options)
       OptionParser.new do |parser|
+        parser.summary_width = 34
+
         parser.banner = "Usage: rspec [options] [files or directories]\n\n"
 
         parser.on('-I PATH', 'Specify PATH to add to $LOAD_PATH (may be used more than once).') do |dirs|
@@ -131,8 +133,23 @@ module RSpec::Core
           options[:full_backtrace] = true
         end
 
-        parser.on('-c', '--[no-]color', '--[no-]colour', 'Enable color in the output.') do |o|
-          options[:color] = o
+        parser.on('-c', '--color', '--colour', 'Enable color in the output.') do |_o|
+          options[:color] = true
+          options[:color_mode] = :automatic
+        end
+
+        parser.on('--force-color', '--force-colour', 'Force the output to be in color, even if the output is not a TTY') do |_o|
+          if options[:color_mode] == :off
+            abort "Please only use one of `--force-color` and `--no-color`"
+          end
+          options[:color_mode] = :on
+        end
+
+        parser.on('--no-color', '--no-colour', 'Force the output to not be in color, even if the output is a TTY') do |_o|
+          if options[:color_mode] == :on
+            abort "Please only use one of --force-color and --no-color"
+          end
+          options[:color_mode] = :off
         end
 
         parser.on('-p', '--[no-]profile [COUNT]',

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -133,7 +133,8 @@ module RSpec::Core
           options[:full_backtrace] = true
         end
 
-        parser.on('-c', '--color', '--colour', 'Enable color in the output.') do |_o|
+        parser.on('-c', '--color', '--colour', '') do |_o|
+          # flag will be excluded from `--help` output because it is deprecated
           options[:color] = true
           options[:color_mode] = :automatic
         end
@@ -273,8 +274,10 @@ FILTERING
         #     trigger --default-path.
         invalid_options = %w[-d --I]
 
+        hidden_options = invalid_options + %w[-c]
+
         parser.on_tail('-h', '--help', "You're looking at it.") do
-          options[:runner] = RSpec::Core::Invocations::PrintHelp.new(parser, invalid_options)
+          options[:runner] = RSpec::Core::Invocations::PrintHelp.new(parser, hidden_options)
         end
 
         # This prevents usage of the invalid_options.

--- a/lib/rspec/core/project_initializer/.rspec
+++ b/lib/rspec/core/project_initializer/.rspec
@@ -1,2 +1,1 @@
---color
 --require spec_helper

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1230,6 +1230,62 @@ module RSpec::Core
     end
 
     describe "#color=" do
+      context "given false" do
+        before { config.color = false }
+
+        context "with config.tty? and output.tty?" do
+          it "does not set color_enabled?" do
+            output = StringIO.new
+            config.output_stream = output
+
+            config.tty = true
+            allow(config.output_stream).to receive_messages :tty? => true
+
+            expect(config.color_enabled?).to be_falsy
+            expect(config.color_enabled?(output)).to be_falsy
+          end
+        end
+
+        context "with config.tty? and !output.tty?" do
+          it "does not set color_enabled?" do
+            output = StringIO.new
+            config.output_stream = output
+
+            config.tty = true
+            allow(config.output_stream).to receive_messages :tty? => false
+
+            expect(config.color_enabled?).to be_falsy
+            expect(config.color_enabled?(output)).to be_falsy
+          end
+        end
+
+        context "with !config.tty? and output.tty?" do
+          it "does not set color_enabled?" do
+            output = StringIO.new
+            config.output_stream = output
+
+            config.tty = false
+            allow(config.output_stream).to receive_messages :tty? => true
+
+            expect(config.color_enabled?).to be_falsy
+            expect(config.color_enabled?(output)).to be_falsy
+          end
+        end
+
+        context "with !config.tty? and !output.tty?" do
+          it "does not set color_enabled?" do
+            output = StringIO.new
+            config.output_stream = output
+
+            config.tty = false
+            allow(config.output_stream).to receive_messages :tty? => false
+
+            expect(config.color_enabled?).to be_falsey
+            expect(config.color_enabled?(output)).to be_falsey
+          end
+        end
+      end
+
       context "given true" do
         before { config.color = true }
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1259,8 +1259,8 @@ module RSpec::Core
           end
         end
 
-        context "with config.tty? and !output.tty?" do
-          it "does not set color_enabled?" do
+        context "with !config.tty? and output.tty?" do
+          it "sets color_enabled?" do
             output = StringIO.new
             config.output_stream = output
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1229,20 +1229,111 @@ module RSpec::Core
       end
     end
 
+    describe "#color_mode" do
+      context ":automatic" do
+        before do
+          config.color_mode = :automatic
+        end
+
+        context "with output.tty?" do
+          it "sets color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => true)
+            expect(config.color_enabled?).to be true
+          end
+        end
+
+        context "with !output.tty?" do
+          it "sets !color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => false)
+            expect(config.color_enabled?).to be false
+          end
+        end
+      end
+
+      context ":on" do
+        before do
+          config.color_mode = :on
+        end
+
+        context "with output.tty?" do
+          it "sets color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => true)
+            expect(config.color_enabled?).to be true
+          end
+        end
+
+        context "with !output.tty?" do
+          it "sets color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => false)
+            expect(config.color_enabled?).to be true
+          end
+        end
+      end
+
+      context ":off" do
+        before do
+          config.color_mode = :off
+        end
+
+        context "with output.tty?" do
+          it "sets !color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => true)
+            expect(config.color_enabled?).to be false
+          end
+        end
+
+        context "with !output.tty?" do
+          it "sets !color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => false)
+            expect(config.color_enabled?).to be false
+          end
+        end
+
+        it "prefers incoming cli_args" do
+          config.output_stream = StringIO.new
+          config.force :color_mode => :on
+          config.color_mode = :off
+          expect(config.color_mode).to be :on
+        end
+      end
+    end
+
+    describe "#color_enabled?" do
+      it "allows overriding instance output stream with an argument" do
+        config.output_stream = StringIO.new
+        output_override = StringIO.new
+
+        config.color_mode = :automatic
+        allow(config.output_stream).to receive_messages(:tty? => false)
+        allow(output_override).to receive_messages(:tty? => true)
+
+        expect(config.color_enabled?).to be false
+        expect(config.color_enabled?(output_override)).to be true
+      end
+    end
+
     describe "#color=" do
+      before { config.color_mode = :automatic }
+
       context "given false" do
         before { config.color = false }
 
         context "with config.tty? and output.tty?" do
-          it "does not set color_enabled?" do
+          it "sets color_enabled?" do
             output = StringIO.new
             config.output_stream = output
 
             config.tty = true
-            allow(config.output_stream).to receive_messages :tty? => true
+            allow(config.output_stream).to receive_messages(:tty? => true)
 
-            expect(config.color_enabled?).to be_falsy
-            expect(config.color_enabled?(output)).to be_falsy
+            expect(config.color_enabled?).to be true
+            expect(config.color_enabled?(output)).to be true
           end
         end
 
@@ -1252,23 +1343,23 @@ module RSpec::Core
             config.output_stream = output
 
             config.tty = true
-            allow(config.output_stream).to receive_messages :tty? => false
+            allow(config.output_stream).to receive_messages(:tty? => false)
 
-            expect(config.color_enabled?).to be_falsy
-            expect(config.color_enabled?(output)).to be_falsy
+            expect(config.color_enabled?).to be false
+            expect(config.color_enabled?(output)).to be false
           end
         end
 
         context "with !config.tty? and output.tty?" do
-          it "does not set color_enabled?" do
+          it "sets color_enabled?" do
             output = StringIO.new
             config.output_stream = output
 
             config.tty = false
-            allow(config.output_stream).to receive_messages :tty? => true
+            allow(config.output_stream).to receive_messages(:tty? => true)
 
-            expect(config.color_enabled?).to be_falsy
-            expect(config.color_enabled?(output)).to be_falsy
+            expect(config.color_enabled?).to be true
+            expect(config.color_enabled?(output)).to be true
           end
         end
 
@@ -1278,10 +1369,10 @@ module RSpec::Core
             config.output_stream = output
 
             config.tty = false
-            allow(config.output_stream).to receive_messages :tty? => false
+            allow(config.output_stream).to receive_messages(:tty? => false)
 
-            expect(config.color_enabled?).to be_falsey
-            expect(config.color_enabled?(output)).to be_falsey
+            expect(config.color_enabled?).to be false
+            expect(config.color_enabled?(output)).to be false
           end
         end
       end
@@ -1295,10 +1386,10 @@ module RSpec::Core
             config.output_stream = output
 
             config.tty = true
-            allow(config.output_stream).to receive_messages :tty? => true
+            allow(config.output_stream).to receive_messages(:tty? => true)
 
-            expect(config.color_enabled?).to be_truthy
-            expect(config.color_enabled?(output)).to be_truthy
+            expect(config.color_enabled?).to be true
+            expect(config.color_enabled?(output)).to be true
           end
         end
 
@@ -1308,10 +1399,10 @@ module RSpec::Core
             config.output_stream = output
 
             config.tty = true
-            allow(config.output_stream).to receive_messages :tty? => false
+            allow(config.output_stream).to receive_messages(:tty? => false)
 
-            expect(config.color_enabled?).to be_truthy
-            expect(config.color_enabled?(output)).to be_truthy
+            expect(config.color_enabled?).to be true
+            expect(config.color_enabled?(output)).to be true
           end
         end
 
@@ -1321,10 +1412,10 @@ module RSpec::Core
             config.output_stream = output
 
             config.tty = false
-            allow(config.output_stream).to receive_messages :tty? => true
+            allow(config.output_stream).to receive_messages(:tty? => true)
 
-            expect(config.color_enabled?).to be_truthy
-            expect(config.color_enabled?(output)).to be_truthy
+            expect(config.color_enabled?).to be true
+            expect(config.color_enabled?(output)).to be true
           end
         end
 
@@ -1334,20 +1425,20 @@ module RSpec::Core
             config.output_stream = output
 
             config.tty = false
-            allow(config.output_stream).to receive_messages :tty? => false
+            allow(config.output_stream).to receive_messages(:tty? => false)
 
-            expect(config.color_enabled?).to be_falsey
-            expect(config.color_enabled?(output)).to be_falsey
+            expect(config.color_enabled?).to be false
+            expect(config.color_enabled?(output)).to be false
           end
         end
       end
 
       it "prefers incoming cli_args" do
         config.output_stream = StringIO.new
-        allow(config.output_stream).to receive_messages :tty? => true
+        allow(config.output_stream).to receive_messages(:tty? => true)
         config.force :color => true
         config.color = false
-        expect(config.color).to be_truthy
+        expect(config.color).to be true
       end
     end
 

--- a/spec/rspec/core/drb_spec.rb
+++ b/spec/rspec/core/drb_spec.rb
@@ -100,10 +100,9 @@ RSpec.describe RSpec::Core::DRbRunner, :isolated_directory => true, :isolated_ho
       expect(result).to be(1)
     end
 
-    it "outputs colorized text when running with --color option" do
+    it "outputs colorized text when running with --force-color option" do
       failure_symbol = "\e[#{RSpec::Core::Formatters::ConsoleCodes.console_code_for(:red)}mF"
-      allow(out).to receive_messages(:tty? => true)
-      runner(failing_spec_filename, "--color", "--drb-port", @drb_port).run(err, out)
+      runner(failing_spec_filename, "--force-color", "--drb-port", @drb_port).run(err, out)
       expect(out.string).to include(failure_symbol)
     end
   end
@@ -129,7 +128,7 @@ RSpec.describe RSpec::Core::DRbOptions, :isolated_directory => true, :isolated_h
       expect(drb_argv_for(%w[ a --drb b --color c ])).to match_array %w[ --color a b c ]
     end
 
-    %w(--color --fail-fast --profile --backtrace --tty).each do |option|
+    %w(--color --force-color --no-color --fail-fast --profile --backtrace --tty).each do |option|
       it "includes #{option}" do
         expect(drb_argv_for([option])).to include(option)
       end

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -268,8 +268,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
   describe "custom_colors" do
     it "uses the custom success color" do
       RSpec.configure do |config|
-        config.color = true
-        config.tty = true
+        config.color_mode = :on
         config.success_color = :cyan
       end
       send_notification :dump_summary, summary_notification(0, examples(1), [], [], 0)

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -33,12 +33,8 @@ module RSpec::Core
     end
 
     it "proposes you to use --help and returns an error on incorrect argument" do
-      parser = Parser.new([option = "--my_wrong_arg"])
-
-      expect(parser).to receive(:abort) do |msg|
-        expect(msg).to include('use --help', option)
-      end
-
+      parser = Parser.new(["--my_wrong_arg"])
+      expect(parser).to receive(:abort).with(a_string_including('use --help'))
       parser.parse
     end
 
@@ -58,11 +54,7 @@ module RSpec::Core
       shorts.each do |option|
         it "won't parse #{option} as a shorthand for #{long}" do
           parser = Parser.new([option])
-
-          expect(parser).to receive(:abort) do |msg|
-            expect(msg).to include('use --help', option)
-          end
-
+          expect(parser).to receive(:abort).with(a_string_including('use --help'))
           parser.parse
         end
       end
@@ -394,5 +386,20 @@ module RSpec::Core
       end
     end
 
+    describe '--force-color' do
+      it 'aborts if --no-color was previously set' do
+        parser = Parser.new(%w[--no-color --force-color])
+        expect(parser).to receive(:abort).with(a_string_including('only use one of `--force-color` and `--no-color`'))
+        parser.parse
+      end
+    end
+
+    describe '--no-color' do
+      it 'aborts if --force-color was previously set' do
+        parser = Parser.new(%w[--force-color --no-color])
+        expect(parser).to receive(:abort).with(a_string_including('only use one of --force-color and --no-color'))
+        parser.parse
+      end
+    end
   end
 end

--- a/spec/rspec/core/project_initializer_spec.rb
+++ b/spec/rspec/core/project_initializer_spec.rb
@@ -19,7 +19,7 @@ module RSpec::Core
 
           it "generates a .rspec" do
             command_line_config.run
-            expect(File.read('.rspec')).to match(/--color/m)
+            expect(File.read('.rspec')).to match(/--require spec_helper/m)
           end
         end
 
@@ -86,7 +86,7 @@ module RSpec::Core
       context "with no .rspec file" do
         it "generates a .rspec" do
           command_line_config.run
-          expect(File.read(File.join(tmpdir, '.rspec'))).to match(/--color/m)
+          expect(File.read(File.join(tmpdir, '.rspec'))).to match(/--require spec_helper/m)
         end
       end
 

--- a/spec/rspec/core/source/syntax_highlighter_spec.rb
+++ b/spec/rspec/core/source/syntax_highlighter_spec.rb
@@ -2,7 +2,7 @@ require 'rspec/core/source/syntax_highlighter'
 
 class RSpec::Core::Source
   RSpec.describe SyntaxHighlighter do
-    let(:config)      { RSpec::Core::Configuration.new.tap { |c| c.color = true } }
+    let(:config)      { RSpec::Core::Configuration.new.tap { |config| config.color_mode = :on } }
     let(:highlighter) { SyntaxHighlighter.new(config)  }
 
     context "when CodeRay is available", :unless => RSpec::Support::OS.windows? do
@@ -25,16 +25,16 @@ class RSpec::Core::Source
       end
 
       it 'returns the provided lines unmodified if color is disabled' do
-        config.color = false
+        config.color_mode = :off
         expect(highlighter.highlight(['[:ok, "ok"]'])).to eq(['[:ok, "ok"]'])
       end
 
       it 'dynamically adjusts to changing color config' do
-        config.color = false
+        config.color_mode = :off
         expect(highlighter.highlight(['[:ok, "ok"]']).first).not_to be_highlighted
-        config.color = true
+        config.color_mode = :on
         expect(highlighter.highlight(['[:ok, "ok"]']).first).to be_highlighted
-        config.color = false
+        config.color_mode = :off
         expect(highlighter.highlight(['[:ok, "ok"]']).first).not_to be_highlighted
       end
 
@@ -69,8 +69,8 @@ class RSpec::Core::Source
         expect(highlighter.highlight([])).to eq([])
       end
 
-      it 'does not add the comment about coderay if color id disabled even when given a multiline snippet' do
-        config.color = false
+      it 'does not add the comment about coderay if color is disabled even when given a multiline snippet' do
+        config.color_mode = :off
         lines = ["a = 1", "b = 2"]
         expect(highlighter.highlight(lines)).to eq(lines)
       end

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -67,7 +67,7 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:18
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
-        |     # ./spec/support/sandboxing.rb:14
+        |     # ./spec/support/sandboxing.rb:16
         |     # ./spec/support/sandboxing.rb:7
         |
         |Failures:
@@ -87,7 +87,7 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:33
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
-        |     # ./spec/support/sandboxing.rb:14
+        |     # ./spec/support/sandboxing.rb:16
         |     # ./spec/support/sandboxing.rb:7
         |
         |  3) a failing spec with odd backtraces fails with a backtrace that has no file
@@ -142,7 +142,7 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:18:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
-        |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
         |Failures:
@@ -162,7 +162,7 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
-        |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
         |  3) a failing spec with odd backtraces fails with a backtrace that has no file
@@ -174,7 +174,7 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
-        |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
         |  4) a failing spec with odd backtraces fails with a backtrace containing an erb file

--- a/spec/support/sandboxing.rb
+++ b/spec/support/sandboxing.rb
@@ -10,6 +10,8 @@ RSpec.configure do |c|
       # something like `pending`
       config.before(:context) { RSpec.current_example = nil }
 
+      config.color_mode = :off
+
       orig_load_path = $LOAD_PATH.dup
       ex.run
       $LOAD_PATH.replace(orig_load_path)


### PR DESCRIPTION
Fixes #2230 by adding a --force-color flag to use alongside --no-color, while preserving backward-compatibility with the --color flag.

Please let me know anything I can do to improve this PR! A few thoughts:

- configuration.rb is a bit more complex than it otherwise might need to be because of --color backward compatibility, but I think it's worth it
- Setting config.no_color = true in spec_helper.rb felt a bit dirty, but I do think the best default behavior in the specs is to _not_ have color in the output, and that was the most reliable way I could find to accomplish that.
- The specs that distinguish the behavior of force_color and no_color when --tty is passed can probably be removed, now that they've demonstrated that that flag doesn't affect their behavior.
- The name of the --force-color flag gets a bit confusing with the ConfigurationOptions method `force` (e.g. it "forces force_color"), but I think --force-color is the best external name, and it probably doesn't make sense to consider any renaming of the internal `force` method just for this.
- Reading `no_color = true` and `no_color = false` gets a bit confusing, but this wouldn't extend to end users: they just use --force-color or --no-color and get the expected result. The two different properties are needed, as I describe in the commit message for 9af8f0c, because the default behavior is different from both the force_color and no_color behavior, so there are several different states.