### PR TITLE
Add multiple failures to HTML formatter

### DIFF
--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -346,7 +346,10 @@ module RSpec
 
                 failure   = common_backtrace_truncater.with_truncated_backtrace(failure)
                 presenter = ExceptionPresenter.new(failure, @example, options)
-                presenter.fully_formatted_lines("#{failure_number}.#{index + 1}", colorizer)
+                presenter.fully_formatted_lines(
+                  "#{failure_number ? "#{failure_number}." : ''}#{index + 1}",
+                  colorizer
+                )
               end
             end
           end

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -73,7 +73,7 @@ module RSpec
           exception_details = if exception
                                 {
                                   :message => message_lines.drop(2).join("\n"),
-                                  :backtrace => failure.formatted_backtrace.join("\n")
+                                  :backtrace => failure.formatted_backtrace.join("\n"),
                                 }
                               end
           extra = extra_failure_content(failure)

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -72,8 +72,7 @@ module RSpec
           message_lines = failure.fully_formatted_lines(nil, RSpec::Core::Notifications::NullColorizer)
           exception_details = if exception
                                 {
-                                  # the regular expression here removes the CLI leading indentation, and any trailing spaces.
-                                  :message => message_lines.drop(2).join("\n").gsub(/^  (.*?)( +)?$/, '\1'),
+                                  :message => message_lines.drop(2).join("\n"),
                                   :backtrace => failure.formatted_backtrace.join("\n")
                                 }
                               end

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -69,9 +69,11 @@ module RSpec
           example = failure.example
 
           exception = failure.exception
+          message_lines = failure.fully_formatted_lines(nil, RSpec::Core::Notifications::NullColorizer)
           exception_details = if exception
                                 {
-                                  :message => failure.message_lines.join("\n"),
+                                  # the regular expression here removes the CLI leading indentation, and any trailing spaces.
+                                  :message => message_lines.drop(2).join("\n").gsub(/^  (.*?)( +)?$/, '\1'),
                                   :backtrace => failure.formatted_backtrace.join("\n")
                                 }
                               end

--- a/lib/rspec/core/formatters/html_formatter.rb
+++ b/lib/rspec/core/formatters/html_formatter.rb
@@ -72,6 +72,7 @@ module RSpec
           message_lines = failure.fully_formatted_lines(nil, RSpec::Core::Notifications::NullColorizer)
           exception_details = if exception
                                 {
+                                  # drop 2 removes the description (regardless of newlines) and leading blank line
                                   :message => message_lines.drop(2).join("\n"),
                                   :backtrace => failure.formatted_backtrace.join("\n"),
                                 }

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -200,6 +200,12 @@ module RSpec::Core
         @exception_presenter.fully_formatted(failure_number, colorizer)
       end
 
