### PR TITLE
docs: remove non-existent shared_context overload

### DIFF
--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -64,11 +64,6 @@ module RSpec
       #     group; any example group or example with matching metadata will
       #     automatically include this shared example group.
       #   @param block The block to be eval'd
-      # @overload shared_examples(metadata, &block)
-      #   @param metadata [Array<Symbol>, Hash] metadata to attach to this
-      #     group; any example group or example with matching metadata will
-      #     automatically include this shared example group.
-      #   @param block The block to be eval'd
       #
       # Stores the block for later use. The block will be evaluated
       # in the context of an example group via `include_examples`,


### PR DESCRIPTION
Fixes #2374.