### PR TITLE
Allow options files and SPEC_OPTS to append to formatters options.

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -40,6 +40,10 @@ module RSpec
 
     private
 
+      # Keys that are appended to instead of overriden when organizing options
+      # from multiple sources such as CLI, options file, and SPEC_OPTS
+      APPEND_KEYS = Set.new([:libs, :requires, :formatters])
+
       def organize_options
         @filter_manager_options = []
 
@@ -50,7 +54,7 @@ module RSpec
 
         @options = @options.inject(:libs => [], :requires => []) do |hash, opts|
           hash.merge(opts) do |key, oldval, newval|
-            [:libs, :requires].include?(key) ? oldval + newval : newval
+            APPEND_KEYS.include?(key) ? oldval + newval : newval
           end
         end
       end

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -471,10 +471,10 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
       end
     end
 
-    it "prefers CLI over file options" do
+    it "includes all formatting options" do
       File.open("./.rspec", "w") {|f| f << "--format project"}
       File.open(File.expand_path("~/.rspec"), "w") {|f| f << "--format global"}
-      expect(parse_options("--format", "cli")[:formatters]).to eq([['cli']])
+      expect(parse_options("--format", "cli")[:formatters]).to eq([['global'], ['project'], ['cli']])
     end
 
     it "prefers CLI over file options for filter inclusion" do

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -487,15 +487,15 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
     end
 
     it "prefers project file options over global file options" do
-      File.open("./.rspec", "w") {|f| f << "--format project"}
-      File.open(File.expand_path("~/.rspec"), "w") {|f| f << "--format global"}
-      expect(parse_options[:formatters]).to eq([['project']])
+      File.open("./.rspec", "w") {|f| f << "--force-color"}
+      File.open(File.expand_path("~/.rspec"), "w") {|f| f << "--no-force-color"}
+      expect(parse_options[:color_mode]).to be_truthy
     end
 
     it "prefers local file options over project file options" do
-      File.open("./.rspec-local", "w") {|f| f << "--format local"}
-      File.open("./.rspec", "w") {|f| f << "--format global"}
-      expect(parse_options[:formatters]).to eq([['local']])
+      File.open("./.rspec-local", "w") {|f| f << "--force-color"}
+      File.open("./.rspec", "w") {|f| f << "--no-force-color"}
+      expect(parse_options[:color_mode]).to be_truthy
     end
 
     it "parses options file correctly if erb code has trimming options" do


### PR DESCRIPTION
Hi! I'm realizing that when using the CLI to do something like so:

```
$ rspec -f progress -O custom.rspec spec/
```

And `custom.rspec` has:

```
--format RSpecJunitFormatter --out 'tmp/rspec-results/<%= SecureRandom.hex(10) %>'
```

It actually will not append multiple formatters to the RSpec configuration. I find this odd because it's very possible to add multiple from the CLI doing `-f progress -f documentation --out docformat.txt` 


I found a spec that asserts that this behavior I'm describing is true, however it looks very old (several years):
https://github.com/rspec/rspec-core/blob/master/spec/rspec/core/configuration_options_spec.rb#L474-L478

Is there a reason to maintain this behavior? Why always prefer CLI instead of merging both options like the others?