### PR TITLE
Add output stream changing for created formatters

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1,6 +1,7 @@
 RSpec::Support.require_rspec_core "backtrace_formatter"
 RSpec::Support.require_rspec_core "ruby_project"
 RSpec::Support.require_rspec_core "formatters/deprecation_formatter"
+RSpec::Support.require_rspec_core "output_wrapper"
 
 module RSpec
   module Core
@@ -141,7 +142,7 @@ module RSpec
 
       # Determines where deprecation warnings are printed.
       # Defaults to `$stderr`.
-      # @return [IO, String] IO to write to or filename to write to
+      # @return [IO] IO to write to
       define_reader :deprecation_stream
 
       # Determines where deprecation warnings are printed.
@@ -154,7 +155,7 @@ module RSpec
             "it to take effect, or use the `--deprecation-out` CLI option. " \
             "(Called from #{CallerFilter.first_non_rspec_line})"
         else
-          @deprecation_stream = value
+          @deprecation_stream = prepare_stream(value)
         end
       end
 
@@ -218,7 +219,7 @@ module RSpec
       define_reader :output_stream
 
       # Set the output stream for reporter.
-      # @attr value [IO] value for output, defaults to $stdout
+      # @attr value [IO, String] IO to write to or filename to write to, defaults to $stdout
       def output_stream=(value)
         if @reporter && !value.equal?(@output_stream)
           warn "RSpec's reporter has already been initialized with " \
@@ -226,7 +227,8 @@ module RSpec
             "`output_stream` will be ignored. You should configure it earlier for " \
             "it to take effect. (Called from #{CallerFilter.first_non_rspec_line})"
         else
-          @output_stream = value
+          @output_stream = prepare_stream(value)
+          output_wrapper.output = @output_stream
         end
       end
 
@@ -471,7 +473,8 @@ module RSpec
       # Used to set higher priority option values from the command line.
       def force(hash)
         ordering_manager.force(hash)
-        @preferred_options.merge!(hash)
+
+        @preferred_options.merge!(hash).merge!(prepared_streams(hash))
 
         return unless hash.key?(:example_status_persistence_file_path)
         clear_values_derived_from_example_status_persistence_file_path
@@ -482,12 +485,14 @@ module RSpec
         @spec_files_loaded = false
         @reporter = nil
         @formatter_loader = nil
+        @output_wrapper = nil
       end
 
       # @private
       def reset_reporter
         @reporter = nil
         @formatter_loader = nil
+        @output_wrapper = nil
       end
 
       # @private
@@ -870,7 +875,8 @@ module RSpec
       # Adds a formatter to the set RSpec will use for this run.
       #
       # @see RSpec::Core::Formatters::Protocol
-      def add_formatter(formatter, output=output_stream)
+      def add_formatter(formatter, output=output_wrapper)
+        output = prepare_stream(output) unless output == output_wrapper
         formatter_loader.add(formatter, output)
       end
       alias_method :formatter=, :add_formatter
@@ -936,7 +942,7 @@ module RSpec
         @reporter_buffer || @reporter ||=
           begin
             @reporter_buffer = DeprecationReporterBuffer.new
-            formatter_loader.prepare_default output_stream, deprecation_stream
+            formatter_loader.prepare_default output_wrapper, deprecation_stream
             @reporter_buffer.play_onto(formatter_loader.reporter)
             @reporter_buffer = nil
             formatter_loader.reporter
@@ -2045,8 +2051,28 @@ module RSpec
         )
       end
 
+      def output_wrapper
+        @output_wrapper ||= OutputWrapper.new(output_stream)
+      end
+
       def output_to_tty?(output=output_stream)
         output.respond_to?(:tty?) && output.tty?
+      end
+
+      def prepare_stream(stream)
+        stream.respond_to?(:puts) ? stream : file_at(stream)
+      end
+
+      def prepared_streams(hash)
+        [:deprecation_stream, :output_stream].inject({}) do |result, stream|
+          result[stream] = prepare_stream(hash[stream]) if hash.key?(stream)
+          result
+        end
+      end
+
+      def file_at(path)
+        RSpec::Support::DirectoryMaker.mkdir_p(File.dirname(path))
+        File.new(path, 'w')
       end
 
       def conditionally_disable_mocks_monkey_patching

--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -142,10 +142,8 @@ module RSpec::Core::Formatters
     end
 
     # @private
-    def add(formatter_to_use, *paths)
+    def add(formatter_to_use, *args)
       formatter_class = find_formatter(formatter_to_use)
-
-      args = paths.map { |p| p.respond_to?(:puts) ? p : file_at(p) }
 
       if !Loader.formatters[formatter_class].nil?
         formatter = formatter_class.new(*args)
@@ -250,11 +248,6 @@ module RSpec::Core::Formatters
       word.tr!("-", "_")
       word.downcase!
       word
-    end
-
-    def file_at(path)
-      RSpec::Support::DirectoryMaker.mkdir_p(File.dirname(path))
-      File.new(path, 'w')
     end
   end
 end

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -63,7 +63,6 @@ module RSpec
         #
         # @param _notification [NullNotification] (Ignored)
         def close(_notification)
