### PR TITLE
Ensure example_finished gets reported from context-hook failures

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -465,22 +465,22 @@ module RSpec
 
         if @exception
           execution_result.exception = @exception
-          record_finished :failed
+          record_finished :failed, reporter
           reporter.example_failed self
           false
         elsif pending_message
           execution_result.pending_message = pending_message
-          record_finished :pending
+          record_finished :pending, reporter
           reporter.example_pending self
           true
         else
-          record_finished :passed
+          record_finished :passed, reporter
           reporter.example_passed self
           true
         end
       end
 
-      def record_finished(status)
+      def record_finished(status, reporter)
         execution_result.record_finished(status, clock.now)
         reporter.example_finished(self)
       end


### PR DESCRIPTION
Regression in c0564a3928d9928b6bcc770455152825383d581a

`#reporter` is a `RSpec::Core::NullReporter` at this point, so pass along the correct `reporter` argument.

It appears that `#reporter` is never actually used in rspec-core (or anywhere?), and given that we rely on a `reporter` argument it feels a bit error prone. Perhaps `#reporter` should just be removed? Alternatively, maybe we should stop passing `reporter` around internally and just set
`@reporter` in places like `fail_with_exception`?

Feels out of scope for this bugfix, but I think it warrants discussing.