### PR TITLE
Remove `example` from list of RSpec keywords.

### DIFF
--- a/lib/rspec/core/source/syntax_highlighter.rb
+++ b/lib/rspec/core/source/syntax_highlighter.rb
@@ -43,7 +43,7 @@ module RSpec
         def self.attempt_to_add_rspec_terms_to_coderay_keywords
           CodeRay::Scanners::Ruby::Patterns::IDENT_KIND.add(%w[
             describe context
-            it specify example
+            it specify
             before after around
             let subject
             expect allow

--- a/spec/rspec/core/source/syntax_highlighter_spec.rb
+++ b/spec/rspec/core/source/syntax_highlighter_spec.rb
@@ -65,7 +65,7 @@ class RSpec::Core::Source
 
         expect(highlighted_terms).to match_array %w[
           describe context
-          it specify example
+          it specify
           before after around
           let subject
           expect allow


### PR DESCRIPTION
While it is an alias of `it` and `specify`, it is
not often used, and often is used as a variable name
(e.g. when an `example` is yielded to a hook), so it
is better not to highlight it.