-          return unless IO === output
           return if output.closed?
 
           output.puts

--- a/lib/rspec/core/output_wrapper.rb
+++ b/lib/rspec/core/output_wrapper.rb
@@ -1,0 +1,21 @@
+module RSpec
+  module Core
+    # @private
+    class OutputWrapper
+      # @private
+      attr_writer :output
+
+      # @private
+      def initialize(output)
+        @output = output
+      end
+
+      # Redirect calls for IO interface methods
+      IO.instance_methods(false).each do |method|
+        define_method(method) do |*args, &block|
+          @output.send(method, *args, &block)
+        end
+      end
+    end
+  end
+end

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -1,0 +1,4 @@
+      RSpec.describe "calling a deprecated method" do
+             example { 123 }
+      end
+

--- a/spec/integration/output_stream_spec.rb
+++ b/spec/integration/output_stream_spec.rb
@@ -1,0 +1,30 @@
+require 'support/aruba_support'
+
+RSpec.describe 'Output stream' do
+  include_context 'aruba support'
+  before { clean_current_dir }
+
+  context 'when a formatter set in a configure block' do
+    it 'writes to the right output stream' do
+      write_file_formatted 'spec/example_spec.rb', "
+        RSpec.configure do |c|
+          c.formatter = :documentation
+          c.output_stream = File.open('saved_output', 'w')
+        end
+
+        RSpec.describe 'something' do
+          it 'succeeds' do
+            true
+          end
+        end
+      "
+
+      run_command ''
+      expect(last_cmd_stdout).to be_empty
+      in_current_dir do
+        expect(File.read('saved_output')).to include('1 example, 0 failures')
+      end
+    end
+  end
+
+end

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe 'Spec file load errors' do
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
       0 examples, 0 failures, 2 errors occurred outside of examples
+
     EOS
   end
 end

--- a/spec/integration/suite_hooks_errors_spec.rb
+++ b/spec/integration/suite_hooks_errors_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'Suite hook errors' do
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
       0 examples, 0 failures, 1 error occurred outside of examples
+
     EOS
   end
 
@@ -80,6 +81,7 @@ RSpec.describe 'Suite hook errors' do
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
       1 example, 0 failures, 1 error occurred outside of examples
+
     EOS
   end
 
@@ -127,6 +129,7 @@ RSpec.describe 'Suite hook errors' do
 
       Finished in n.nnnn seconds (files took n.nnnn seconds to load)
       0 examples, 0 failures, 3 errors occurred outside of examples
+
     EOS
   end
 end

--- a/spec/rspec/core/bisect/coordinator_spec.rb
+++ b/spec/rspec/core/bisect/coordinator_spec.rb
@@ -95,6 +95,7 @@ module RSpec::Core
         |
         |The minimal reproduction command is:
         |  rspec 1.rb[1:1] 2.rb[1:1] 4.rb[1:1] 5.rb[1:1]
+
       EOS
     end
 
@@ -115,6 +116,7 @@ module RSpec::Core
           |
           |The minimal reproduction command is:
           |  rspec 2.rb[1:1]
+
         EOS
       end
 
@@ -144,6 +146,7 @@ module RSpec::Core
           |
           |The minimal reproduction command is:
           |  rspec 2.rb[1:1]
+
         EOS
       end
     end
@@ -190,6 +193,7 @@ module RSpec::Core
           |
           |The most minimal reproduction command discovered so far is:
           |  rspec 1.rb[1:1] 2.rb[1:1] 3.rb[1:1] 4.rb[1:1] 5.rb[1:1]
+
         EOS
       end
     end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1,4 +1,5 @@
 require 'tmpdir'
+require 'pathname'
 require 'rspec/support/spec/in_sub_process'
 
 module RSpec::Core
@@ -64,7 +65,7 @@ module RSpec::Core
       end
 
       it 'is configurable' do
-        io = double 'deprecation io'
+        io = StringIO.new
         config.deprecation_stream = io
         expect(config.deprecation_stream).to eq io
       end
@@ -97,9 +98,11 @@ module RSpec::Core
       it 'defaults to standard output' do
         expect(config.output_stream).to eq $stdout
       end
+    end
 
+    describe "#output_stream=" do
       it 'is configurable' do
-        io = double 'output io'
+        io = StringIO.new
         config.output_stream = io
         expect(config.output_stream).to eq io
       end
@@ -124,6 +127,26 @@ module RSpec::Core
           config.output_stream = config.output_stream
           expect(config).not_to have_received(:warn)
         end
+      end
+
+      it 'creates a file at that path' do
+        path = File.join(Dir.tmpdir, 'output.txt')
+        config.output_stream = path
+        expect(config.output_stream).to be_a(File)
+        expect(config.output_stream.path).to eq(path)
+      end
+
+      it 'accepts a Pathname object' do
+        path = File.join(Dir.tmpdir, 'output.txt')
+        config.output_stream = Pathname.new(path)
+        expect(config.output_stream).to be_a(File)
+        expect(config.output_stream.path).to eq(path)
+      end
+
+      it 'changes the output wrapper output' do
+        io = StringIO.new
+        expect(config.send(:output_wrapper)).to receive(:output=).with(io)
+        config.output_stream = io
       end
     end
 
