### PR TITLE
Add failure details when using HTML formatter with "aggregate_failures"

### DIFF
--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -71,8 +71,10 @@ module RSpec
           exception = failure.exception
 
           message = if exception
-                      if exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError) || exception.is_a?(RSpec::Core::MultipleExceptionError)
-                        failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer).split("\n").drop(2).join("\n").gsub(/\e\[(\d+)(;(\d+))?m/, '')
+                      if exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError) ||
+                          exception.is_a?(RSpec::Core::MultipleExceptionError)
+                        failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer).
+                          split("\n").drop(2).join("\n").gsub(/\e\[(\d+)(;(\d+))?m/, '')
                       else
                         failure.message_lines.join("\n")
                       end

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -72,8 +72,8 @@ module RSpec
 
           message = if exception
             if exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError) || exception.is_a?(RSpec::Core::MultipleExceptionError)
-              failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer)
-                .split("\n").drop(2).join("\n").gsub(/\e\[(\d+)(;(\d+))?m/, '')
+              failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer).
+                split("\n").drop(2).join("\n").gsub(/\e\[(\d+)(;(\d+))?m/, '')
             else
               failure.message_lines.join("\n")
             end

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -71,13 +71,12 @@ module RSpec
           exception = failure.exception
 
           message = if exception
-            if exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError) || exception.is_a?(RSpec::Core::MultipleExceptionError)
-              failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer).
-                split("\n").drop(2).join("\n").gsub(/\e\[(\d+)(;(\d+))?m/, '')
-            else
-              failure.message_lines.join("\n")
-            end
-          end
+                      if exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError) || exception.is_a?(RSpec::Core::MultipleExceptionError)
+                        failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer).split("\n").drop(2).join("\n").gsub(/\e\[(\d+)(;(\d+))?m/, '')
+                      else
+                        failure.message_lines.join("\n")
+                      end
+                    end
 
           exception_details = if exception
                                 {

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -70,11 +70,13 @@ module RSpec
 
           exception = failure.exception
           
-          message = if exception && exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError)
-            failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer)
-              .split("\n").drop(2).join("\n").gsub(/\e\[(\d+)(;(\d+))?m/, '')
-          else
-            failure.message_lines.join("\n")
+          message = if exception
+            if exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError) || exception.is_a?(RSpec::Core::MultipleExceptionError)
+              failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer)
+                .split("\n").drop(2).join("\n").gsub(/\e\[(\d+)(;(\d+))?m/, '')
+            else
+              failure.message_lines.join("\n")
+            end
           end
           
           exception_details = if exception

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -69,9 +69,17 @@ module RSpec
           example = failure.example
 
           exception = failure.exception
+          
+          message = if exception && exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError)
+            failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer)
+              .split("\n").drop(2).join("\n").gsub(/\e\[(\d+)(;(\d+))?m/, '')
+          else
+            failure.message_lines.join("\n")
+          end
+          
           exception_details = if exception
                                 {
-                                  :message => failure.message_lines.join("\n"),
+                                  :message => message,
                                   :backtrace => failure.formatted_backtrace.join("\n")
                                 }
                               end

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -69,7 +69,7 @@ module RSpec
           example = failure.example
 
           exception = failure.exception
-          
+
           message = if exception
             if exception.is_a?(RSpec::Expectations::MultipleExpectationsNotMetError) || exception.is_a?(RSpec::Core::MultipleExceptionError)
               failure.fully_formatted(nil, RSpec::Core::Notifications::NullColorizer)
@@ -78,7 +78,7 @@ module RSpec
               failure.message_lines.join("\n")
             end
           end
-          
+
           exception_details = if exception
                                 {
                                   :message => message,

--- a/spec/rspec/core/bisect/server_spec.rb
+++ b/spec/rspec/core/bisect/server_spec.rb
@@ -68,8 +68,12 @@ module RSpec::Core
             ./spec/rspec/core/resources/formatter_specs.rb[1:1]
             ./spec/rspec/core/resources/formatter_specs.rb[2:1:1]
             ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
+            ./spec/rspec/core/resources/formatter_specs.rb[2:2:2]
             ./spec/rspec/core/resources/formatter_specs.rb[3:1]
             ./spec/rspec/core/resources/formatter_specs.rb[4:1]
+            ./spec/rspec/core/resources/formatter_specs.rb[4:2]
+            ./spec/rspec/core/resources/formatter_specs.rb[4:3:1]
+            ./spec/rspec/core/resources/formatter_specs.rb[4:3:2]
             ./spec/rspec/core/resources/formatter_specs.rb[5:1]
             ./spec/rspec/core/resources/formatter_specs.rb[5:2]
             ./spec/rspec/core/resources/formatter_specs.rb[5:3:1]
@@ -77,7 +81,11 @@ module RSpec::Core
 
           expect(results.failed_example_ids).to eq %w[
             ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
+            ./spec/rspec/core/resources/formatter_specs.rb[2:2:2]
             ./spec/rspec/core/resources/formatter_specs.rb[4:1]
+            ./spec/rspec/core/resources/formatter_specs.rb[4:2]
+            ./spec/rspec/core/resources/formatter_specs.rb[4:3:1]
+            ./spec/rspec/core/resources/formatter_specs.rb[4:3:2]
             ./spec/rspec/core/resources/formatter_specs.rb[5:1]
             ./spec/rspec/core/resources/formatter_specs.rb[5:2]
             ./spec/rspec/core/resources/formatter_specs.rb[5:3:1]
@@ -101,11 +109,13 @@ module RSpec::Core
               ./spec/rspec/core/resources/formatter_specs.rb[1:1]
               ./spec/rspec/core/resources/formatter_specs.rb[2:1:1]
               ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
+              ./spec/rspec/core/resources/formatter_specs.rb[2:2:2]
               ./spec/rspec/core/resources/formatter_specs.rb[3:1]
               ./spec/rspec/core/resources/formatter_specs.rb[4:1]
             ],
             :failed_example_ids => %w[
               ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
+              ./spec/rspec/core/resources/formatter_specs.rb[2:2:2]
               ./spec/rspec/core/resources/formatter_specs.rb[4:1]
             ]
           )
@@ -124,10 +134,12 @@ module RSpec::Core
               ./spec/rspec/core/resources/formatter_specs.rb[1:1]
               ./spec/rspec/core/resources/formatter_specs.rb[2:1:1]
               ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
+              ./spec/rspec/core/resources/formatter_specs.rb[2:2:2]
               ./spec/rspec/core/resources/formatter_specs.rb[3:1]
             ],
             :failed_example_ids => %w[
               ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
+              ./spec/rspec/core/resources/formatter_specs.rb[2:2:2]
             ]
           )
         end

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -95,18 +95,23 @@ root
         |    is pending (PENDING: No reason given)
         |  behaves like shared
         |    is marked as pending but passes (FAILED - 1)
