### PR TITLE
Fix for #2312

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -56,7 +56,7 @@ module RSpec
   # they use the runner multiple times within the same process. Users must deal
   # themselves with re-configuration of RSpec before run.
   def self.reset
-    @world.example_groups.reduce(&:remove_all_constants)
+    RSpec::ExampleGroups.remove_all_constants
     @world = nil
     @configuration = nil
   end

--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -56,6 +56,7 @@ module RSpec
   # they use the runner multiple times within the same process. Users must deal
   # themselves with re-configuration of RSpec before run.
   def self.reset
+    @world.example_groups.reduce(&:remove_all_constants)
     @world = nil
     @configuration = nil
   end

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -827,6 +827,12 @@ module RSpec
       const_scope
     end
 
+    def self.remove_all_constants
+      self.constants.each do |constant|
+        self.send(:remove_const, constant)
+      end
+    end
+
     def self.base_name_for(group)
       return "Anonymous" if group.description.empty?
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -828,8 +828,8 @@ module RSpec
     end
 
     def self.remove_all_constants
-      self.constants.each do |constant|
-        self.send(:remove_const, constant)
+      constants.each do |constant|
+        __send__(:remove_const, constant)
       end
     end
 

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -38,7 +38,7 @@ module RSpec
       #
       # Reset world to 'scratch' before running suite.
       def reset
-        example_groups.reduce(&:remove_all_constants)
+        RSpec::ExampleGroups.remove_all_constants
         example_groups.clear
         @shared_example_group_registry = nil
       end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -38,6 +38,7 @@ module RSpec
       #
       # Reset world to 'scratch' before running suite.
       def reset
+        example_groups.reduce(&:remove_all_constants)
         example_groups.clear
         @shared_example_group_registry = nil
       end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -140,12 +140,6 @@ module RSpec::Core
         expect(child).to have_class_const("SomeParentGroup::Hash")
       end
 
-      it 'removes it\'s constants' do
-        groups = RSpec::ExampleGroups
-        groups.remove_all_constants
-        expect(groups.constants).to be_empty
-      end
-
       it 'disambiguates name collisions by appending a number', :unless => RUBY_VERSION == '1.9.2' do
         groups = 10.times.map { RSpec.describe("Collision") }
         expect(groups[0]).to have_class_const("Collision")

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -140,6 +140,12 @@ module RSpec::Core
         expect(child).to have_class_const("SomeParentGroup::Hash")
       end
 
+      it 'removes it\'s constants' do
+        groups = RSpec::ExampleGroups
+        groups.remove_all_constants
+        expect(groups.constants).to be_empty
+      end
+
       it 'disambiguates name collisions by appending a number', :unless => RUBY_VERSION == '1.9.2' do
         groups = 10.times.map { RSpec.describe("Collision") }
         expect(groups[0]).to have_class_const("Collision")

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -13,6 +13,14 @@ module RSpec::Core
         world.reset
         expect(world.example_groups).to be_empty
       end
+
+      it 'removes the previously assigned example group constants' do
+        RSpec.describe "group"
+
+        expect {
+          RSpec.world.reset
+        }.to change(RSpec::ExampleGroups, :constants).to([])
+      end
     end
 
     describe "#example_groups" do

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -124,6 +124,14 @@ RSpec.describe RSpec do
       expect(RSpec.configuration).not_to equal(config_before_reset)
       expect(RSpec.world).not_to equal(world_before_reset)
     end
+
+    it 'removes the previously assigned example group constants' do
+        RSpec.describe "group"
+
+        expect {
+          RSpec.world.reset
+        }.to change(RSpec::ExampleGroups, :constants).to([])
+    end
   end
 
   describe ".clear_examples" do


### PR DESCRIPTION
Implemented constant cleanup method for ExampleGroups and implemented in RSpec::Core::World.reset and RSpec.reset.