+      # @return [Array] The failure information fully formatted in the way that
+      #   RSpec's built-in formatters emit, split by line.
+      def fully_formatted_lines(failure_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        @exception_presenter.fully_formatted_lines(failure_number, colorizer)
+      end
+
     private
 
       def initialize(example, exception_presenter=Formatters::ExceptionPresenter::Factory.new(example).build)

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -200,7 +200,7 @@ module RSpec::Core
         @exception_presenter.fully_formatted(failure_number, colorizer)
       end
 
-      # @return [Array] The failure information fully formatted in the way that
+      # @return [Array<string>] The failure information fully formatted in the way that
       #   RSpec's built-in formatters emit, split by line.
       def fully_formatted_lines(failure_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         @exception_presenter.fully_formatted_lines(failure_number, colorizer)

--- a/spec/rspec/core/bisect/server_spec.rb
+++ b/spec/rspec/core/bisect/server_spec.rb
@@ -70,6 +70,7 @@ module RSpec::Core
             ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
             ./spec/rspec/core/resources/formatter_specs.rb[3:1]
             ./spec/rspec/core/resources/formatter_specs.rb[4:1]
+            ./spec/rspec/core/resources/formatter_specs.rb[4:2]
             ./spec/rspec/core/resources/formatter_specs.rb[5:1]
             ./spec/rspec/core/resources/formatter_specs.rb[5:2]
             ./spec/rspec/core/resources/formatter_specs.rb[5:3:1]
@@ -78,6 +79,7 @@ module RSpec::Core
           expect(results.failed_example_ids).to eq %w[
             ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
             ./spec/rspec/core/resources/formatter_specs.rb[4:1]
+            ./spec/rspec/core/resources/formatter_specs.rb[4:2]
             ./spec/rspec/core/resources/formatter_specs.rb[5:1]
             ./spec/rspec/core/resources/formatter_specs.rb[5:2]
             ./spec/rspec/core/resources/formatter_specs.rb[5:3:1]

--- a/spec/rspec/core/bisect/server_spec.rb
+++ b/spec/rspec/core/bisect/server_spec.rb
@@ -69,6 +69,7 @@ module RSpec::Core
             ./spec/rspec/core/resources/formatter_specs.rb[2:1:1]
             ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
             ./spec/rspec/core/resources/formatter_specs.rb[3:1]
+            ./spec/rspec/core/resources/formatter_specs.rb[3:2]
             ./spec/rspec/core/resources/formatter_specs.rb[4:1]
             ./spec/rspec/core/resources/formatter_specs.rb[4:2]
             ./spec/rspec/core/resources/formatter_specs.rb[5:1]
@@ -104,6 +105,7 @@ module RSpec::Core
               ./spec/rspec/core/resources/formatter_specs.rb[2:1:1]
               ./spec/rspec/core/resources/formatter_specs.rb[2:2:1]
               ./spec/rspec/core/resources/formatter_specs.rb[3:1]
+              ./spec/rspec/core/resources/formatter_specs.rb[3:2]
               ./spec/rspec/core/resources/formatter_specs.rb[4:1]
             ],
             :failed_example_ids => %w[

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -101,12 +101,13 @@ root
         |
         |failing spec
         |  fails (FAILED - 2)
+        |  fails twice (FAILED - 3)
         |
         |a failing spec with odd backtraces
-        |  fails with a backtrace that has no file (FAILED - 3)
-        |  fails with a backtrace containing an erb file (FAILED - 4)
+        |  fails with a backtrace that has no file (FAILED - 4)
+        |  fails with a backtrace containing an erb file (FAILED - 5)
         |  with a `nil` backtrace
-        |    raises (FAILED - 5)
+        |    raises (FAILED - 6)
         |
         |#{expected_summary_output_for_example_specs}
       EOS

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -98,6 +98,8 @@ root
         |
         |passing spec
         |  passes
+        |  passes with a multiple
+        |     line description
         |
         |failing spec
         |  fails (FAILED - 2)

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -316,7 +316,8 @@ a {
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_1">
         <div class="message"><pre>Expected pending &#39;No reason given&#39; to fail. No Error was raised.
-Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources/formatter_specs.rb:22</pre></div>
+Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources/formatter_specs.rb:22
+# ./spec/rspec/core/resources/formatter_specs.rb:4</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:4</pre></div>
     <pre class="ruby"><code><span class="linenum">2</span>
 <span class="linenum">3</span><span class="constant">RSpec</span>.shared_examples_for <span class="string"><span class="delimiter">&quot;</span><span class="content">shared</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
@@ -349,7 +350,8 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
   expected: 2
        got: 1
 
-  (compared using ==)</pre></div>
+  (compared using ==)
+# ./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
     <pre class="ruby"><code><span class="linenum">31</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="linenum">32</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
@@ -362,7 +364,23 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
       <span class="failed_spec_name">fails twice</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_3">
-        <div class="message"><pre></pre></div>
+        <div class="message"><pre>Got 2 failures:
+
+.1) Failure/Error: expect(1).to eq(2)
+
+      expected: 2
+           got: 1
+
+      (compared using ==)
+    # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in &lt;top (required)&gt;&#39;
+
+.2) Failure/Error: expect(3).to eq(4)
+
+      expected: 4
+           got: 3
+
+      (compared using ==)
+    # ./spec/rspec/core/resources/formatter_specs.rb:38:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre></pre></div>
     <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for </span></code></pre>
       </div>
@@ -382,7 +400,8 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
         <div class="message"><pre>Failure/Error: ERB.new(&quot;&lt;%= raise &#39;foo&#39; %&gt;&quot;).result
 
 RuntimeError:
-  foo</pre></div>
+  foo
+# ./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
     <pre class="ruby"><code><span class="linenum">44</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
 <span class="linenum">45</span>
@@ -398,7 +417,13 @@ RuntimeError:
         <div class="message"><pre>Failure/Error: Unable to find /foo.html.erb to read failed line
 
 Exception:
-  Exception</pre></div>
+  Exception
+# /foo.html.erb:1:in `&lt;main&gt;&#39;: foo (RuntimeError)
+#    from /lib/ruby/1.9.1/erb.rb:753:in `eval&#39;
+#
+#   Showing full backtrace because every line was filtered out.
+#   See docs for RSpec::Configuration#backtrace_exclusion_patterns and
+#   RSpec::Configuration#backtrace_inclusion_patterns for more information.</pre></div>
         <div class="backtrace"><pre>/foo.html.erb:1:in `&lt;main&gt;&#39;: foo (RuntimeError)
    from /lib/ruby/1.9.1/erb.rb:753:in `eval&#39;
 

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -285,7 +285,7 @@ a {
     <script type="text/javascript">makeYellow('rspec-header');</script>
     <script type="text/javascript">makeYellow('div_group_1');</script>
     <script type="text/javascript">makeYellow('example_group_1');</script>
-    <script type="text/javascript">moveProgressBar('12.5');</script>
+    <script type="text/javascript">moveProgressBar('11.1');</script>
     <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: Not yet implemented)</span></dd>
   </dl>
 </div>
@@ -300,7 +300,7 @@ a {
     <script type="text/javascript">makeYellow('rspec-header');</script>
     <script type="text/javascript">makeYellow('div_group_3');</script>
     <script type="text/javascript">makeYellow('example_group_3');</script>
-    <script type="text/javascript">moveProgressBar('25.0');</script>
+    <script type="text/javascript">moveProgressBar('22.2');</script>
     <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: No reason given)</span></dd>
   </dl>
 </div>
@@ -310,7 +310,7 @@ a {
     <script type="text/javascript">makeRed('rspec-header');</script>
     <script type="text/javascript">makeRed('div_group_4');</script>
     <script type="text/javascript">makeRed('example_group_4');</script>
-    <script type="text/javascript">moveProgressBar('37.5');</script>
+    <script type="text/javascript">moveProgressBar('33.3');</script>
     <dd class="example pending_fixed">
       <span class="failed_spec_name">is marked as pending but passes</span>
       <span class="duration">n.nnnns</span>
@@ -330,7 +330,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
 <div id="div_group_5" class="example_group passed">
   <dl style="margin-left: 0px;">
   <dt id="example_group_5" class="passed">passing spec</dt>
-    <script type="text/javascript">moveProgressBar('50.0');</script>
+    <script type="text/javascript">moveProgressBar('44.4');</script>
     <dd class="example passed"><span class="passed_spec_name">passes</span><span class='duration'>n.nnnns</span></dd>
   </dl>
 </div>
@@ -339,7 +339,7 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
   <dt id="example_group_6" class="passed">failing spec</dt>
     <script type="text/javascript">makeRed('div_group_6');</script>
     <script type="text/javascript">makeRed('example_group_6');</script>
-    <script type="text/javascript">moveProgressBar('62.5');</script>
+    <script type="text/javascript">moveProgressBar('55.5');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails</span>
       <span class="duration">n.nnnns</span>
@@ -354,8 +354,17 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
     <pre class="ruby"><code><span class="linenum">31</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="linenum">32</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="offending"><span class="linenum">33</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
-<span class="linenum">34</span>  <span class="keyword">end</span>
-<span class="linenum">35</span><span class="keyword">end</span></code></pre>
+<span class="linenum">34</span>  <span class="keyword">end</span></code></pre>
+      </div>
+    </dd>
+    <script type="text/javascript">moveProgressBar('66.6');</script>
+    <dd class="example failed">
+      <span class="failed_spec_name">fails twice</span>
+      <span class="duration">n.nnnns</span>
+      <div class="failure" id="failure_3">
+        <div class="message"><pre></pre></div>
+        <div class="backtrace"><pre></pre></div>
+    <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for </span></code></pre>
       </div>
     </dd>
   </dl>
@@ -365,27 +374,27 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
   <dt id="example_group_7" class="passed">a failing spec with odd backtraces</dt>
     <script type="text/javascript">makeRed('div_group_7');</script>
     <script type="text/javascript">makeRed('example_group_7');</script>
-    <script type="text/javascript">moveProgressBar('75.0');</script>
+    <script type="text/javascript">moveProgressBar('77.7');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace that has no file</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_3">
+      <div class="failure" id="failure_4">
         <div class="message"><pre>Failure/Error: ERB.new(&quot;&lt;%= raise &#39;foo&#39; %&gt;&quot;).result
 
 RuntimeError:
   foo</pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-    <pre class="ruby"><code><span class="linenum">39</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
-<span class="linenum">40</span>
-<span class="offending"><span class="linenum">41</span>    <span class="constant">ERB</span>.new(<span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;%= raise 'foo' %&gt;</span><span class="delimiter">&quot;</span></span>).result</span>
-<span class="linenum">42</span>  <span class="keyword">end</span></code></pre>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">44</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
+<span class="linenum">45</span>
+<span class="offending"><span class="linenum">46</span>    <span class="constant">ERB</span>.new(<span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;%= raise 'foo' %&gt;</span><span class="delimiter">&quot;</span></span>).result</span>
+<span class="linenum">47</span>  <span class="keyword">end</span></code></pre>
       </div>
     </dd>
-    <script type="text/javascript">moveProgressBar('87.5');</script>
+    <script type="text/javascript">moveProgressBar('88.8');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace containing an erb file</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_4">
+      <div class="failure" id="failure_5">
         <div class="message"><pre>Failure/Error: Unable to find /foo.html.erb to read failed line
 
 Exception:
@@ -410,7 +419,7 @@ Exception:
     <dd class="example failed">
       <span class="failed_spec_name">raises</span>
       <span class="duration">n.nnnns</span>
-      <div class="failure" id="failure_5">
+      <div class="failure" id="failure_6">
         <div class="message"><pre>Failure/Error: Unable to find matching line from backtrace
 
 RuntimeError:
@@ -422,7 +431,7 @@ RuntimeError:
   </dl>
 </div>
 <script type="text/javascript">document.getElementById('duration').innerHTML = "Finished in <strong>n.nnnn seconds</strong>";</script>
-<script type="text/javascript">document.getElementById('totals').innerHTML = "8 examples, 5 failures, 2 pending";</script>
+<script type="text/javascript">document.getElementById('totals').innerHTML = "9 examples, 6 failures, 2 pending";</script>
 </div>
 </div>
 </body>

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -315,9 +315,9 @@ a {
       <span class="failed_spec_name">is marked as pending but passes</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_1">
-        <div class="message"><pre>Expected pending &#39;No reason given&#39; to fail. No Error was raised.
-Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources/formatter_specs.rb:22
-# ./spec/rspec/core/resources/formatter_specs.rb:4</pre></div>
+        <div class="message"><pre>  Expected pending &#39;No reason given&#39; to fail. No Error was raised.
+  Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources/formatter_specs.rb:22
+  # ./spec/rspec/core/resources/formatter_specs.rb:4</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:4</pre></div>
     <pre class="ruby"><code><span class="linenum">2</span>
 <span class="linenum">3</span><span class="constant">RSpec</span>.shared_examples_for <span class="string"><span class="delimiter">&quot;</span><span class="content">shared</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
@@ -345,13 +345,13 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
       <span class="failed_spec_name">fails</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_2">
-        <div class="message"><pre>Failure/Error: expect(1).to eq(2)
+        <div class="message"><pre>  Failure/Error: expect(1).to eq(2)
 
-  expected: 2
-       got: 1
+    expected: 2
+         got: 1
 
-  (compared using ==)
-# ./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    (compared using ==)
+  # ./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
     <pre class="ruby"><code><span class="linenum">31</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
 <span class="linenum">32</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
@@ -364,23 +364,23 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
       <span class="failed_spec_name">fails twice</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_3">
-        <div class="message"><pre>Got 2 failures:
+        <div class="message"><pre>  Got 2 failures:
 
-.1) Failure/Error: expect(1).to eq(2)
+  .1) Failure/Error: expect(1).to eq(2)
 
-      expected: 2
-           got: 1
+        expected: 2
+             got: 1
 
-      (compared using ==)
-    # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in &lt;top (required)&gt;&#39;
+        (compared using ==)
+      # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in &lt;top (required)&gt;&#39;
 
-.2) Failure/Error: expect(3).to eq(4)
+  .2) Failure/Error: expect(3).to eq(4)
 
-      expected: 4
-           got: 3
+        expected: 4
+             got: 3
 
-      (compared using ==)
-    # ./spec/rspec/core/resources/formatter_specs.rb:38:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+        (compared using ==)
+      # ./spec/rspec/core/resources/formatter_specs.rb:38:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre></pre></div>
     <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for </span></code></pre>
       </div>
@@ -397,11 +397,11 @@ Shared Example Group: &quot;shared&quot; called from ./spec/rspec/core/resources
       <span class="failed_spec_name">fails with a backtrace that has no file</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_4">
-        <div class="message"><pre>Failure/Error: ERB.new(&quot;&lt;%= raise &#39;foo&#39; %&gt;&quot;).result
+        <div class="message"><pre>  Failure/Error: ERB.new(&quot;&lt;%= raise &#39;foo&#39; %&gt;&quot;).result
 
-RuntimeError:
-  foo
-# ./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+  RuntimeError:
+    foo
+  # ./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
     <pre class="ruby"><code><span class="linenum">44</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
 <span class="linenum">45</span>
@@ -414,16 +414,16 @@ RuntimeError:
       <span class="failed_spec_name">fails with a backtrace containing an erb file</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_5">
-        <div class="message"><pre>Failure/Error: Unable to find /foo.html.erb to read failed line
+        <div class="message"><pre>  Failure/Error: Unable to find /foo.html.erb to read failed line
 
-Exception:
-  Exception
-# /foo.html.erb:1:in `&lt;main&gt;&#39;: foo (RuntimeError)
-#    from /lib/ruby/1.9.1/erb.rb:753:in `eval&#39;
-#
-#   Showing full backtrace because every line was filtered out.
-#   See docs for RSpec::Configuration#backtrace_exclusion_patterns and
-#   RSpec::Configuration#backtrace_inclusion_patterns for more information.</pre></div>
+  Exception:
+    Exception
+  # /foo.html.erb:1:in `&lt;main&gt;&#39;: foo (RuntimeError)
+  #    from /lib/ruby/1.9.1/erb.rb:753:in `eval&#39;
+  # 
+  #   Showing full backtrace because every line was filtered out.
+  #   See docs for RSpec::Configuration#backtrace_exclusion_patterns and
+  #   RSpec::Configuration#backtrace_inclusion_patterns for more information.</pre></div>
         <div class="backtrace"><pre>/foo.html.erb:1:in `&lt;main&gt;&#39;: foo (RuntimeError)
    from /lib/ruby/1.9.1/erb.rb:753:in `eval&#39;
 
@@ -445,10 +445,10 @@ Exception:
       <span class="failed_spec_name">raises</span>
       <span class="duration">n.nnnns</span>
       <div class="failure" id="failure_6">
-        <div class="message"><pre>Failure/Error: Unable to find matching line from backtrace
+        <div class="message"><pre>  Failure/Error: Unable to find matching line from backtrace
 
-RuntimeError:
-  boom</pre></div>
+  RuntimeError:
+    boom</pre></div>
         <div class="backtrace"><pre></pre></div>
     <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for </span></code></pre>
       </div>

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -285,7 +285,7 @@ a {
     <script type="text/javascript">makeYellow('rspec-header');</script>
     <script type="text/javascript">makeYellow('div_group_1');</script>
     <script type="text/javascript">makeYellow('example_group_1');</script>
-    <script type="text/javascript">moveProgressBar('11.1');</script>
+    <script type="text/javascript">moveProgressBar('10.0');</script>
     <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: Not yet implemented)</span></dd>
   </dl>
 </div>
@@ -300,7 +300,7 @@ a {
     <script type="text/javascript">makeYellow('rspec-header');</script>
     <script type="text/javascript">makeYellow('div_group_3');</script>
     <script type="text/javascript">makeYellow('example_group_3');</script>
-    <script type="text/javascript">moveProgressBar('22.2');</script>
+    <script type="text/javascript">moveProgressBar('20.0');</script>
     <dd class="example not_implemented"><span class="not_implemented_spec_name">is pending (PENDING: No reason given)</span></dd>
   </dl>
 </div>
@@ -310,7 +310,7 @@ a {
     <script type="text/javascript">makeRed('rspec-header');</script>
     <script type="text/javascript">makeRed('div_group_4');</script>
     <script type="text/javascript">makeRed('example_group_4');</script>
-    <script type="text/javascript">moveProgressBar('33.3');</script>
+    <script type="text/javascript">moveProgressBar('30.0');</script>
     <dd class="example pending_fixed">
       <span class="failed_spec_name">is marked as pending but passes</span>
       <span class="duration">n.nnnns</span>
@@ -331,8 +331,11 @@ a {
 <div id="div_group_5" class="example_group passed">
   <dl style="margin-left: 0px;">
   <dt id="example_group_5" class="passed">passing spec</dt>
-    <script type="text/javascript">moveProgressBar('44.4');</script>
+    <script type="text/javascript">moveProgressBar('40.0');</script>
     <dd class="example passed"><span class="passed_spec_name">passes</span><span class='duration'>n.nnnns</span></dd>
+    <script type="text/javascript">moveProgressBar('50.0');</script>
+    <dd class="example passed"><span class="passed_spec_name">passes with a multiple
+     line description</span><span class='duration'>n.nnnns</span></dd>
   </dl>
 </div>
 <div id="div_group_6" class="example_group passed">
@@ -340,7 +343,7 @@ a {
   <dt id="example_group_6" class="passed">failing spec</dt>
     <script type="text/javascript">makeRed('div_group_6');</script>
     <script type="text/javascript">makeRed('example_group_6');</script>
-    <script type="text/javascript">moveProgressBar('55.5');</script>
+    <script type="text/javascript">moveProgressBar('60.0');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails</span>
       <span class="duration">n.nnnns</span>
@@ -351,15 +354,15 @@ a {
          got: 1
 
     (compared using ==)
-  # ./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-    <pre class="ruby"><code><span class="linenum">31</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
-<span class="linenum">32</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
-<span class="offending"><span class="linenum">33</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
-<span class="linenum">34</span>  <span class="keyword">end</span></code></pre>
+  # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">35</span><span class="constant">RSpec</span>.describe <span class="string"><span class="delimiter">&quot;</span><span class="content">failing spec</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="linenum">36</span>  it <span class="string"><span class="delimiter">&quot;</span><span class="content">fails</span><span class="delimiter">&quot;</span></span> <span class="keyword">do</span>
+<span class="offending"><span class="linenum">37</span>    expect(<span class="integer">1</span>).to eq(<span class="integer">2</span>)</span>
+<span class="linenum">38</span>  <span class="keyword">end</span></code></pre>
       </div>
     </dd>
-    <script type="text/javascript">moveProgressBar('66.6');</script>
+    <script type="text/javascript">moveProgressBar('70.0');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails twice</span>
       <span class="duration">n.nnnns</span>
@@ -372,7 +375,7 @@ a {
              got: 1
 
         (compared using ==)
-      # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in &lt;top (required)&gt;&#39;
+      # ./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in &lt;top (required)&gt;&#39;
 
   .2) Failure/Error: expect(3).to eq(4)
 
@@ -380,7 +383,7 @@ a {
              got: 3
 
         (compared using ==)
-      # ./spec/rspec/core/resources/formatter_specs.rb:38:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+      # ./spec/rspec/core/resources/formatter_specs.rb:42:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre></pre></div>
     <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for </span></code></pre>
       </div>
@@ -392,7 +395,7 @@ a {
   <dt id="example_group_7" class="passed">a failing spec with odd backtraces</dt>
     <script type="text/javascript">makeRed('div_group_7');</script>
     <script type="text/javascript">makeRed('example_group_7');</script>
-    <script type="text/javascript">moveProgressBar('77.7');</script>
+    <script type="text/javascript">moveProgressBar('80.0');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace that has no file</span>
       <span class="duration">n.nnnns</span>
@@ -401,15 +404,15 @@ a {
 
   RuntimeError:
     foo
-  # ./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
-    <pre class="ruby"><code><span class="linenum">44</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
-<span class="linenum">45</span>
-<span class="offending"><span class="linenum">46</span>    <span class="constant">ERB</span>.new(<span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;%= raise 'foo' %&gt;</span><span class="delimiter">&quot;</span></span>).result</span>
-<span class="linenum">47</span>  <span class="keyword">end</span></code></pre>
+  # ./spec/rspec/core/resources/formatter_specs.rb:50:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+        <div class="backtrace"><pre>./spec/rspec/core/resources/formatter_specs.rb:50:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+    <pre class="ruby"><code><span class="linenum">48</span>    require <span class="string"><span class="delimiter">'</span><span class="content">erb</span><span class="delimiter">'</span></span>
+<span class="linenum">49</span>
+<span class="offending"><span class="linenum">50</span>    <span class="constant">ERB</span>.new(<span class="string"><span class="delimiter">&quot;</span><span class="content">&lt;%= raise 'foo' %&gt;</span><span class="delimiter">&quot;</span></span>).result</span>
+<span class="linenum">51</span>  <span class="keyword">end</span></code></pre>
       </div>
     </dd>
-    <script type="text/javascript">moveProgressBar('88.8');</script>
+    <script type="text/javascript">moveProgressBar('90.0');</script>
     <dd class="example failed">
       <span class="failed_spec_name">fails with a backtrace containing an erb file</span>
       <span class="duration">n.nnnns</span>
@@ -456,7 +459,7 @@ a {
   </dl>
 </div>
 <script type="text/javascript">document.getElementById('duration').innerHTML = "Finished in <strong>n.nnnn seconds</strong>";</script>
-<script type="text/javascript">document.getElementById('totals').innerHTML = "9 examples, 6 failures, 2 pending";</script>
+<script type="text/javascript">document.getElementById('totals').innerHTML = "10 examples, 6 failures, 2 pending";</script>
 </div>
 </div>
 </body>

--- a/spec/rspec/core/formatters/html_formatted.html
+++ b/spec/rspec/core/formatters/html_formatted.html
@@ -369,21 +369,21 @@ a {
       <div class="failure" id="failure_3">
         <div class="message"><pre>  Got 2 failures:
 
-  .1) Failure/Error: expect(1).to eq(2)
+  1) Failure/Error: expect(1).to eq(2)
 
-        expected: 2
-             got: 1
+       expected: 2
+            got: 1
 
-        (compared using ==)
-      # ./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in &lt;top (required)&gt;&#39;
+       (compared using ==)
+     # ./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in &lt;top (required)&gt;&#39;
 
-  .2) Failure/Error: expect(3).to eq(4)
+  2) Failure/Error: expect(3).to eq(4)
 
-        expected: 4
-             got: 3
+       expected: 4
+            got: 3
 
-        (compared using ==)
-      # ./spec/rspec/core/resources/formatter_specs.rb:42:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
+       (compared using ==)
+     # ./spec/rspec/core/resources/formatter_specs.rb:42:in `block (2 levels) in &lt;top (required)&gt;&#39;</pre></div>
         <div class="backtrace"><pre></pre></div>
     <pre class="ruby"><code><span class="linenum">-1</span><span class="comment"># Couldn't get snippet for </span></code></pre>
       </div>

--- a/spec/rspec/core/formatters/progress_formatter_spec.rb
+++ b/spec/rspec/core/formatters/progress_formatter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RSpec::Core::Formatters::ProgressFormatter do
     output.gsub!(/ +$/, '') # strip trailing whitespace
 
     expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
-      |**F.FFFF
+      |**F.FFFFF
       |
       |#{expected_summary_output_for_example_specs}
     EOS

--- a/spec/rspec/core/formatters/progress_formatter_spec.rb
+++ b/spec/rspec/core/formatters/progress_formatter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RSpec::Core::Formatters::ProgressFormatter do
     output.gsub!(/ +$/, '') # strip trailing whitespace
 
     expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
-      |**F.FFFFF
+      |**F..FFFFF
       |
       |#{expected_summary_output_for_example_specs}
     EOS

--- a/spec/rspec/core/resources/formatter_specs.rb
+++ b/spec/rspec/core/resources/formatter_specs.rb
@@ -32,6 +32,11 @@ RSpec.describe "failing spec" do
   it "fails" do
     expect(1).to eq(2)
   end
+
+  it "fails twice", :aggregate_failures do
+    expect(1).to eq(2)
+    expect(3).to eq(4)
+  end
 end
 
 RSpec.describe "a failing spec with odd backtraces" do

--- a/spec/rspec/core/resources/formatter_specs.rb
+++ b/spec/rspec/core/resources/formatter_specs.rb
@@ -26,6 +26,10 @@ RSpec.describe "passing spec" do
   it "passes" do
     expect(1).to eq(1)
   end
+
+  it 'passes with a multiple
+     line description' do
+  end
 end
 
 RSpec.describe "failing spec" do

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -90,36 +90,56 @@ module FormatterSupport
         |     # ./spec/support/sandboxing.rb:16
         |     # ./spec/support/sandboxing.rb:7
         |
-        |  3) a failing spec with odd backtraces fails with a backtrace that has no file
+        |  3) failing spec fails twice
+        |     Got 2 failures:
+        |
+        |     3.1) Failure/Error: expect(1).to eq(2)
+        |
+        |            expected: 2
+        |                 got: 1
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:37
+        |
+        |     3.2) Failure/Error: expect(3).to eq(4)
+        |
+        |            expected: 4
+        |                 got: 3
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:38
+        |
+        |  4) a failing spec with odd backtraces fails with a backtrace that has no file
         |     Failure/Error: Unable to find (erb) to read failed line
         |
         |     RuntimeError:
         |       foo
         |     # (erb):1
         |
-        |  4) a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |  5) a failing spec with odd backtraces fails with a backtrace containing an erb file
         |     Failure/Error: Unable to find /foo.html.erb to read failed line
         |
         |     Exception:
         |       Exception
         |     # /foo.html.erb:1:in `<main>': foo (RuntimeError)
         |
-        |  5) a failing spec with odd backtraces with a `nil` backtrace raises
+        |  6) a failing spec with odd backtraces with a `nil` backtrace raises
         |     Failure/Error: Unable to find matching line from backtrace
         |
         |     RuntimeError:
         |       boom
         |
         |Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-        |8 examples, 5 failures, 2 pending
+        |9 examples, 6 failures, 2 pending
         |
         |Failed examples:
         |
         |rspec ./spec/rspec/core/resources/formatter_specs.rb:4 # pending command with block format behaves like shared is marked as pending but passes
         |rspec ./spec/rspec/core/resources/formatter_specs.rb:32 # failing spec fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:38 # a failing spec with odd backtraces fails with a backtrace that has no file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:44 # a failing spec with odd backtraces fails with a backtrace containing an erb file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:62 # a failing spec with odd backtraces with a `nil` backtrace raises
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # failing spec fails twice
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:43 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:49 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:67 # a failing spec with odd backtraces with a `nil` backtrace raises
       EOS
     end
   else
@@ -165,41 +185,61 @@ module FormatterSupport
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
-        |  3) a failing spec with odd backtraces fails with a backtrace that has no file
+        |  3) failing spec fails twice
+        |     Got 2 failures:
+        |
+        |     3.1) Failure/Error: expect(1).to eq(2)
+        |
+        |            expected: 2
+        |                 got: 1
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in <top (required)>'
+        |
+        |     3.2) Failure/Error: expect(3).to eq(4)
+        |
+        |            expected: 4
+        |                 got: 3
+        |
+        |            (compared using ==)
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:38:in `block (2 levels) in <top (required)>'
+        |
+        |  4) a failing spec with odd backtraces fails with a backtrace that has no file
         |     Failure/Error: ERB.new("<%= raise 'foo' %>").result
         |
         |     RuntimeError:
         |       foo
         |     # (erb):1:in `<main>'
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in <top (required)>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
-        |  4) a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |  5) a failing spec with odd backtraces fails with a backtrace containing an erb file
         |     Failure/Error: Unable to find /foo.html.erb to read failed line
         |
         |     Exception:
         |       Exception
         |     # /foo.html.erb:1:in `<main>': foo (RuntimeError)
         |