+        |    fails twice with failure aggregation in shared (FAILED - 2)
         |
         |passing spec
         |  passes
         |
         |failing spec
-        |  fails (FAILED - 2)
+        |  fails (FAILED - 3)
+        |  fails twice with failure aggregation (FAILED - 4)
+        |  failure aggregation
+        |    fails twice with failure aggregation in context (FAILED - 5)
+        |    has one failure and one error (FAILED - 6)
         |
         |a failing spec with odd backtraces
-        |  fails with a backtrace that has no file (FAILED - 3)
-        |  fails with a backtrace containing an erb file (FAILED - 4)
+        |  fails with a backtrace that has no file (FAILED - 7)
+        |  fails with a backtrace containing an erb file (FAILED - 8)
         |  with a `nil` backtrace
-        |    raises (FAILED - 5)
+        |    raises (FAILED - 9)
         |
         |#{expected_summary_output_for_example_specs}
       EOS

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -386,8 +386,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
     <pre class="ruby"><code><span class="linenum">38</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="linenum">39</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="offending"><span class="linenum">40</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
-<span class="linenum">41</span>  <span class="keyword">end</span>
-<span class="linenum">42</span>  </code></pre>
+<span class="linenum">41</span>  <span class="keyword">end</span></code></pre>
       </div>
     </dd>
     <script type="text/javascript">moveProgressBar('58.3');</script>

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -474,11 +474,8 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
         (compared using ==)
       # ./spec/rspec/core/resources/formatter_specs.rb:61:in `block (4 levels) in &lt;top (required)&gt;&#39;
 
-  .2) Failure/Error: expect(4[:error]).to eq 4
-
-      TypeError:
-        no implicit conversion of Symbol into Integer
-      # ./spec/rspec/core/resources/formatter_specs.rb:62:in `[]&#39;
+  .2) Failure/Error: raise
+      RuntimeError:
       # ./spec/rspec/core/resources/formatter_specs.rb:62:in `block (4 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:59:in `block (3 levels) in &lt;top (required)&gt;&#39;</pre></div>
     <pre class="ruby"><code><span class="linenum">57</span>

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -350,7 +350,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
         (compared using ==)
       # ./spec/rspec/core/resources/formatter_specs.rb:12:in `block (3 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:10:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-    <pre class="ruby"><code><span class="linenum">8</span>  
+    <pre class="ruby"><code><span class="linenum">8</span>
 <span class="linenum">9</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails twice with failure aggregation in shared</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="offending"><span class="linenum">10</span>    aggregate_failures <span class="keyword">do</span></span>
 <span class="linenum">11</span>      expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)
@@ -414,7 +414,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
         (compared using ==)
       # ./spec/rspec/core/resources/formatter_specs.rb:46:in `block (3 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:44:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-    <pre class="ruby"><code><span class="linenum">42</span>  
+    <pre class="ruby"><code><span class="linenum">42</span>
 <span class="linenum">43</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails twice with failure aggregation</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="offending"><span class="linenum">44</span>    aggregate_failures <span class="keyword">do</span></span>
 <span class="linenum">45</span>      expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)
@@ -482,7 +482,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
       # ./spec/rspec/core/resources/formatter_specs.rb:62:in `[]&#39;
       # ./spec/rspec/core/resources/formatter_specs.rb:62:in `block (4 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:59:in `block (3 levels) in &lt;top (required)&gt;&#39;</pre></div>
-    <pre class="ruby"><code><span class="linenum">57</span>    
+    <pre class="ruby"><code><span class="linenum">57</span>
 <span class="linenum">58</span>    it <span class="string"><span class="delimiter">'</span><span class="content">has one failure and one error</span><span class="delimiter">'</span></span> <span class="keyword">do</span>
 <span class="offending"><span class="linenum">59</span>      aggregate_failures <span class="keyword">do</span></span>
 <span class="linenum">60</span>        expect(<span class="integer">1</span>).to eq <span class="integer">1</span>

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -285,7 +285,7 @@ a {
     <script type="text/javascript">makeYellow('rspec-header');</script>
     <script type="text/javascript">makeYellow('div_group_1');</script>
     <script type="text/javascript">makeYellow('example_group_1');</script>
-    <script type="text/javascript">moveProgressBar('12.5');</script>
+    <script type="text/javascript">moveProgressBar('9.0');</script>
     <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: Not yet implemented)</span></dd>
   </dl>
 </div>
@@ -300,7 +300,7 @@ a {
     <script type="text/javascript">makeYellow('rspec-header');</script>
     <script type="text/javascript">makeYellow('div_group_3');</script>
     <script type="text/javascript">makeYellow('example_group_3');</script>
-    <script type="text/javascript">moveProgressBar('25.0');</script>
+    <script type="text/javascript">moveProgressBar('18.1');</script>
     <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: No reason given)</span></dd>
   </dl>
 </div>
