### PR TITLE
Updates for frozen-string-literal compatibility.

### DIFF
--- a/features/configuration/pattern.feature
+++ b/features/configuration/pattern.feature
@@ -45,7 +45,7 @@ Feature: pattern
     Given a file named "spec/spec_helper.rb" with:
       """ruby
       RSpec.configure do |config|
-        config.pattern << ',**/*.spec'
+        config.pattern += ',**/*.spec'
       end
       """
     And a file named "spec/two_examples.spec" with:

--- a/lib/rspec/core/drb.rb
+++ b/lib/rspec/core/drb.rb
@@ -84,7 +84,7 @@ module RSpec
       def add_filter(argv, name, hash)
         hash.each_pair do |k, v|
           next if CONDITIONAL_FILTERS.include?(k)
-          tag = name == :inclusion ? k.to_s : "~#{k}"
+          tag = name == :inclusion ? k.to_s : "~#{k}".dup
           tag << ":#{v}" if v.is_a?(String)
           argv << "--tag" << tag
         end unless hash.empty?

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -523,7 +523,7 @@ module RSpec
       def assign_generated_description
         if metadata[:description].empty? && (description = generate_description)
           metadata[:description] = description
-          metadata[:full_description] << description
+          metadata[:full_description] += description
         end
       ensure
         RSpec::Matchers.clear_generated_description

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -838,7 +838,7 @@ module RSpec
     end
 
     def self.base_name_for(group)