-        |  5) a failing spec with odd backtraces with a `nil` backtrace raises
+        |  6) a failing spec with odd backtraces with a `nil` backtrace raises
         |     Failure/Error: Unable to find matching line from backtrace
         |
         |     RuntimeError:
         |       boom
         |
         |Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-        |8 examples, 5 failures, 2 pending
+        |9 examples, 6 failures, 2 pending
         |
         |Failed examples:
         |
         |rspec ./spec/rspec/core/resources/formatter_specs.rb:4 # pending command with block format behaves like shared is marked as pending but passes
         |rspec ./spec/rspec/core/resources/formatter_specs.rb:32 # failing spec fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:38 # a failing spec with odd backtraces fails with a backtrace that has no file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:44 # a failing spec with odd backtraces fails with a backtrace containing an erb file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:62 # a failing spec with odd backtraces with a `nil` backtrace raises
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # failing spec fails twice
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:43 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:49 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:67 # a failing spec with odd backtraces with a `nil` backtrace raises
       EOS
     end
   end

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -84,7 +84,7 @@ module FormatterSupport
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:33
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:37
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:16
@@ -99,7 +99,7 @@ module FormatterSupport
         |                 got: 1
         |
         |            (compared using ==)
-        |          # ./spec/rspec/core/resources/formatter_specs.rb:37
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:41
         |
         |     3.2) Failure/Error: expect(3).to eq(4)
         |