@@ -310,13 +310,13 @@ a {
     <script type="text/javascript">makeRed('rspec-header');</script>
     <script type="text/javascript">makeRed('div_group_4');</script>
     <script type="text/javascript">makeRed('example_group_4');</script>
-    <script type="text/javascript">moveProgressBar('37.5');</script>
+    <script type="text/javascript">moveProgressBar('27.2');</script>
     <dd class="example pending_fixed">
       <span class="failed_spec_name">is marked as pending but passes</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_1">
         <div class="message"><pre>Expected pending &#39;No reason given&#39; to fail. No Error was raised.
-Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources/formatter_specs.rb:22</pre></div>
+Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources/formatter_specs.rb:29</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:4</pre></div>
     <pre class="ruby"><code><span class="linenum">2</span>
 <span class="linenum">3</span><span class="constant">RSpec</span>.shared_examples_for <span class="string"><span class="delimiter">&quot;</span><span class="content">shared</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
@@ -325,12 +325,44 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
 <span class="linenum">6</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">1</span>)</code></pre>
       </div>
     </dd>
+    <script type="text/javascript">moveProgressBar('36.3');</script>
+    <dd class="example failed">
+      <span class="failed_spec_name">fails twice with failure aggregation in shared</span>
+      <span class="duration">n.nnnns</span>
+      <div class="failure" id="failure_2">
+        <div class="message"><pre>  Got 2 failures from failure aggregation block.
+  Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources/formatter_specs.rb:29
+  # ./spec/rspec/core/resources/formatter_specs.rb:10:in `block (2 levels) in &lt;top (required)&gt;&#39;
+
+  .1) Failure/Error: expect(1).to eq(2)
+
+        expected: 2
+             got: 1
+
+        (compared using ==)
+      # ./spec/rspec/core/resources/formatter_specs.rb:11:in `block (3 levels) in &lt;top (required)&gt;&#39;
+
+  .2) Failure/Error: expect(3).to eq(4)
+
+        expected: 4
+             got: 3
+
+        (compared using ==)
+      # ./spec/rspec/core/resources/formatter_specs.rb:12:in `block (3 levels) in &lt;top (required)&gt;&#39;</pre></div>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:10:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">8</span>  
+<span class="linenum">9</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails twice with failure aggregation in shared</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="offending"><span class="linenum">10</span>    aggregate_failures <span class="keyword">do</span></span>
+<span class="linenum">11</span>      expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)
+<span class="linenum">12</span>      expect(<span class="integer">3</span>).to eq(<span class="integer">4</span>)</code></pre>
+      </div>
+    </dd>
   </dl>
 </div>
 <div id="div_group_5" class="example_group passed">
   <dl style="margin-left: 0px;">
   <dt id="example_group_5" class="passed">passing spec</dt>
-    <script type="text/javascript">moveProgressBar('50.0');</script>
+    <script type="text/javascript">moveProgressBar('45.4');</script>
     <dd class="example passed"><span class="passed_spec_name">passes</span><span class='duration'>n.nnnns</span></dd>
   </dl>
 </div>
@@ -339,53 +371,122 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
   <dt id="example_group_6" class="passed">failing spec</dt>
     <script type="text/javascript">makeRed('div_group_6');</script>
     <script type="text/javascript">makeRed('example_group_6');</script>
-    <script type="text/javascript">moveProgressBar('62.5');</script>
+    <script type="text/javascript">moveProgressBar('54.5');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_2">
+      <div class="failure" id="failure_3">
         <div class="message"><pre>Failure/Error: expect(1).to eq(2)
 
   expected: 2
        got: 1
 
   (compared using ==)</pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-    <pre class="ruby"><code><span class="linenum">31</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
-<span class="linenum">32</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
-<span class="offending"><span class="linenum">33</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
-<span class="linenum">34</span>  <span class="keyword">end</span>
-<span class="linenum">35</span><span class="keyword">end</span></code></pre>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:40:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">38</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="linenum">39</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="offending"><span class="linenum">40</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
+<span class="linenum">41</span>  <span class="keyword">end</span>
+<span class="linenum">42</span>  </code></pre>
+      </div>
+    </dd>
+    <script type="text/javascript">moveProgressBar('63.6');</script>
+    <dd class="example failed">
+      <span class="failed_spec_name">fails twice with failure aggregation</span>
+      <span class="duration">n.nnnns</span>
+      <div class="failure" id="failure_4">
+        <div class="message"><pre>  Got 2 failures from failure aggregation block.
+  # ./spec/rspec/core/resources/formatter_specs.rb:44:in `block (2 levels) in &lt;top (required)&gt;&#39;
+
+  .1) Failure/Error: expect(1).to eq(2)
+
+        expected: 2
+             got: 1
+
+        (compared using ==)
+      # ./spec/rspec/core/resources/formatter_specs.rb:45:in `block (3 levels) in &lt;top (required)&gt;&#39;
+
+  .2) Failure/Error: expect(3).to eq(4)
+
+        expected: 4
+             got: 3
+
+        (compared using ==)
+      # ./spec/rspec/core/resources/formatter_specs.rb:46:in `block (3 levels) in &lt;top (required)&gt;&#39;</pre></div>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:44:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">42</span>  
+<span class="linenum">43</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails twice with failure aggregation</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="offending"><span class="linenum">44</span>    aggregate_failures <span class="keyword">do</span></span>
+<span class="linenum">45</span>      expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)
+<span class="linenum">46</span>      expect(<span class="integer">3</span>).to eq(<span class="integer">4</span>)</code></pre>
       </div>
     </dd>
   </dl>
 </div>
 <div id="div_group_7" class="example_group passed">