-      return "Anonymous" if group.description.empty?
+      return "Anonymous".dup if group.description.empty?
 
       # Convert to CamelCase.
       name = ' ' + group.description

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -232,9 +232,14 @@ module RSpec::Core
       #   RSpec's built-in formatters emit.
       def fully_formatted(pending_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted_caller = RSpec.configuration.backtrace_formatter.backtrace_line(example.location)
-        colorizer.wrap("\n  #{pending_number}) #{example.full_description}", :pending) + "\n     " +
-          Formatters::ExceptionPresenter::PENDING_DETAIL_FORMATTER.call(example, colorizer) +
-          "\n" + colorizer.wrap("     # #{formatted_caller}\n", :detail)
+
+        [
+          colorizer.wrap("\n  #{pending_number}) #{example.full_description}", :pending),
+          "\n     ",
+          Formatters::ExceptionPresenter::PENDING_DETAIL_FORMATTER.call(example, colorizer),
+          "\n",
+          colorizer.wrap("     # #{formatted_caller}\n", :detail)
+        ].join("")
       end
     end
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -120,7 +120,7 @@ module RSpec::Core
       # @return [String] The list of pending examples, fully formatted in the
       #   way that RSpec's built-in formatters emit.
       def fully_formatted_pending_examples(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
-        formatted = "\nPending: (Failures listed here are expected and do not affect your suite's status)\n"
+        formatted = "\nPending: (Failures listed here are expected and do not affect your suite's status)\n".dup
 
         pending_notifications.each_with_index do |notification, index|
           formatted << notification.fully_formatted(index.next, colorizer)
@@ -232,9 +232,9 @@ module RSpec::Core
       #   RSpec's built-in formatters emit.
       def fully_formatted(pending_number, colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         formatted_caller = RSpec.configuration.backtrace_formatter.backtrace_line(example.location)
-        colorizer.wrap("\n  #{pending_number}) #{example.full_description}", :pending) << "\n     " <<
-          Formatters::ExceptionPresenter::PENDING_DETAIL_FORMATTER.call(example, colorizer) <<
-          "\n" << colorizer.wrap("     # #{formatted_caller}\n", :detail)
+        colorizer.wrap("\n  #{pending_number}) #{example.full_description}", :pending) + "\n     " +
+          Formatters::ExceptionPresenter::PENDING_DETAIL_FORMATTER.call(example, colorizer) +
+          "\n" + colorizer.wrap("     # #{formatted_caller}\n", :detail)
       end
     end
 

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
 
-  s.add_development_dependency "coderay",  "~> 1.0.9"
+  s.add_development_dependency "coderay",  "~> 1.1.1"
 
   s.add_development_dependency "mocha",        "~> 0.13.0"
   s.add_development_dependency "rr",           "~> 1.0.4"

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     if String.method_defined?(:encoding)
       context "with an exception that has a differently encoded message" do
         it "runs without encountering an encoding exception" do
-          group.example("Mixing encodings, e.g. UTF-8: © and Binary") { raise "Error: \xC2\xA9".force_encoding("ASCII-8BIT") }
+          group.example("Mixing encodings, e.g. UTF-8: © and Binary") { raise "Error: \xC2\xA9".dup.force_encoding("ASCII-8BIT") }
           run_all_and_dump_failures
           expect(formatter_output.string).to match(/RuntimeError:\n\s+Error: \?\?/m) # ?? because the characters dont encode properly
         end

--- a/spec/rspec/core/formatters/html_snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/html_snippet_extractor_spec.rb
@@ -14,7 +14,7 @@ module RSpec
 
         it "falls back on a default message when it gets a security error" do
           message = with_safe_set_to_level_that_triggers_security_errors do
-            RSpec::Core::Formatters::HtmlSnippetExtractor.new.lines_around("blech".taint, 8)
+            RSpec::Core::Formatters::HtmlSnippetExtractor.new.lines_around("blech".dup.taint, 8)
           end
           expect(message).to eq("# Couldn't get snippet for blech")
         end

--- a/spec/rspec/core/formatters/syntax_highlighter_spec.rb
+++ b/spec/rspec/core/formatters/syntax_highlighter_spec.rb
@@ -83,7 +83,7 @@ module RSpec::Core::Formatters
         highlighted = highlighter.highlight(lines)
         highlighted_terms = []
 
-        highlighted.join("\n").scan(/\e\[1;[1-9]\dm(\w+)\e\[0m/) do |first_capture, _|
+        highlighted.join("\n").scan(/\e\[[1-9]\dm(\w+)\e\[0m/) do |first_capture, _|
           highlighted_terms << first_capture
         end
 
@@ -124,7 +124,7 @@ module RSpec::Core::Formatters
     end
 
     def be_highlighted
-      include("\e[32m")
+      include("\e[31m")
     end
 
   end

--- a/spec/rspec/core/notifications_spec.rb
+++ b/spec/rspec/core/notifications_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe "FailedExampleNotification" do
     if String.method_defined?(:encoding)
       it "returns failures_lines with invalid bytes replace by '?'" do
         message_with_invalid_byte_sequence =
-          "\xEF \255 \xAD I have bad bytes".force_encoding(Encoding::UTF_8)
+          "\xEF \255 \xAD I have bad bytes".dup.force_encoding(Encoding::UTF_8)
         allow(exception).to receive(:message).
           and_return(message_with_invalid_byte_sequence)
 

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe RSpec do
 
       RSpec.clear_examples
 
-      RSpec.configuration.deprecation_stream = StringIO.new(deprecations = "")
+      RSpec.configuration.deprecation_stream = StringIO.new(deprecations = "".dup)
 
       group = RSpec.describe do
         example { RSpec.deprecate("second deprecation") }


### PR DESCRIPTION
(I've got patches for `rspec-expectations`, `rspec-mocks` and `rspec-support` which are related to this one, so I'm going to write out all the detail here, and then link to it from the others.)

I've put together these patches by running the test suites for each gem with the `RUBYOPT=--enable-frozen-string-literal` flag, so they're more thorough than my previous patches on this topic. However, as noted in those previous discussions, the test suite cannot yet be run reliably in that situation, so I've had some local changes to my Gemfile, and worked on patches for some dependencies. I've also had to have all rspec-x repos locally to debug some of the fixes in these patches.

Also: I've not got the cucumber test suites working in `rspec-core`, `rspec-expectations`, or `rspec-mocks`, so there could very well be further places in the Spec codebase that need changing. You're using a two-year-old version of Cucumber (1.3.x, when 2.x is released and 3.x is on the way), so I'm not sure how much effort should be put into updating that? Should we fork the 1.3.x release and make that frozen-string-literal-safe? Although, there are issues in Cucumber's dependencies as well…

Regarding how I've patched things: generally, I'm using `dup` instead of `String.new` - this is mostly because I've been working on similar patches for Rails, and the maintainers there prefer `dup`, hence that's my current habit. Also, `String.new` has an ASCII encoding, whereas `String.new('some string')` respects the argument's encoding (which defaults to UTF in recent Rubies), and that inconsistency is annoying.

I could (and might) keep going down the dependency rabbit hole and offer further patches, but I wanted to at least get these changes submitted so they're useful for the RSpec team sooner rather than later.

The dependency situation as it currently stands:

Patched (albeit with no new versions yet):
* [simplecov](https://github.com/colszowka/simplecov/pull/590)
* [simplecov-html](https://github.com/colszowka/simplecov-html/pull/56)

Pull Requests submitted:
* [coderay](https://github.com/rubychan/coderay/pull/211)
* [parser](https://github.com/whitequark/parser/pull/354) (used by rubocop)

In-progress patches:
* [racc](https://github.com/tenderlove/racc/pull/80) (used by parser)

No known patches:
* cucumber
* aruba (used by cucumber)
* syntax (used by cucumber)
* Possibly more, related to cucumber?

For anyone wanting to help: if you have commit bits on any of the above dependency repos, maybe get outstanding PRs merged, or help investigate failing test suites (racc). If anyone's on the Cucumber team: discussions need to be had around updating the version of Aruba it's dependant on, and maybe migrating from Syntax to Coderay (as that's what's recommended in the Syntax README).