### PR TITLE
Added a group level boundary check to prevent unexpected negative val…

### DIFF
--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -22,10 +22,7 @@ module RSpec
         end
 
         def example_group_finished(_notification)
-          if @group_level > 0
-            @group_level -= 1
-          end
-          @group_level
+          @group_level = if @group_level > 0 then @group_level - 1 else @group_level end
         end
 
         def example_passed(passed)

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -22,7 +22,10 @@ module RSpec
         end
 
         def example_group_finished(_notification)
-          @group_level -= 1
+          if @group_level > 0
+            @group_level -= 1
+          end
+          @group_level
         end
 
         def example_passed(passed)

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -22,7 +22,7 @@ module RSpec
         end
 
         def example_group_finished(_notification)
-          @group_level =  @group_level > 0 ? @group_level - 1 : @group_level
+          @group_level -= 1 if @group_level > 0
         end
 
         def example_passed(passed)

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -22,7 +22,7 @@ module RSpec
         end
 
         def example_group_finished(_notification)
-          @group_level = if @group_level > 0 then @group_level - 1 else @group_level end
+          @group_level =  @group_level > 0 ? @group_level - 1 : @group_level
         end
 
         def example_passed(passed)

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -32,6 +32,19 @@ module RSpec::Core::Formatters
       expect(formatter_output.string).to match(/second example \(FAILED - 2\)/m)
     end
 
+    it 'group level will not go negative' do
+      send_notification :example_group_finished, nil
+      send_notification :example_group_finished, nil
+      send_notification :example_group_finished, nil
+      expect {
+        send_notification :example_group_started, group_notification(double("example 1",
+               :description => "first example",
+               :full_description => "group first example",
+               :metadata => {}
+              ))
+      }.not_to raise_error
+    end
+
     it "represents nested group using hierarchy tree" do
       group = RSpec.describe("root")
       context1 = group.describe("context 1")


### PR DESCRIPTION
Added a group level boundary check to prevent unexpected negative values in group level in DocumentationFormatter

When trying to run documentation on a working rspec test suite, I was getting a negative argument error from @group_level.   This pull request is to mitigate unknown issues with calling the end method too many times, and triggering an Error rather than just malformed output.