-  <dl style="margin-left: 0px;">
-  <dt id="example_group_7" class="passed">a failing spec with odd backtraces</dt>
+  <dl style="margin-left: 15px;">
+  <dt id="example_group_7" class="passed">failure aggregation</dt>
     <script type="text/javascript">makeRed('div_group_7');</script>
     <script type="text/javascript">makeRed('example_group_7');</script>
-    <script type="text/javascript">moveProgressBar('75.0');</script>
+    <script type="text/javascript">moveProgressBar('72.7');</script>
+    <dd class="example failed">
+      <span class="failed_spec_name">fails twice with failure aggregation in context</span>
+      <span class="duration">n.nnnns</span>
+      <div class="failure" id="failure_5">
+        <div class="message"><pre>  Got 2 failures from failure aggregation block.
+  # ./spec/rspec/core/resources/formatter_specs.rb:52:in `block (3 levels) in &lt;top (required)&gt;&#39;
+
+  .1) Failure/Error: expect(1).to eq(2)
+
+        expected: 2
+             got: 1
+
+        (compared using ==)
+      # ./spec/rspec/core/resources/formatter_specs.rb:53:in `block (4 levels) in &lt;top (required)&gt;&#39;
+
+  .2) Failure/Error: expect(3).to eq(4)
+
+        expected: 4
+             got: 3
+
+        (compared using ==)
+      # ./spec/rspec/core/resources/formatter_specs.rb:54:in `block (4 levels) in &lt;top (required)&gt;&#39;</pre></div>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:52:in `block (3 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">50</span>  context <span class="string"><span class="delimiter">&quot;</span><span class="content">failure aggregation</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="linenum">51</span>    it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails twice with failure aggregation in context</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="offending"><span class="linenum">52</span>      aggregate_failures <span class="keyword">do</span></span>
+<span class="linenum">53</span>        expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)
+<span class="linenum">54</span>        expect(<span class="integer">3</span>).to eq(<span class="integer">4</span>)</code></pre>
+      </div>
+    </dd>
+  </dl>
+</div>
+<div id="div_group_8" class="example_group passed">
+  <dl style="margin-left: 0px;">
+  <dt id="example_group_8" class="passed">a failing spec with odd backtraces</dt>
+    <script type="text/javascript">makeRed('div_group_8');</script>
+    <script type="text/javascript">makeRed('example_group_8');</script>
+    <script type="text/javascript">moveProgressBar('81.8');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace that has no file</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_3">
+      <div class="failure" id="failure_6">
         <div class="message"><pre>Failure/Error: ERB.new(&quot;&lt;%= raise &#39;foo&#39; %&gt;&quot;).result
 
 RuntimeError:
   foo</pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-    <pre class="ruby"><code><span class="linenum">39</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
-<span class="linenum">40</span>
-<span class="offending"><span class="linenum">41</span>    <span class="constant">ERB</span>.new(<span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;%= raise 'foo' %&gt;</span><span class="delimiter">&quot;</span></span>).result</span>
-<span class="linenum">42</span>  <span class="keyword">end</span></code></pre>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:64:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">62</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
+<span class="linenum">63</span>
+<span class="offending"><span class="linenum">64</span>    <span class="constant">ERB</span>.new(<span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;%= raise 'foo' %&gt;</span><span class="delimiter">&quot;</span></span>).result</span>
+<span class="linenum">65</span>  <span class="keyword">end</span></code></pre>
       </div>
     </dd>
-    <script type="text/javascript">moveProgressBar('87.5');</script>
+    <script type="text/javascript">moveProgressBar('90.9');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace containing an erb file</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_4">
+      <div class="failure" id="failure_7">
         <div class="message"><pre>Failure/Error: Unable to find /foo.html.erb to read failed line
 
 Exception:
@@ -401,16 +502,16 @@ Exception:
     </dd>
   </dl>
 </div>
-<div id="div_group_8" class="example_group passed">
+<div id="div_group_9" class="example_group passed">
   <dl style="margin-left: 15px;">
-  <dt id="example_group_8" class="passed">with a `nil` backtrace</dt>
-    <script type="text/javascript">makeRed('div_group_8');</script>
-    <script type="text/javascript">makeRed('example_group_8');</script>
+  <dt id="example_group_9" class="passed">with a `nil` backtrace</dt>
+    <script type="text/javascript">makeRed('div_group_9');</script>
+    <script type="text/javascript">makeRed('example_group_9');</script>
     <script type="text/javascript">moveProgressBar('100.0');</script>
     <dd class="example failed">
       <span class="failed_spec_name">raises</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_5">
+      <div class="failure" id="failure_8">
         <div class="message"><pre>Failure/Error: Unable to find matching line from backtrace
 
 RuntimeError:
@@ -422,7 +523,7 @@ RuntimeError:
   </dl>
 </div>
 <script type="text/javascript">document.getElementById('duration').innerHTML = "Finished in <strong>n.nnnn seconds</strong>";</script>
-<script type="text/javascript">document.getElementById('totals').innerHTML = "8 examples, 5 failures, 2 pending";</script>
+<script type="text/javascript">document.getElementById('totals').innerHTML = "11 examples, 8 failures, 2 pending";</script>
 </div>
 </div>
 </body>

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -285,7 +285,7 @@ a {
     <script type="text/javascript">makeYellow('rspec-header');</script>
     <script type="text/javascript">makeYellow('div_group_1');</script>
     <script type="text/javascript">makeYellow('example_group_1');</script>
-    <script type="text/javascript">moveProgressBar('9.0');</script>
+    <script type="text/javascript">moveProgressBar('8.3');</script>
     <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: Not yet implemented)</span></dd>
   </dl>
 </div>
@@ -300,7 +300,7 @@ a {
     <script type="text/javascript">makeYellow('rspec-header');</script>
     <script type="text/javascript">makeYellow('div_group_3');</script>
     <script type="text/javascript">makeYellow('example_group_3');</script>
-    <script type="text/javascript">moveProgressBar('18.1');</script>
+    <script type="text/javascript">moveProgressBar('16.6');</script>
     <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: No reason given)</span></dd>
   </dl>
 </div>
@@ -310,7 +310,7 @@ a {
     <script type="text/javascript">makeRed('rspec-header');</script>
     <script type="text/javascript">makeRed('div_group_4');</script>
     <script type="text/javascript">makeRed('example_group_4');</script>
-    <script type="text/javascript">moveProgressBar('27.2');</script>
+    <script type="text/javascript">moveProgressBar('25.0');</script>
     <dd class="example pending_fixed">
       <span class="failed_spec_name">is marked as pending but passes</span>
       <span class="duration">n.nnnns</span>
@@ -325,7 +325,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
 <span class="linenum">6</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">1</span>)</code></pre>
       </div>
     </dd>
-    <script type="text/javascript">moveProgressBar('36.3');</script>
+    <script type="text/javascript">moveProgressBar('33.3');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails twice with failure aggregation in shared</span>
       <span class="duration">n.nnnns</span>
@@ -362,7 +362,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
 <div id="div_group_5" class="example_group passed">
   <dl style="margin-left: 0px;">
   <dt id="example_group_5" class="passed">passing spec</dt>
-    <script type="text/javascript">moveProgressBar('45.4');</script>
+    <script type="text/javascript">moveProgressBar('41.6');</script>
     <dd class="example passed"><span class="passed_spec_name">passes</span><span class='duration'>n.nnnns</span></dd>
   </dl>
 </div>
@@ -371,7 +371,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
   <dt id="example_group_6" class="passed">failing spec</dt>
     <script type="text/javascript">makeRed('div_group_6');</script>
     <script type="text/javascript">makeRed('example_group_6');</script>
-    <script type="text/javascript">moveProgressBar('54.5');</script>
+    <script type="text/javascript">moveProgressBar('50.0');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails</span>
       <span class="duration">n.nnnns</span>
@@ -390,7 +390,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
 <span class="linenum">42</span>  </code></pre>
       </div>
     </dd>
-    <script type="text/javascript">moveProgressBar('63.6');</script>
+    <script type="text/javascript">moveProgressBar('58.3');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails twice with failure aggregation</span>
       <span class="duration">n.nnnns</span>
@@ -428,7 +428,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
   <dt id="example_group_7" class="passed">failure aggregation</dt>
     <script type="text/javascript">makeRed('div_group_7');</script>
     <script type="text/javascript">makeRed('example_group_7');</script>
-    <script type="text/javascript">moveProgressBar('72.7');</script>
+    <script type="text/javascript">moveProgressBar('66.6');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails twice with failure aggregation in context</span>
       <span class="duration">n.nnnns</span>
@@ -459,6 +459,36 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
 <span class="linenum">54</span>        expect(<span class="integer">3</span>).to eq(<span class="integer">4</span>)</code></pre>
       </div>
     </dd>
+    <script type="text/javascript">moveProgressBar('75.0');</script>
+    <dd class="example failed">
+      <span class="failed_spec_name">has one failure and one error</span>
+      <span class="duration">n.nnnns</span>
+      <div class="failure" id="failure_6">
+        <div class="message"><pre>  Got 1 failure and 1 other error from failure aggregation block.
+  # ./spec/rspec/core/resources/formatter_specs.rb:59:in `block (3 levels) in &lt;top (required)&gt;&#39;
+
+  .1) Failure/Error: expect(2).to eq 3
+
+        expected: 3
+             got: 2
+
+        (compared using ==)
+      # ./spec/rspec/core/resources/formatter_specs.rb:61:in `block (4 levels) in &lt;top (required)&gt;&#39;
+
+  .2) Failure/Error: expect(4[:error]).to eq 4
+
+      TypeError:
+        no implicit conversion of Symbol into Integer
+      # ./spec/rspec/core/resources/formatter_specs.rb:62:in `[]&#39;
+      # ./spec/rspec/core/resources/formatter_specs.rb:62:in `block (4 levels) in &lt;top (required)&gt;&#39;</pre></div>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:59:in `block (3 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">57</span>    
+<span class="linenum">58</span>    it <span class="string"><span class="delimiter">'</span><span class="content">has one failure and one error</span><span class="delimiter">'</span></span> <span class="keyword">do</span>
+<span class="offending"><span class="linenum">59</span>      aggregate_failures <span class="keyword">do</span></span>
+<span class="linenum">60</span>        expect(<span class="integer">1</span>).to eq <span class="integer">1</span>
+<span class="linenum">61</span>        expect(<span class="integer">2</span>).to eq <span class="integer">3</span></code></pre>
+      </div>
+    </dd>
   </dl>
 </div>
 <div id="div_group_8" class="example_group passed">
