### PR TITLE
Include error count for errors occurring outside examples in summary

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### Development
+[Full Changelog](http://github.com/rspec/rspec-core/compare/v3.6.0.beta1...master)
+
+Enhancements:
+
+* Include count of errors occurring outside examples in default summaries.
+  (#2351, Jon Rowe)
+
 ### 3.6.0.beta1 / 2016-10-09
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.5.4...v3.6.0.beta1)
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -281,8 +281,10 @@ module RSpec::Core
     # @attr pending_examples [Array<RSpec::Core::Example>] the pending examples
     # @attr load_time [Float] the number of seconds taken to boot RSpec
     #                         and load the spec files
+    # @attr errors [Integer] the number of errors that have occurred processing
+    #                        the spec suite
     SummaryNotification = Struct.new(:duration, :examples, :failed_examples,
-                                     :pending_examples, :load_time)
+                                     :pending_examples, :load_time, :errors)
     class SummaryNotification
       # @api
       # @return [Fixnum] the number of examples run
@@ -308,6 +310,9 @@ module RSpec::Core
         summary = Formatters::Helpers.pluralize(example_count, "example")
         summary << ", " << Formatters::Helpers.pluralize(failure_count, "failure")
         summary << ", #{pending_count} pending" if pending_count > 0
+        if errors > 0
+          summary << ", " << Formatters::Helpers.pluralize(errors, "error") << " occurred"
+        end
         summary
       end
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -281,10 +281,12 @@ module RSpec::Core
     # @attr pending_examples [Array<RSpec::Core::Example>] the pending examples
     # @attr load_time [Float] the number of seconds taken to boot RSpec
     #                         and load the spec files
-    # @attr errors [Integer] the number of errors that have occurred processing
-    #                        the spec suite
+    # @attr errors_outside_of_examples_count [Integer] the number of errors that
+    #                                                  have occurred processing
+    #                                                  the spec suite
     SummaryNotification = Struct.new(:duration, :examples, :failed_examples,
-                                     :pending_examples, :load_time, :errors)
+                                     :pending_examples, :load_time,
+                                     :errors_outside_of_examples_count)
     class SummaryNotification
       # @api
       # @return [Fixnum] the number of examples run
@@ -310,8 +312,9 @@ module RSpec::Core
         summary = Formatters::Helpers.pluralize(example_count, "example")
         summary << ", " << Formatters::Helpers.pluralize(failure_count, "failure")
         summary << ", #{pending_count} pending" if pending_count > 0
-        if errors > 0
-          summary << ", " << Formatters::Helpers.pluralize(errors, "error")
+        if errors_outside_of_examples_count > 0
+          summary << ", "
+          summary << Formatters::Helpers.pluralize(errors_outside_of_examples_count, "error")
           summary << " occurred outside of examples"
         end
         summary

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -311,7 +311,8 @@ module RSpec::Core
         summary << ", " << Formatters::Helpers.pluralize(failure_count, "failure")
         summary << ", #{pending_count} pending" if pending_count > 0
         if errors > 0
-          summary << ", " << Formatters::Helpers.pluralize(errors, "error") << " occurred"
+          summary << ", " << Formatters::Helpers.pluralize(errors, "error")
+          summary << " occurred outside of examples"
         end
         summary
       end

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -18,7 +18,7 @@ module RSpec::Core
       @failed_examples = []
       @pending_examples = []
       @duration = @start = @load_time = nil
-      @errors = 0
+      @non_example_exception_count = 0
     end
 
     # @private
@@ -158,7 +158,7 @@ module RSpec::Core
     # Exceptions will be formatted the same way they normally are.
     def notify_non_example_exception(exception, context_description)
       @configuration.world.non_example_failure = true
-      @errors += 1
+      @non_example_exception_count += 1
 
       example = Example.new(AnonymousExampleGroup, context_description, {})
       presenter = Formatters::ExceptionPresenter.new(exception, example, :indentation => 0)
@@ -179,7 +179,8 @@ module RSpec::Core
                                                                        @profiler.example_groups)
         end
         notify :dump_summary, Notifications::SummaryNotification.new(@duration, @examples, @failed_examples,
-                                                                     @pending_examples, @load_time, @errors)
+                                                                     @pending_examples, @load_time,
+                                                                     @non_example_exception_count)
         notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
       end
     end

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -18,6 +18,7 @@ module RSpec::Core
       @failed_examples = []
       @pending_examples = []
       @duration = @start = @load_time = nil
