### PR TITLE
Use double quote for default generated spec_helper.rb

### DIFF
--- a/lib/rspec/core/project_initializer/spec/spec_helper.rb
+++ b/lib/rspec/core/project_initializer/spec/spec_helper.rb
@@ -80,7 +80,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
+    config.default_formatter = "doc"
   end
 
   # Print the 10 slowest examples and example groups at the


### PR DESCRIPTION
This file all uses double quote except for default_formatter. Let's all use double quotes in this file.