### PR TITLE
Change comment in base_formatter.rb

### DIFF
--- a/lib/rspec/core/formatters/base_formatter.rb
+++ b/lib/rspec/core/formatters/base_formatter.rb
@@ -5,7 +5,7 @@ module RSpec
   module Core
     module Formatters
       # RSpec's built-in formatters are all subclasses of
-      # RSpec::Core::Formatters::BaseTextFormatter.
+      # RSpec::Core::Formatters::BaseFormatter.
       #
       # @see RSpec::Core::Formatters::BaseTextFormatter
       # @see RSpec::Core::Reporter


### PR DESCRIPTION
BaseTextFormatter inherits BaseFromatter but BaseFormatters comments says
"RSpec's built-in formatters are all subclasses of  RSpec::Core::Formatters::BaseTextFormatter."