### PR TITLE
Various RSpec.clear_examples bug fixes.

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -69,7 +69,7 @@ module RSpec
   # same process.
   def self.clear_examples
     world.reset
-    configuration.reporter.reset
+    configuration.reset_reporter
     configuration.start_time = ::RSpec::Core::Time.now
     configuration.reset_filters
   end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -485,6 +485,12 @@ module RSpec
       end
 
       # @private
+      def reset_reporter
+        @reporter = nil
+        @formatter_loader = nil
+      end
+
+      # @private
       def reset_filters
         self.filter_manager = FilterManager.new
         filter_manager.include_only(

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -57,8 +57,9 @@ module RSpec
 
         # @api public
         #
-        # Invoked at the very end, `close` allows the formatter to clean
-        # up resources, e.g. open streams, etc.
+        # Invoked at the end of a suite run. Allows the formatter to do any
+        # tidying up, but be aware that formatter output streams may be used
+        # elsewhere so don't actually close them.
         #
         # @param _notification [NullNotification] (Ignored)
         def close(_notification)
@@ -68,7 +69,6 @@ module RSpec
           output.puts
 
           output.flush
-          output.close unless output == $stdout
         end
       end
     end

--- a/lib/rspec/core/formatters/json_formatter.rb
+++ b/lib/rspec/core/formatters/json_formatter.rb
@@ -48,7 +48,6 @@ module RSpec
 
         def close(_notification)
           output.write @output_hash.to_json
-          output.close if IO === output && output != $stdout
         end
 
         def dump_profile(profile)

--- a/lib/rspec/core/formatters/protocol.rb
+++ b/lib/rspec/core/formatters/protocol.rb
@@ -171,8 +171,9 @@ module RSpec
         # @api public
         # @group Suite Notifications
         #
-        # Invoked at the very end, `close` allows the formatter to clean
-        # up resources, e.g. open streams, etc.
+        # Invoked at the end of a suite run. Allows the formatter to do any
+        # tidying up, but be aware that formatter output streams may be used
+        # elsewhere so don't actually close them.
         #
         # @param notification [Notifications::NullNotification]
       end

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -25,14 +25,6 @@ module RSpec::Core
     attr_reader :examples, :failed_examples, :pending_examples
 
     # @private
-    def reset
-      @examples = []
-      @failed_examples = []
-      @pending_examples = []
-      @profiler = Profiler.new if defined?(@profiler)
-    end
-
-    # @private
     def setup_profiler
       @profiler = Profiler.new
       register_listener @profiler, *Profiler::NOTIFICATIONS

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -40,7 +40,6 @@ module RSpec
       def reset
         RSpec::ExampleGroups.remove_all_constants
         example_groups.clear
-        @shared_example_group_registry = nil
       end
 
       # @private

--- a/spec/rspec/core/bisect/coordinator_spec.rb
+++ b/spec/rspec/core/bisect/coordinator_spec.rb
@@ -26,24 +26,25 @@ module RSpec::Core
 
     it 'notifies the bisect progress formatter of progress and closes the output' do
       tempfile = Tempfile.new("bisect")
-      output_file = File.open(tempfile.path, "w")
-      expect { find_minimal_repro(output_file) }.to change(output_file, :closed?).from(false).to(true)
-      output = normalize_durations(File.read(tempfile.path)).chomp
+      File.open(tempfile.path, "w") do |output_file|
+        find_minimal_repro(output_file)
+        output = normalize_durations(File.read(tempfile.path)).chomp
 
-      expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
-        |Bisect started using options: ""
-        |Running suite to find failures... (n.nnnn seconds)
-        |Starting bisect with 2 failing examples and 6 non-failing examples.
-        |Checking that failure(s) are order-dependent... failure appears to be order-dependent
-        |
-        |Round 1: bisecting over non-failing examples 1-6 .. ignoring examples 4-6 (n.nnnn seconds)
-        |Round 2: bisecting over non-failing examples 1-3 .. multiple culprits detected - splitting candidates (n.nnnn seconds)
-        |Round 3: bisecting over non-failing examples 1-2 .. ignoring example 2 (n.nnnn seconds)
-        |Bisect complete! Reduced necessary non-failing examples from 6 to 2 in n.nnnn seconds.
-        |
-        |The minimal reproduction command is:
-        |  rspec 1.rb[1:1] 2.rb[1:1] 4.rb[1:1] 5.rb[1:1]
-      EOS
+        expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
+          |Bisect started using options: ""
+          |Running suite to find failures... (n.nnnn seconds)
+          |Starting bisect with 2 failing examples and 6 non-failing examples.
+          |Checking that failure(s) are order-dependent... failure appears to be order-dependent
+          |
+          |Round 1: bisecting over non-failing examples 1-6 .. ignoring examples 4-6 (n.nnnn seconds)
+          |Round 2: bisecting over non-failing examples 1-3 .. multiple culprits detected - splitting candidates (n.nnnn seconds)
+          |Round 3: bisecting over non-failing examples 1-2 .. ignoring example 2 (n.nnnn seconds)
+          |Bisect complete! Reduced necessary non-failing examples from 6 to 2 in n.nnnn seconds.
+          |
+          |The minimal reproduction command is:
+          |  rspec 1.rb[1:1] 2.rb[1:1] 4.rb[1:1] 5.rb[1:1]
+        EOS
+      end
     end
 
     it 'can use the bisect debug formatter to get detailed progress' do

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -103,6 +103,11 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
         :version => RSpec::Core::Version::STRING
       }.to_json)
     end
