### PR TITLE
Fix bugs where config.when_first_matching_example_defined hooks would fire multiple times

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ Bug Fixes:
   being closed after the first. (#2368, Xavier Shay)
 * Prevent unexpected `example_group_finished` notifications causing an error.
   (#2396, VTJamie)
+* Fix bugs where `config.when_first_matching_example_defined` hooks would fire
+  multiple times in some cases. (Yuji Nakayama, #2400)
 
 ### 3.6.0.beta2 / 2016-12-12
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.6.0.beta1...v3.6.0.beta2)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1767,7 +1767,7 @@ module RSpec
           return unless example_or_group_meta.key?(:example_group)
 
           # Ensure the callback only fires once.
-          @derived_metadata_blocks.items_for(specified_meta).delete(callback)
+          @derived_metadata_blocks.delete(callback, specified_meta)
 
           block.call
         end

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -111,6 +111,10 @@ module RSpec
           @items_and_filters.unshift [item, metadata]
         end
 
+        def delete(item, metadata)
+          @items_and_filters.delete [item, metadata]
+        end
+
         def items_for(request_meta)
           @items_and_filters.each_with_object([]) do |(item, item_meta), to_return|
             to_return << item if item_meta.empty? ||
@@ -167,6 +171,11 @@ module RSpec
           handle_mutation(metadata)
         end
 
+        def delete(item, metadata)
+          super
+          reconstruct_caches
+        end
+
         def items_for(metadata)
           # The filtering of `metadata` to `applicable_metadata` is the key thing
           # that makes the memoization actually useful in practice, since each
@@ -190,6 +199,14 @@ module RSpec
         end
 
       private
+
+        def reconstruct_caches
+          @applicable_keys.clear
+          @proc_keys.clear
+          @items_and_filters.each do |_item, metadata|
+            handle_mutation(metadata)
+          end
+        end
 
         def handle_mutation(metadata)
           @applicable_keys.merge(metadata.keys)

--- a/lib/rspec/core/set.rb
+++ b/lib/rspec/core/set.rb
@@ -44,6 +44,11 @@ module RSpec
         end
         self
       end
+
+      def clear
+        @values.clear
+        self
+      end
     end
   end
 end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1994,7 +1994,7 @@ module RSpec::Core
       end
 
       context 'when the value of the registered metadata is a Proc' do
-        pending 'does not fire when later matching examples are defined' do
+        it 'does not fire when later matching examples are defined' do
           sequence = []
           RSpec.configuration.when_first_matching_example_defined(:foo => proc { true }) do
             sequence << :callback
@@ -2014,7 +2014,7 @@ module RSpec::Core
       end
 
       context 'when a matching example group with other registered metadata has been defined' do
-        pending 'does not fire when later matching examples with the other metadata are defined' do
+        it 'does not fire when later matching examples with the other metadata are defined' do
           sequence = []
 
           RSpec.configuration.when_first_matching_example_defined(:foo) do
@@ -2024,16 +2024,11 @@ module RSpec::Core
           RSpec.configuration.when_first_matching_example_defined(:bar) do
           end
 
-          # The hook is memoized for `:foo, :bar` in FilterableItemRepository::QueryOptimized
-          # but doesn't fire because this is an example group
           RSpec.describe 'group', :foo, :bar do
-            # The hook fires here and is unregistered _only_ from memoized collection for `:foo`
-            # (i.e. still remains in the memoized collection for `:foo, :bar`)
             example("ex 1", :foo)
             sequence.clear
 
             sequence << :before_second_matching_example_defined
-            # The hook unexpectedly fires
             example("ex 2", :foo, :bar)
             sequence << :after_second_matching_example_defined
           end

--- a/spec/rspec/core/filterable_item_repository_spec.rb
+++ b/spec/rspec/core/filterable_item_repository_spec.rb
@@ -132,6 +132,39 @@ module RSpec
         it_behaves_like "adding items to the repository", :prepend do
           let(:items_in_expected_order) { [item_3, item_2, item_1] }
         end
+
+        describe '#delete' do
+          before do
+            repo.append item_1, {}
+            repo.append item_1, :foo => true
+            repo.append item_1, :foo => true, :bar => true
+            repo.append item_2, :foo => true
+          end
+
+          it 'deletes the specified item with the metadata' do
+            expect { repo.delete(item_1, :foo => true) }.
+              to change { repo.items_and_filters }.
+                from([
+                  [item_1, {}],
+                  [item_1, { :foo => true }],
+                  [item_1, { :foo => true, :bar => true }],
+                  [item_2, { :foo => true }]
+                ]).
+                to([
+                  [item_1, {}],
+                  [item_1, { :foo => true, :bar => true }],
+                  [item_2, { :foo => true }]
+                ]).
+              and change { repo.items_for({ :foo => true }) }.
+                from([item_1, item_1, item_1, item_2]).
+                to([item_1, item_1, item_2]).
+              and change { repo.items_for({ :foo => true, :bar => true }) }.
+                from([item_1, item_1, item_1, item_2]).
+                to([item_1, item_1, item_2]).
+              and avoid_changing { repo.items_for({}) }.
+                from([item_1])
+          end
+        end
       end
 
       describe FilterableItemRepository::UpdateOptimized do

--- a/spec/rspec/core/set_spec.rb
+++ b/spec/rspec/core/set_spec.rb
@@ -33,4 +33,9 @@ RSpec.describe 'RSpec::Core::Set' do
       set << 1
     }.to change { set.empty? }.from(true).to(false)
   end
+
+  it 'can be cleared' do
+    expect { set.clear }.to change { set.empty? }.from(false).to(true)
+    expect(set.clear).to equal(set)
+  end
 end


### PR DESCRIPTION
The `config.when_first_matching_example_defined` hooks are registered on `@derived_metadata_blocks`, which is an instance of `FilterableItemRepository::QueryOptimized`, and [unregistered on the first invocation](https://github.com/rspec/rspec-core/blob/v3.5.4/lib/rspec/core/configuration.rb#L1724), so that they won't run multiple times.

However, they are actually unregistered _only_ from the internal memoized cache for a particular metadata in `FilterableItemRepository::QueryOptimized`. As a result, the hooks would be invoked multiple times in the following cases:

* When the memoized cache is not used. In particular, [when the value of the hook's metadata is a `Proc`](https://github.com/rspec/rspec-core/blob/v3.5.4/lib/rspec/core/metadata_filter.rb#L189-L191).
* When the hooks are memoized in combination with another registered metadata before the first invocation.

To fix these bugs, we need to properly unregister the hook from the original hook collection (`@items_and_filters` in `FilterableItemRepository::QueryOptimized`) rather than the memoized cache.