### PR TITLE
Limit rubocop to known working platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,14 +40,8 @@ end
 
 gem 'simplecov', '~> 0.8'
 
-# There is no platform :ruby_193 and Rubocop only supports >= 1.9.3
-unless RUBY_VERSION == "1.9.2"
-  platforms = [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
-  # There is no platform :ruby_23 on JRuby currently.
-  platforms << :ruby_23 if Bundler::Dependency::PLATFORM_MAP[:ruby_23]
-  gem "rubocop",
-      "~> 0.32.1",
-      :platform => platforms
+if RUBY_VERSION >= '1.9.3' && RUBY_VERSION < '2.4.0'
+  gem "rubocop", "~> 0.32.1"
 end
 
 gem 'test-unit', '~> 3.0' if RUBY_VERSION.to_f >= 2.2


### PR DESCRIPTION
Following discussion elsewhere I think our builds are actually being broken by `:platform =>` not working anymore, we use pure Ruby™ elsewhere so lets do that for rubocop too.