### PR TITLE
Add -n short option for --next-failure

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -161,7 +161,7 @@ module RSpec
 
       # @macro define_reader
       # The file path to use for persisting example statuses. Necessary for the
-      # `--only-failures` and `--next-failures` CLI options.
+      # `--only-failures` and `--next-failure` CLI options.
       #
       # @overload example_status_persistence_file_path
       #   @return [String] the file path
@@ -170,7 +170,7 @@ module RSpec
       define_reader :example_status_persistence_file_path
 
       # Sets the file path to use for persisting example statuses. Necessary for the
-      # `--only-failures` and `--next-failures` CLI options.
+      # `--only-failures` and `--next-failure` CLI options.
       def example_status_persistence_file_path=(value)
         @example_status_persistence_file_path = value
         clear_values_derived_from_example_status_persistence_file_path

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -201,7 +201,7 @@ FILTERING
           configure_only_failures(options)
         end
 
-        parser.on("--next-failure", "Apply `--only-failures` and abort after one failure.",
+        parser.on("-n", "--next-failure", "Apply `--only-failures` and abort after one failure.",
                   "  (Equivalent to `--only-failures --fail-fast --order defined`)") do
           configure_only_failures(options)
           set_fail_fast(options, 1)

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
       end
     end
 
-    %w[ --only-failures --next-failure ].each do |option|
+    %w[ --only-failures --next-failure -n].each do |option|
       describe option do
         it "changes `config.only_failures?` to true" do
           opts = config_options_object(option)

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -185,22 +185,24 @@ module RSpec::Core
       end
     end
 
-    describe "--next-failure" do
-      it 'is equivalent to `--tag last_run_status:failed --fail-fast --order defined`' do
-        long_form = Parser.parse(%w[ --tag last_run_status:failed --fail-fast --order defined ])
-        next_failure = Parser.parse(%w[ --next-failure ])
+    %w[--next-failure -n].each do |option|
+      describe option do
+        it 'is equivalent to `--tag last_run_status:failed --fail-fast --order defined`' do
+          long_form = Parser.parse(%w[ --tag last_run_status:failed --fail-fast --order defined ])
+          next_failure = Parser.parse([option])
 
-        expect(next_failure).to include(long_form)
-      end
+          expect(next_failure).to include(long_form)
+        end
 
-      it 'does not force `--order defined` over a specified `--seed 1234` option that comes before it' do
-        options = Parser.parse(%w[ --seed 1234 --next-failure ])
-        expect(options).to include(:order => "rand:1234")
-      end
+        it 'does not force `--order defined` over a specified `--seed 1234` option that comes before it' do
+          options = Parser.parse(['--seed', '1234', option])
+          expect(options).to include(:order => "rand:1234")
+        end
 
-      it 'does not force `--order defined` over a specified `--seed 1234` option that comes after it' do
-        options = Parser.parse(%w[ --next-failure --seed 1234 ])
-        expect(options).to include(:order => "rand:1234")
+        it 'does not force `--order defined` over a specified `--seed 1234` option that comes after it' do
+          options = Parser.parse([option, '--seed', '1234'])
+          expect(options).to include(:order => "rand:1234")
+        end
       end
     end
 


### PR DESCRIPTION
`--next-failures` is such a terrific feature! It really helps me to stay focused and write specs which are concise, and more easily squash bugs when they arise.

The only thing that I do not like about the feature is all of the typing involved when writing `--next-failures`. This PR makes a short option `-n`, to increase the ergonomics of using the feature. Less typing, happier hands!