### PR TITLE
Add platform ruby 2.3 for rubocop environment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,9 +38,12 @@ gem 'simplecov', '~> 0.8'
 
 # There is no platform :ruby_193 and Rubocop only supports >= 1.9.3
 unless RUBY_VERSION == "1.9.2"
+  platforms = [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+  # There is no platform :ruby_23 on Travis jruby.
+  platforms << :ruby_23 if Bundler::Dependency::PLATFORM_MAP[:ruby_23]
   gem "rubocop",
       "~> 0.32.1",
-      :platform => [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+      :platform => platforms
 end
 
 gem 'test-unit', '~> 3.0' if RUBY_VERSION.to_f >= 2.2


### PR DESCRIPTION
Hi,

I want to add ruby 2.3 to rubocop running environment.

```
$ ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]

$ bundle install --path vendor/bundle

$ bundle exec rake
...
bundler: command not found: rubocop
```

The reason why it is not failed in Travis, is that it might be pre-installed in Travis environment.

After my patch.

```
$ bundle exec rake
...
71 files inspected, no offenses detected
```