@@ -466,27 +496,27 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
   <dt id="example_group_8" class="passed">a failing spec with odd backtraces</dt>
     <script type="text/javascript">makeRed('div_group_8');</script>
     <script type="text/javascript">makeRed('example_group_8');</script>
-    <script type="text/javascript">moveProgressBar('81.8');</script>
+    <script type="text/javascript">moveProgressBar('83.3');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace that has no file</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_6">
+      <div class="failure" id="failure_7">
         <div class="message"><pre>Failure/Error: ERB.new(&quot;&lt;%= raise &#39;foo&#39; %&gt;&quot;).result
 
 RuntimeError:
   foo</pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:64:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-    <pre class="ruby"><code><span class="linenum">62</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
-<span class="linenum">63</span>
-<span class="offending"><span class="linenum">64</span>    <span class="constant">ERB</span>.new(<span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;%= raise 'foo' %&gt;</span><span class="delimiter">&quot;</span></span>).result</span>
-<span class="linenum">65</span>  <span class="keyword">end</span></code></pre>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:73:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">71</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
+<span class="linenum">72</span>
+<span class="offending"><span class="linenum">73</span>    <span class="constant">ERB</span>.new(<span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;%= raise 'foo' %&gt;</span><span class="delimiter">&quot;</span></span>).result</span>
+<span class="linenum">74</span>  <span class="keyword">end</span></code></pre>
       </div>
     </dd>
-    <script type="text/javascript">moveProgressBar('90.9');</script>
+    <script type="text/javascript">moveProgressBar('91.6');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace containing an erb file</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_7">
+      <div class="failure" id="failure_8">
         <div class="message"><pre>Failure/Error: Unable to find /foo.html.erb to read failed line
 
 Exception:
@@ -511,7 +541,7 @@ Exception:
     <dd class="example failed">
       <span class="failed_spec_name">raises</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_8">
+      <div class="failure" id="failure_9">
         <div class="message"><pre>Failure/Error: Unable to find matching line from backtrace
 
 RuntimeError:
@@ -523,7 +553,7 @@ RuntimeError:
   </dl>
 </div>
 <script type="text/javascript">document.getElementById('duration').innerHTML = "Finished in <strong>n.nnnn seconds</strong>";</script>
-<script type="text/javascript">document.getElementById('totals').innerHTML = "11 examples, 8 failures, 2 pending";</script>
+<script type="text/javascript">document.getElementById('totals').innerHTML = "12 examples, 9 failures, 2 pending";</script>
 </div>
 </div>
 </body>

--- a/spec/rspec/core/formatters/progress_formatter_spec.rb
+++ b/spec/rspec/core/formatters/progress_formatter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RSpec::Core::Formatters::ProgressFormatter do
     output.gsub!(/ +$/, '') # strip trailing whitespace
 
     expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
-      |**F.FFFF
+      |**FF.FFFFFFF
       |
       |#{expected_summary_output_for_example_specs}
     EOS

--- a/spec/rspec/core/resources/formatter_specs.rb
+++ b/spec/rspec/core/resources/formatter_specs.rb
@@ -5,6 +5,13 @@ RSpec.shared_examples_for "shared" do
     pending
     expect(1).to eq(1)
   end
+  
+  it "fails twice with failure aggregation in shared" do
+    aggregate_failures do
+      expect(1).to eq(2)
+      expect(3).to eq(4)
+    end
+  end
 end
 
 RSpec.describe "pending spec with no implementation" do
@@ -31,6 +38,22 @@ end
 RSpec.describe "failing spec" do
   it "fails" do
     expect(1).to eq(2)
+  end
+  
+  it "fails twice with failure aggregation" do
+    aggregate_failures do
+      expect(1).to eq(2)
+      expect(3).to eq(4)
+    end
+  end
+  
+  context "failure aggregation" do
+    it "fails twice with failure aggregation in context" do
+      aggregate_failures do
+        expect(1).to eq(2)
+        expect(3).to eq(4)
+      end
+    end
   end
 end
 

--- a/spec/rspec/core/resources/formatter_specs.rb
+++ b/spec/rspec/core/resources/formatter_specs.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples_for "shared" do
     pending
     expect(1).to eq(1)
   end
-  
+
   it "fails twice with failure aggregation in shared" do
     aggregate_failures do
       expect(1).to eq(2)
@@ -39,14 +39,14 @@ RSpec.describe "failing spec" do
   it "fails" do
     expect(1).to eq(2)
   end
-  
+
   it "fails twice with failure aggregation" do
     aggregate_failures do
       expect(1).to eq(2)
       expect(3).to eq(4)
     end
   end
-  
+
   context "failure aggregation" do
     it "fails twice with failure aggregation in context" do
       aggregate_failures do
@@ -54,7 +54,7 @@ RSpec.describe "failing spec" do
         expect(3).to eq(4)
       end
     end
-    
+
     it 'has one failure and one error' do
       aggregate_failures do
         expect(1).to eq 1

--- a/spec/rspec/core/resources/formatter_specs.rb
+++ b/spec/rspec/core/resources/formatter_specs.rb
@@ -54,6 +54,15 @@ RSpec.describe "failing spec" do
         expect(3).to eq(4)
       end
     end
+    
+    it 'has one failure and one error' do
+      aggregate_failures do
+        expect(1).to eq 1
+        expect(2).to eq 3
+        expect(4[:error]).to eq 4
+        expect(4).to eq 4
+      end
+    end
   end
 end
 

--- a/spec/rspec/core/resources/formatter_specs.rb
+++ b/spec/rspec/core/resources/formatter_specs.rb
@@ -59,7 +59,7 @@ RSpec.describe "failing spec" do
       aggregate_failures do
         expect(1).to eq 1
         expect(2).to eq 3
-        expect(4[:error]).to eq 4
+        raise
         expect(4).to eq 4
       end
     end

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -164,7 +164,7 @@ module FormatterSupport
         |          # ./spec/rspec/core/resources/formatter_specs.rb:54
         |
         |  6) failing spec failure aggregation has one failure and one error
