### PR TITLE
mock_with -> expect_with

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1704,7 +1704,7 @@ module RSpec
       #       mocks.patch_marshal_to_support_partial_doubles = false
       #     end
       #
-      #     config.mock_with :rspec do |expectations|
+      #     config.expect_with :rspec do |expectations|
       #       expectations.syntax = :expect
       #     end
       #   end


### PR DESCRIPTION
The `config.mock_with` block is right above. For configuring the expectation library's syntax, we must use `config.expect_with`.