+
+    it "does not close the stream so that it can be reused within a process" do
+      formatter.close(RSpec::Core::Notifications::NullNotification)
+      expect(formatter_output.closed?).to be(false)
+    end
   end
 
   describe "#message" do

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -136,7 +136,10 @@ RSpec.describe RSpec do
 
   describe ".clear_examples" do
     let(:listener) { double("listener") }
-    let(:reporter) { RSpec.configuration.reporter }
+
+    def reporter
+      RSpec.configuration.reporter
+    end
 
     before do
       RSpec.configuration.output_stream = StringIO.new
@@ -175,6 +178,8 @@ RSpec.describe RSpec do
       reporter.example_pending(pending_ex)
       reporter.finish
 
+      RSpec.clear_examples
+
       reporter.register_listener(listener, :dump_summary)
 
       expect(listener).to receive(:dump_summary) do |notification|
@@ -183,7 +188,6 @@ RSpec.describe RSpec do
         expect(notification.pending_examples).to be_empty
       end
 
-      RSpec.clear_examples
       reporter.start(0)
       reporter.finish
     end
@@ -223,6 +227,31 @@ RSpec.describe RSpec do
       expect(
         RSpec.configuration.filter_manager.exclusions.rules
       ).to eq(:slow => true)
+    end
+
+    it 'clears the deprecation buffer' do
+      RSpec.configuration.deprecation_stream = StringIO.new
+
+      group = RSpec.describe do
+        example { RSpec.deprecate("first deprecation") }
+      end.run
+
+      reporter.start(1)
+      reporter.finish
+
+      RSpec.clear_examples
+
+      RSpec.configuration.deprecation_stream = StringIO.new(deprecations = "")
+
+      group = RSpec.describe do
+        example { RSpec.deprecate("second deprecation") }
+      end.run
+
+      reporter.start(1)
+      reporter.finish
+
+      expect(deprecations).to     include("second deprecation")
+      expect(deprecations).to_not include("first deprecation")
     end
   end
 

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -253,6 +253,15 @@ RSpec.describe RSpec do
       expect(deprecations).to     include("second deprecation")
       expect(deprecations).to_not include("first deprecation")
     end
+
+    it 'does not clear shared examples' do
+      RSpec.shared_examples_for("shared") { }
+
+      RSpec.clear_examples
+
+      registry = RSpec.world.shared_example_group_registry
+      expect(registry.find([:main], "shared")).to_not be_nil
+    end
   end
 
   it 'uses only one thread local variable', :run_last do


### PR DESCRIPTION
Fixes #2367 

See individual commit messages.

This doesn't consider whether we should change/alias the name of `clear_examples` as proposed in linked ticket. We probably do want to do that though.

Probably not interesting to anyone, but I tried streaming my process of making this PR. Took me longer than I thought! Got some weird audio feedback issues so may not be too watchable...

* https://www.twitch.tv/xaviershay/v/114691294
* https://www.twitch.tv/xaviershay/v/114813777
* https://www.twitch.tv/xaviershay/v/114825637