-        |     Got 2 failures from failure aggregation block.
+        |     Got 1 failure and 1 other error from failure aggregation block.
         |     # ./spec/rspec/core/resources/formatter_specs.rb:59
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
@@ -179,12 +179,8 @@ module FormatterSupport
         |            (compared using ==)
         |          # ./spec/rspec/core/resources/formatter_specs.rb:61
         |
-        |     6.2) Failure/Error: expect(4[:error]).to eq 4
-        |
-        |            expected: 4
-        |                 got: 0
-        |
-        |            (compared using ==)
+        |     6.2) Failure/Error: raise
+        |          RuntimeError:
         |          # ./spec/rspec/core/resources/formatter_specs.rb:62
         |
         |  7) a failing spec with odd backtraces fails with a backtrace that has no file

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -355,11 +355,8 @@ module FormatterSupport
         |            (compared using ==)
         |          # ./spec/rspec/core/resources/formatter_specs.rb:61:in `block (4 levels) in <top (required)>'
         |
-        |     6.2) Failure/Error: expect(4[:error]).to eq 4
-        |
-        |          TypeError:
-        |            no implicit conversion of Symbol into Integer
-        |          # ./spec/rspec/core/resources/formatter_specs.rb:62:in `[]'
+        |     6.2) Failure/Error: raise
+        |          RuntimeError:
         |          # ./spec/rspec/core/resources/formatter_specs.rb:62:in `block (4 levels) in <top (required)>'
         |
         |  7) a failing spec with odd backtraces fails with a backtrace that has no file

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -129,7 +129,7 @@ module FormatterSupport
         |
         |  1) pending spec with no implementation is pending
         |     # Not yet implemented
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:11
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:18
         |
         |  2) pending command with block format with content that would fail is pending
         |     # No reason given