@@ -107,7 +107,7 @@ module FormatterSupport
         |                 got: 3
         |
         |            (compared using ==)
-        |          # ./spec/rspec/core/resources/formatter_specs.rb:38
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:42
         |
         |  4) a failing spec with odd backtraces fails with a backtrace that has no file
         |     Failure/Error: Unable to find (erb) to read failed line
@@ -130,16 +130,16 @@ module FormatterSupport
         |       boom
         |
         |Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-        |9 examples, 6 failures, 2 pending
+        |10 examples, 6 failures, 2 pending
         |
         |Failed examples:
         |
         |rspec ./spec/rspec/core/resources/formatter_specs.rb:4 # pending command with block format behaves like shared is marked as pending but passes
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:32 # failing spec fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # failing spec fails twice
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:43 # a failing spec with odd backtraces fails with a backtrace that has no file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:49 # a failing spec with odd backtraces fails with a backtrace containing an erb file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:67 # a failing spec with odd backtraces with a `nil` backtrace raises
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # failing spec fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:40 # failing spec fails twice
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:47 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:53 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:71 # a failing spec with odd backtraces with a `nil` backtrace raises
       EOS
     end
   else
@@ -179,7 +179,7 @@ module FormatterSupport
         |            got: 1
         |
         |       (compared using ==)
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:33:in `block (2 levels) in <top (required)>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
@@ -194,7 +194,7 @@ module FormatterSupport
         |                 got: 1
         |
         |            (compared using ==)
-        |          # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in <top (required)>'
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:41:in `block (2 levels) in <top (required)>'
         |
         |     3.2) Failure/Error: expect(3).to eq(4)
         |
