### PR TITLE
Fixing string concatenation for frozen string literals.

### DIFF
--- a/lib/rspec/core/formatters/deprecation_formatter.rb
+++ b/lib/rspec/core/formatters/deprecation_formatter.rb
@@ -59,6 +59,8 @@ module RSpec
 
         DEPRECATION_STREAM_NOTICE = "Pass `--deprecation-out` or set " \
           "`config.deprecation_stream` to a file for full output."
+        TOO_MANY_WARNINGS_NOTICE  = "Too many similar deprecation messages " \
+          "reported, disregarding further reports. #{DEPRECATION_STREAM_NOTICE}"
 
         SpecifiedDeprecationMessage = Struct.new(:type) do
           def initialize(data)
@@ -71,9 +73,7 @@ module RSpec
           end
 
           def too_many_warnings_message
-            msg = "Too many similar deprecation messages reported, disregarding further reports. "
-            msg << DEPRECATION_STREAM_NOTICE
-            msg
+            TOO_MANY_WARNINGS_NOTICE
           end
 
           private
@@ -96,16 +96,14 @@ module RSpec
           end
 
           def to_s
-            msg =  "#{@data.deprecated} is deprecated."
+            msg = String.new("#{@data.deprecated} is deprecated.")
             msg << " Use #{@data.replacement} instead." if @data.replacement
-            msg << " Called from #{@data.call_site}." if @data.call_site
+            msg << " Called from #{@data.call_site}."   if @data.call_site
             msg
           end
 
           def too_many_warnings_message
-            msg = "Too many uses of deprecated '#{type}'. "
-            msg << DEPRECATION_STREAM_NOTICE
-            msg
+            "Too many uses of deprecated '#{type}'. #{DEPRECATION_STREAM_NOTICE}"
           end
         end
 

--- a/lib/rspec/core/formatters/html_printer.rb
+++ b/lib/rspec/core/formatters/html_printer.rb
@@ -59,7 +59,9 @@ module RSpec
         end
 
         def print_summary(duration, example_count, failure_count, pending_count)
-          totals =  "#{example_count} example#{'s' unless example_count == 1}, "
+          totals = String.new(
+            "#{example_count} example#{'s' unless example_count == 1}, "
+          )
           totals << "#{failure_count} failure#{'s' unless failure_count == 1}"
           totals << ", #{pending_count} pending" if pending_count > 0
 


### PR DESCRIPTION
Found a few more instances of string literals not liking being frozen, that crop up with deprecations, plus the HTML formatting change as well from a quick (and most certainly incomplete) search.