@@ -1444,9 +1467,22 @@ module RSpec::Core
 
     %w[formatter= add_formatter].each do |config_method|
       describe "##{config_method}" do
-        it "delegates to formatters#add" do
-          expect(config.formatter_loader).to receive(:add).with('these','options')
-          config.send(config_method,'these','options')
+        it "delegates to formatters#add", :failing_on_appveyor,
+        :pending => false,
+        :skip => (ENV['APPVEYOR'] ? "Failing on AppVeyor but :pending isn't working for some reason" : false) do
+          expect(config.formatter_loader).to receive(:add) do |arg1, arg2|
+            expect(arg1).to eq 'these'
+            expect(arg2).to be_kind_of File
+            expect(arg2.path).to eq 'options'
+          end
+          config.send(config_method, 'these', 'options')
+
+          File.delete('options') if File.exist?('options')
+        end
+
+        it "uses the output wrapper as a default output" do
+          expect(config.formatter_loader).to receive(:add).with('these', config.send(:output_wrapper))
+          config.send(config_method, 'these')
         end
       end
     end
@@ -1456,6 +1492,12 @@ module RSpec::Core
         config.add_formatter 'doc'
         config.formatters.clear
         expect(config.formatters).to_not eq []
+      end
+    end
+
+    describe "#configuration" do
+      it "returns the same object every time" do
+        expect(config.send(:output_wrapper)).to equal(config.send(:output_wrapper))
       end
     end
 
@@ -2291,6 +2333,32 @@ module RSpec::Core
         config.add_formatter "doc"
         config.reset
         expect(config.formatters).to be_empty
+      end
+
+      it "clears the output wrapper" do
+        config.output_stream = StringIO.new
+        config.reset
+        expect(config.instance_variable_get("@output_wrapper")).to be_nil
+      end
+    end
+
+    describe "#reset_reporter" do
+      it "clears the reporter" do
+        expect(config.reporter).not_to be_nil
+        config.reset
+        expect(config.instance_variable_get("@reporter")).to be_nil
+      end
+
+      it "clears the formatters" do
+        config.add_formatter "doc"
+        config.reset
+        expect(config.formatters).to be_empty
+      end
+
+      it "clears the output wrapper" do
+        config.output_stream = StringIO.new
+        config.reset
+        expect(config.instance_variable_get("@output_wrapper")).to be_nil
       end
     end
 

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -125,6 +125,7 @@ root
         |    raises (FAILED - 6)
         |
         |#{expected_summary_output_for_example_specs}
+
       EOS
     end
   end

--- a/spec/rspec/core/formatters/progress_formatter_spec.rb
+++ b/spec/rspec/core/formatters/progress_formatter_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe RSpec::Core::Formatters::ProgressFormatter do
       |**F..FFFFF
       |
       |#{expected_summary_output_for_example_specs}
+
     EOS
   end
 end

--- a/spec/rspec/core/formatters_spec.rb
+++ b/spec/rspec/core/formatters_spec.rb
@@ -106,21 +106,6 @@ module RSpec::Core::Formatters
         expect { loader.add :progresss, output }.to raise_error(ArgumentError)
       end
 
-      context "with a 2nd arg defining the output" do
-        it "creates a file at that path and sets it as the output" do
-          loader.add('doc', path)
-          expect(loader.formatters.first.output).to be_a(File)
-          expect(loader.formatters.first.output.path).to eq(path)
-        end
-
-        it "accepts Pathname objects for file paths" do
-          pathname = Pathname.new(path)
-          loader.add('doc', pathname)
-          expect(loader.formatters.first.output).to be_a(File)
-          expect(loader.formatters.first.output.path).to eq(path)
-        end
-      end
-
       context "when a duplicate formatter exists" do
         before { loader.add :documentation, output }
 

--- a/spec/rspec/core/output_wrapper_spec.rb
+++ b/spec/rspec/core/output_wrapper_spec.rb
@@ -1,0 +1,22 @@
+module RSpec::Core
+  RSpec.describe OutputWrapper do
+    let(:output) { StringIO.new }
+    let(:wrapper) { OutputWrapper.new(output) }
+
+    it 'redirects calls to the wrapped object' do
+      wrapper.puts('message')
+      wrapper.print('another message')
+      expect(output.string).to eq("message\nanother message")
+    end
+
+    describe '#output=' do
+      let(:another_output) { StringIO.new }
+
+      it 'changes the output stream' do
+        wrapper.output = another_output
+        wrapper.puts('message')
+        expect(another_output.string).to eq("message\n")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reason of bug described in #2216. I think easiest way to fix - update `output` of already created formatters at every change of config `output_stream`.

I’m not sure how tests should be written for this fix. So if any thoughts how to tests should be done or how to make solution better - i will glad to make it.