@@ -202,7 +202,7 @@ module FormatterSupport
         |                 got: 3
         |
         |            (compared using ==)
-        |          # ./spec/rspec/core/resources/formatter_specs.rb:38:in `block (2 levels) in <top (required)>'
+        |          # ./spec/rspec/core/resources/formatter_specs.rb:42:in `block (2 levels) in <top (required)>'
         |
         |  4) a failing spec with odd backtraces fails with a backtrace that has no file
         |     Failure/Error: ERB.new("<%= raise 'foo' %>").result
@@ -210,7 +210,7 @@ module FormatterSupport
         |     RuntimeError:
         |       foo
         |     # (erb):1:in `<main>'
-        |     # ./spec/rspec/core/resources/formatter_specs.rb:46:in `block (2 levels) in <top (required)>'
+        |     # ./spec/rspec/core/resources/formatter_specs.rb:50:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:39:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
@@ -230,16 +230,16 @@ module FormatterSupport
         |       boom
         |
         |Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-        |9 examples, 6 failures, 2 pending
+        |10 examples, 6 failures, 2 pending
         |
         |Failed examples:
         |
         |rspec ./spec/rspec/core/resources/formatter_specs.rb:4 # pending command with block format behaves like shared is marked as pending but passes
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:32 # failing spec fails
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # failing spec fails twice
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:43 # a failing spec with odd backtraces fails with a backtrace that has no file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:49 # a failing spec with odd backtraces fails with a backtrace containing an erb file
-        |rspec ./spec/rspec/core/resources/formatter_specs.rb:67 # a failing spec with odd backtraces with a `nil` backtrace raises
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:36 # failing spec fails
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:40 # failing spec fails twice
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:47 # a failing spec with odd backtraces fails with a backtrace that has no file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:53 # a failing spec with odd backtraces fails with a backtrace containing an erb file
+        |rspec ./spec/rspec/core/resources/formatter_specs.rb:71 # a failing spec with odd backtraces with a `nil` backtrace raises
       EOS
     end
   end


### PR DESCRIPTION
This is an alternate to #2324 building on the work started by @samuel-hcl, but using the message details for all exceptions and neatening up the implementation slightly.