+      @errors = 0
     end
 
     # @private
@@ -157,6 +158,7 @@ module RSpec::Core
     # Exceptions will be formatted the same way they normally are.
     def notify_non_example_exception(exception, context_description)
       @configuration.world.non_example_failure = true
+      @errors += 1
 
       example = Example.new(AnonymousExampleGroup, context_description, {})
       presenter = Formatters::ExceptionPresenter.new(exception, example, :indentation => 0)
@@ -177,7 +179,7 @@ module RSpec::Core
                                                                        @profiler.example_groups)
         end
         notify :dump_summary, Notifications::SummaryNotification.new(@duration, @examples, @failed_examples,
-                                                                     @pending_examples, @load_time)
+                                                                     @pending_examples, @load_time, @errors)
         notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
       end
     end

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Spec file load errors' do
 
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-      0 examples, 0 failures, 2 errors occurred
+      0 examples, 0 failures, 2 errors occurred outside of examples
     EOS
   end
 end

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'Spec file load errors' do
 
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-      0 examples, 0 failures
+      0 examples, 0 failures, 2 errors occurred
     EOS
   end
 end

--- a/spec/integration/suite_hooks_errors_spec.rb
+++ b/spec/integration/suite_hooks_errors_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Suite hook errors' do
 
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-      0 examples, 0 failures, 1 error occurred
+      0 examples, 0 failures, 1 error occurred outside of examples
     EOS
   end
 
@@ -79,7 +79,7 @@ RSpec.describe 'Suite hook errors' do
 
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-      1 example, 0 failures, 1 error occurred
+      1 example, 0 failures, 1 error occurred outside of examples
     EOS
   end
 
@@ -126,7 +126,7 @@ RSpec.describe 'Suite hook errors' do
 
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-      0 examples, 0 failures, 3 errors occurred
+      0 examples, 0 failures, 3 errors occurred outside of examples
     EOS
   end
 end

--- a/spec/integration/suite_hooks_errors_spec.rb
+++ b/spec/integration/suite_hooks_errors_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Suite hook errors' do
 
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-      0 examples, 0 failures
+      0 examples, 0 failures, 1 error occurred
     EOS
   end
 
@@ -79,7 +79,7 @@ RSpec.describe 'Suite hook errors' do
 
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-      1 example, 0 failures
+      1 example, 0 failures, 1 error occurred
     EOS
   end
 
@@ -126,7 +126,7 @@ RSpec.describe 'Suite hook errors' do
 
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
-      0 examples, 0 failures
+      0 examples, 0 failures, 3 errors occurred
     EOS
   end
 end

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
       expect(formatter_output.string).to match("2 examples, 2 failures, 2 pending")
     end
 
+    it 'with errors includes that count' do
+      send_notification :dump_summary, summary_notification(2, examples(2), examples(2), examples(2), 0, 3)
+      expect(formatter_output.string).to match("2 examples, 2 failures, 2 pending, 3 errors occurred")
+    end
+
     describe "rerun command for failed examples" do
       it "uses the location to identify the example" do
         line = __LINE__ + 2

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
 
     it 'with errors includes that count' do
       send_notification :dump_summary, summary_notification(2, examples(2), examples(2), examples(2), 0, 3)
-      expect(formatter_output.string).to match("2 examples, 2 failures, 2 pending, 3 errors occurred")
+      expect(formatter_output.string).to match("2 examples, 2 failures, 2 pending, 3 errors occurred outside of examples")
     end
 
     describe "rerun command for failed examples" do

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -311,8 +311,8 @@ module FormatterSupport
     ::RSpec::Core::Notifications::ExamplesNotification.new reporter
   end
 
-  def summary_notification(duration, examples, failed, pending, time)
-    ::RSpec::Core::Notifications::SummaryNotification.new duration, examples, failed, pending, time
+  def summary_notification(duration, examples, failed, pending, time, errors = 0)
+    ::RSpec::Core::Notifications::SummaryNotification.new duration, examples, failed, pending, time, errors
   end
 
   def profile_notification(duration, examples, number)


### PR DESCRIPTION
Improve our handling of errors which occur in suite hooks by displaying a count of errors occurred in the summary.

As suggested in #2329

/cc @myronmarston 