@@ -139,7 +139,7 @@ module FormatterSupport
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:18:in `block (3 levels) in <top (required)>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:25:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
@@ -149,57 +149,157 @@ module FormatterSupport
         |
         |  1) pending command with block format behaves like shared is marked as pending but passes FIXED
         |     Expected pending 'No reason given' to fail. No Error was raised.
-        |     Shared Example Group: "shared" called from ./spec/rspec/core/resources/formatter_specs.rb:22
+        |     Shared Example Group: "shared" called from ./spec/rspec/core/resources/formatter_specs.rb:29
         |     # ./spec/rspec/core/resources/formatter_specs.rb:4
         |
-        |  2) failing spec fails
+        |  2) pending command with block format behaves like shared fails twice with failure aggregation in shared
+        |     Got 2 failures from failure aggregation block.
+        |     Shared Example Group: "shared" called from ./spec/rspec/core/resources/formatter_specs.rb:29
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:10:in `block (2 levels) in <top (required)>'
+        |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
+        |
+        |     2.1) Failure/Error: expect(1).to eq(2)
+        |
+        |            expected: 2
+        |                 got: 1
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:11:in `block (3 levels) in <top (required)>'
+        |
+        |     2.2) Failure/Error: expect(3).to eq(4)
+        |
+        |            expected: 4
+        |                 got: 3
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:12:in `block (3 levels) in <top (required)>'
+        |
+        |  3) failing spec fails
         |     Failure/Error: expect(1).to eq(2)
         |
         |       expected: 2
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in <top (required)>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:40:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
-        |  3) a failing spec with odd backtraces fails with a backtrace that has no file
+        |  4) failing spec fails twice with failure aggregation
+        |     Got 2 failures from failure aggregation block.
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:44:in `block (2 levels) in <top (required)>'
+        |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
+        |
+        |     4.1) Failure/Error: expect(1).to eq(2)
+        |
+        |            expected: 2
+        |                 got: 1
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:45:in `block (3 levels) in <top (required)>'
+        |
+        |     4.2) Failure/Error: expect(3).to eq(4)
+        |
+        |            expected: 4
+        |                 got: 3
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:46:in `block (3 levels) in <top (required)>'
+        |
+        |  5) failing spec failure aggregation fails twice with failure aggregation in context
+        |     Got 2 failures from failure aggregation block.
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:52:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
+        |
+        |     5.1) Failure/Error: expect(1).to eq(2)
+        |
+        |            expected: 2
+        |                 got: 1
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:53:in `block (4 levels) in <top (required)>'
+        |
+        |     5.2) Failure/Error: expect(3).to eq(4)
+        |
+        |            expected: 4
+        |                 got: 3
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:54:in `block (4 levels) in <top (required)>'
+        |
+        |  6) failing spec failure aggregation has one failure and one error
+        |     Got 1 failure and 1 other error from failure aggregation block.
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:59:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
+        |
+        |     6.1) Failure/Error: expect(2).to eq 3
+        |
+        |            expected: 3
+        |                 got: 2
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:61:in `block (4 levels) in <top (required)>'
+        |
+        |     6.2) Failure/Error: expect(4[:error]).to eq 4
+        |
+        |          TypeError:
+        |            no implicit conversion of Symbol into Integer
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:62:in `[]'
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:62:in `block (4 levels) in <top (required)>'
+        |
+        |  7) a failing spec with odd backtraces fails with a backtrace that has no file
         |     Failure/Error: ERB.new("<%= raise 'foo' %>").result
         |
         |     RuntimeError:
         |       foo
         |     # (erb):1:in `<main>'
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in <top (required)>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:73:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
-        |  4) a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |  8) a failing spec with odd backtraces fails with a backtrace containing an erb file
         |     Failure/Error: Unable to find /foo.html.erb to read failed line
         |
         |     Exception:
         |       Exception
         |     # /foo.html.erb:1:in `<main>': foo (RuntimeError)
         |
-        |  5) a failing spec with odd backtraces with a `nil` backtrace raises
+        |  9) a failing spec with odd backtraces with a `nil` backtrace raises
         |     Failure/Error: Unable to find matching line from backtrace
         |
         |     RuntimeError:
         |       boom
         |
         |Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-        |8 examples, 5 failures, 2 pending
+        |12 examples, 9 failures, 2 pending
         |
         |Failed examples:
         |
         |rspec ./spec/rspec/core/resources/formatter_specs.rb:4 # pending command with block format behaves like shared is marked as pending but passes
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:32 # failing spec fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:38 # a failing spec with odd backtraces fails with a backtrace that has no file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:44 # a failing spec with odd backtraces fails with a backtrace containing an erb file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:62 # a failing spec with odd backtraces with a `nil` backtrace raises
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:9 # pending command with block format behaves like shared fails twice with failure aggregation in shared
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:39 # failing spec fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:43 # failing spec fails twice with failure aggregation
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:51 # failing spec failure aggregation fails twice with failure aggregation in context
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:58 # failing spec failure aggregation has one failure and one error
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:70 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:76 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:94 # a failing spec with odd backtraces with a `nil` backtrace raises
       EOS
     end
   end

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -54,7 +54,7 @@ module FormatterSupport
         |
         |  1) pending spec with no implementation is pending
         |     # Not yet implemented
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:11
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:18
         |
         |  2) pending command with block format with content that would fail is pending
         |     # No reason given
