### PR TITLE
Follow up to #2401

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@ Enhancements:
 
 * Add seed information to JSON formatter output. (#2388, Mitsutaka Mimura)
 * Include example id in the JSON formatter output. (#2369, Xavier Shay)
+* Respect changes to `config.output_stream` after formatters have been
+  setup. (#2401, #2419, Ilya Lavrov)
 
 Bug Fixes:
 

--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -142,8 +142,10 @@ module RSpec::Core::Formatters
     end
 
     # @private
-    def add(formatter_to_use, *args)
+    def add(formatter_to_use, *paths)
       formatter_class = find_formatter(formatter_to_use)
+
+      args = paths.map { |p| p.respond_to?(:puts) ? p : open_stream(p) }
 
       if !Loader.formatters[formatter_class].nil?
         formatter = formatter_class.new(*args)
@@ -248,6 +250,16 @@ module RSpec::Core::Formatters
       word.tr!("-", "_")
       word.downcase!
       word
+    end
+
+    def open_stream(path_or_wrapper)
+      if RSpec::Core::OutputWrapper === path_or_wrapper
+        path_or_wrapper.output = open_stream(path_or_wrapper.output)
+        path_or_wrapper
+      else
+        RSpec::Support::DirectoryMaker.mkdir_p(File.dirname(path_or_wrapper))
+        File.new(path_or_wrapper, 'w')
+      end
     end
   end
 end

--- a/lib/rspec/core/output_wrapper.rb
+++ b/lib/rspec/core/output_wrapper.rb
@@ -3,17 +3,25 @@ module RSpec
     # @private
     class OutputWrapper
       # @private
-      attr_writer :output
+      attr_accessor :output
 
       # @private
       def initialize(output)
         @output = output
       end
 
+      def respond_to?(name, priv=false)
+        output.respond_to?(name, priv)
+      end
+
+      def method_missing(name, *args, &block)
+        output.send(name, *args, &block)
+      end
+
       # Redirect calls for IO interface methods
       IO.instance_methods(false).each do |method|
         define_method(method) do |*args, &block|
-          @output.send(method, *args, &block)
+          output.send(method, *args, &block)
         end
       end
     end

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -1,4 +1,0 @@
-      RSpec.describe "calling a deprecated method" do
-             example { 123 }
-      end
-

--- a/spec/integration/output_stream_spec.rb
+++ b/spec/integration/output_stream_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Output stream' do
 
   context 'when a formatter set in a configure block' do
     it 'writes to the right output stream' do
-      write_file_formatted 'spec/example_spec.rb', "
+      write_file_formatted 'spec/example_spec.rb', <<-SPEC
         RSpec.configure do |c|
           c.formatter = :documentation
           c.output_stream = File.open('saved_output', 'w')
@@ -17,7 +17,50 @@ RSpec.describe 'Output stream' do
             true
           end
         end
-      "
+      SPEC
+
+      run_command ''
+      expect(last_cmd_stdout).to be_empty
+      in_current_dir do
+        expect(File.read('saved_output')).to include('1 example, 0 failures')
+      end
+    end
+
+    it 'writes to the right output stream even when its a filename' do
+      write_file_formatted 'spec/example_spec.rb', <<-SPEC
+        RSpec.configure do |c|
+          c.formatter = :documentation
+          c.output_stream = 'saved_output'
+        end
+
+        RSpec.describe 'something' do
+          it 'succeeds' do
+            true
+          end
+        end
+      SPEC
+
+      run_command ''
+      expect(last_cmd_stdout).to be_empty
+      in_current_dir do
+        expect(File.read('saved_output')).to include('1 example, 0 failures')
+      end
+    end
+
+    it 'writes to the right output stream even when its a filename' do
+      write_file_formatted 'spec/example_spec.rb', <<-SPEC
+        require 'pathname'
+        RSpec.configure do |c|
+          c.formatter = :documentation
+          c.output_stream = Pathname.new('saved_output')
+        end
+
+        RSpec.describe 'something' do
+          it 'succeeds' do
+            true
+          end
+        end
+      SPEC
 
       run_command ''
       expect(last_cmd_stdout).to be_empty
@@ -26,5 +69,4 @@ RSpec.describe 'Output stream' do
       end
     end
   end
-
 end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1,5 +1,4 @@
 require 'tmpdir'
-require 'pathname'
 require 'rspec/support/spec/in_sub_process'
 
 module RSpec::Core
@@ -126,26 +125,6 @@ module RSpec::Core
           config.output_stream = config.output_stream
           expect(config).not_to have_received(:warn)
         end
-      end
-
-      it 'creates a file at that path' do
-        path = File.join(Dir.tmpdir, 'output.txt')
-        config.output_stream = path
-        expect(config.output_stream).to be_a(File)
-        expect(config.output_stream.path).to eq(path)
-      end
-
-      it 'accepts a Pathname object' do
-        path = File.join(Dir.tmpdir, 'output.txt')
-        config.output_stream = Pathname.new(path)
-        expect(config.output_stream).to be_a(File)
-        expect(config.output_stream.path).to eq(path)
-      end
-
-      it 'changes the output wrapper output' do
-        io = StringIO.new
-        expect(config.send(:output_wrapper)).to receive(:output=).with(io)
-        config.output_stream = io
       end
     end
 
@@ -1466,22 +1445,9 @@ module RSpec::Core
 
     %w[formatter= add_formatter].each do |config_method|
       describe "##{config_method}" do
-        it "delegates to formatters#add", :failing_on_appveyor,
-        :pending => false,
-        :skip => (ENV['APPVEYOR'] ? "Failing on AppVeyor but :pending isn't working for some reason" : false) do
-          expect(config.formatter_loader).to receive(:add) do |arg1, arg2|
-            expect(arg1).to eq 'these'
-            expect(arg2).to be_kind_of File
-            expect(arg2.path).to eq 'options'
-          end
-          config.send(config_method, 'these', 'options')
-
-          File.delete('options') if File.exist?('options')
-        end
-
-        it "uses the output wrapper as a default output" do
-          expect(config.formatter_loader).to receive(:add).with('these', config.send(:output_wrapper))
-          config.send(config_method, 'these')
+        it "delegates to formatters#add" do
+          expect(config.formatter_loader).to receive(:add).with('these','options')
+          config.send(config_method,'these','options')
         end
       end
     end
@@ -1491,12 +1457,6 @@ module RSpec::Core
         config.add_formatter 'doc'
         config.formatters.clear
         expect(config.formatters).to_not eq []
-      end
-    end
-
-    describe "#configuration" do
-      it "returns the same object every time" do
-        expect(config.send(:output_wrapper)).to equal(config.send(:output_wrapper))
       end
     end
 

--- a/spec/rspec/core/formatters_spec.rb
+++ b/spec/rspec/core/formatters_spec.rb
@@ -106,6 +106,21 @@ module RSpec::Core::Formatters
         expect { loader.add :progresss, output }.to raise_error(ArgumentError)
       end
 
+      context "with a 2nd arg defining the output" do
+        it "creates a file at that path and sets it as the output" do
+          loader.add('doc', path)
+          expect(loader.formatters.first.output).to be_a(File)
+          expect(loader.formatters.first.output.path).to eq(path)
+        end
+
+        it "accepts Pathname objects for file paths" do
+          pathname = Pathname.new(path)
+          loader.add('doc', pathname)
+          expect(loader.formatters.first.output).to be_a(File)
+          expect(loader.formatters.first.output.path).to eq(path)
+        end
+      end
+
       context "when a duplicate formatter exists" do
         before { loader.add :documentation, output }
 

--- a/spec/rspec/core/output_wrapper_spec.rb
+++ b/spec/rspec/core/output_wrapper_spec.rb
@@ -6,7 +6,7 @@ module RSpec::Core
     it 'redirects calls to the wrapped object' do
       wrapper.puts('message')
       wrapper.print('another message')
-      expect(output.string).to eq("message\nanother message")
+      expect(output.string).to eq("message\nanother message").and eq(wrapper.string)
     end
 
     describe '#output=' do


### PR DESCRIPTION
Move the logic for detecting files vs streams back to formatter loader, this restores the deprecation stream behaviour and simplifies config. 