### PR TITLE
Frozen string literal fixes.

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -87,7 +87,7 @@ module RSpec
       def inspect_output
         inspect_output = "\"#{description}\""
         unless metadata[:description].to_s.empty?
-          inspect_output << " (#{location})"
+          inspect_output += " (#{location})"
         end
         inspect_output
       end

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -841,7 +841,7 @@ module RSpec
       return "Anonymous" if group.description.empty?
 
       # Convert to CamelCase.
-      name = ' ' << group.description
+      name = ' ' + group.description
       name.gsub!(/[^0-9a-zA-Z]+([0-9a-zA-Z])/) do
         match = ::Regexp.last_match[1]
         match.upcase!

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -111,7 +111,7 @@ module RSpec::Core
         formatted = "\nFailures:\n"
 
         failure_notifications.each_with_index do |failure, index|
-          formatted << failure.fully_formatted(index.next, colorizer)
+          formatted += failure.fully_formatted(index.next, colorizer)
         end
 
         formatted
@@ -315,13 +315,15 @@ module RSpec::Core
       # @api
       # @return [String] A line summarising the result totals of the spec run.
       def totals_line
-        summary = Formatters::Helpers.pluralize(example_count, "example")
-        summary << ", " << Formatters::Helpers.pluralize(failure_count, "failure")
-        summary << ", #{pending_count} pending" if pending_count > 0
+        summary = Formatters::Helpers.pluralize(example_count, "example") +
+          ", " + Formatters::Helpers.pluralize(failure_count, "failure")
+        summary += ", #{pending_count} pending" if pending_count > 0
         if errors_outside_of_examples_count > 0
-          summary << ", "
-          summary << Formatters::Helpers.pluralize(errors_outside_of_examples_count, "error")
-          summary << " occurred outside of examples"
+          summary += (
+            ", " +
+            Formatters::Helpers.pluralize(errors_outside_of_examples_count, "error") +
+            " occurred outside of examples"
+          )
         end
         summary
       end
@@ -380,7 +382,7 @@ module RSpec::Core
                     "#{colorized_totals_line(colorizer)}\n"
 
         unless failed_examples.empty?
-          formatted << colorized_rerun_commands(colorizer) << "\n"
+          formatted += (colorized_rerun_commands(colorizer) + "\n")
         end
 
         formatted


### PR DESCRIPTION
Not sure if I've got everything covered, but this is enough to get one of my simpler test suites (https://github.com/pat/sliver) passing with frozen string literals enabled.