### PR TITLE
Allow rubycop on MRI 2.3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,9 +38,9 @@ gem 'simplecov', '~> 0.8'
 
 # There is no platform :ruby_193 and Rubocop only supports >= 1.9.3
 unless RUBY_VERSION == "1.9.2"
-  gem "rubocop",
-      "~> 0.32.1",
-      :platform => [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+  platforms = [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+  platforms << :ruby_23 unless RUBY_ENGINE == 'java'
+  gem "rubocop", "~> 0.32.1", :platform => platforms
 end
 
 gem 'test-unit', '~> 3.0' if RUBY_VERSION.to_f >= 2.2


### PR DESCRIPTION
Alternative to #2345 that should fix the jruby issue.