### PR TITLE
JRuby 9.x is currently failing to install a dependency of rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ end
 
 gem 'simplecov', '~> 0.8'
 
-if RUBY_VERSION >= '1.9.3' && RUBY_VERSION < '2.4.0'
+if RUBY_VERSION >= '1.9.3' && RUBY_VERSION < '2.4.0' && !(%w[java jruby].include? RUBY_ENGINE)
   gem "rubocop", "~> 0.32.1"
 end
 


### PR DESCRIPTION
Previously on Bundler 1.13 we limited this via platform so JRuby 9.x never installed it, given that we don't need to run rubocop on every build, this restores the original behaviour of only running on MRI and hopefully fixes the build.