@@ -64,7 +64,7 @@ module FormatterSupport
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:18
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:25
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14
@@ -74,52 +74,153 @@ module FormatterSupport
         |
         |  1) pending command with block format behaves like shared is marked as pending but passes FIXED
         |     Expected pending 'No reason given' to fail. No Error was raised.
-        |     Shared Example Group: "shared" called from ./spec/rspec/core/resources/formatter_specs.rb:22
+        |     Shared Example Group: "shared" called from ./spec/rspec/core/resources/formatter_specs.rb:29
         |     # ./spec/rspec/core/resources/formatter_specs.rb:4
         |
-        |  2) failing spec fails
+        |  2) pending command with block format behaves like shared fails twice with failure aggregation in shared
+        |     Got 2 failures from failure aggregation block.
+        |     Shared Example Group: "shared" called from ./spec/rspec/core/resources/formatter_specs.rb:29
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:10
+        |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/sandboxing.rb:14
+        |     # ./spec/support/sandboxing.rb:7
+        |
+        |     2.1) Failure/Error: expect(1).to eq(2)
+        |
+        |            expected: 2
+        |                 got: 1
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:11
+        |
+        |     2.2) Failure/Error: expect(3).to eq(4)
+        |
+        |            expected: 4
+        |                 got: 3
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:12
+        |
+        |  3) failing spec fails
         |     Failure/Error: expect(1).to eq(2)
         |
         |       expected: 2
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:33
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:40
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:14
         |     # ./spec/support/sandboxing.rb:7
         |
-        |  3) a failing spec with odd backtraces fails with a backtrace that has no file
+        |  4) failing spec fails twice with failure aggregation
+        |     Got 2 failures from failure aggregation block.
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:44
+        |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/sandboxing.rb:14
+        |     # ./spec/support/sandboxing.rb:7
+        |
+        |     4.1) Failure/Error: expect(1).to eq(2)
+        |
+        |            expected: 2
+        |                 got: 1
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:45
+        |
+        |     4.2) Failure/Error: expect(3).to eq(4)
+        |
+        |            expected: 4
+        |                 got: 3
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:46
+        |
+        |  5) failing spec failure aggregation fails twice with failure aggregation in context
+        |     Got 2 failures from failure aggregation block.
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:52
+        |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/sandboxing.rb:14
+        |     # ./spec/support/sandboxing.rb:7
+        |
+        |     5.1) Failure/Error: expect(1).to eq(2)
+        |
+        |            expected: 2
+        |                 got: 1
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:53
+        |
+        |     5.2) Failure/Error: expect(3).to eq(4)
+        |
+        |            expected: 4
+        |                 got: 3
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:54
+        |
+        |  6) failing spec failure aggregation has one failure and one error
+        |     Got 2 failures from failure aggregation block.
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:59
+        |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/sandboxing.rb:14
+        |     # ./spec/support/sandboxing.rb:7
+        |
+        |     6.1) Failure/Error: expect(2).to eq 3
+        |
+        |            expected: 3
+        |                 got: 2
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:61
+        |
+        |     6.2) Failure/Error: expect(4[:error]).to eq 4
+        |
+        |            expected: 4
+        |                 got: 0
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:62
+        |
+        |  7) a failing spec with odd backtraces fails with a backtrace that has no file
         |     Failure/Error: Unable to find (erb) to read failed line
         |
         |     RuntimeError:
         |       foo
         |     # (erb):1
         |
-        |  4) a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |  8) a failing spec with odd backtraces fails with a backtrace containing an erb file
         |     Failure/Error: Unable to find /foo.html.erb to read failed line
         |
         |     Exception:
         |       Exception
         |     # /foo.html.erb:1:in `<main>': foo (RuntimeError)
         |
-        |  5) a failing spec with odd backtraces with a `nil` backtrace raises
+        |  9) a failing spec with odd backtraces with a `nil` backtrace raises
         |     Failure/Error: Unable to find matching line from backtrace
         |
         |     RuntimeError:
         |       boom
         |
         |Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-        |8 examples, 5 failures, 2 pending
+        |12 examples, 9 failures, 2 pending
         |
         |Failed examples:
         |
         |rspec ./spec/rspec/core/resources/formatter_specs.rb:4 # pending command with block format behaves like shared is marked as pending but passes
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:32 # failing spec fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:38 # a failing spec with odd backtraces fails with a backtrace that has no file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:44 # a failing spec with odd backtraces fails with a backtrace containing an erb file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:62 # a failing spec with odd backtraces with a `nil` backtrace raises
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:9 # pending command with block format behaves like shared fails twice with failure aggregation in shared
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:39 # failing spec fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:43 # failing spec fails twice with failure aggregation
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:51 # failing spec failure aggregation fails twice with failure aggregation in context
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:58 # failing spec failure aggregation has one failure and one error
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:70 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:76 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:94 # a failing spec with odd backtraces with a `nil` backtrace raises
       EOS
     end
   else


### PR DESCRIPTION
This is a possible fix for #2319. If someone knows a better way to output the failure details in the html formatter, please let me know.

What I did is get the failure details from _failure.fully_formatted_ method and then formatting the string (removing color codes and removing the first line that display the example name because it would be duplicated in the html formatter) only if the exception is a MultipleExpectationsNotMetError or MultipleExceptionError. For other exceptions, the behavior is not modified.

I have also added the tests and updated the expected output for the formatters.

