### PR TITLE
Skip context all blocks

### DIFF
--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -456,7 +456,9 @@ module RSpec
           return if RSpec.configuration.dry_run?
 
           if scope == :context
-            run_owned_hooks_for(position, :context, example_or_group)
+            unless example_or_group.class.metadata[:skip]
+              run_owned_hooks_for(position, :context, example_or_group)
+            end
           else
             case position
             when :before then run_example_hooks_for(example_or_group, :before, :reverse_each)

--- a/spec/rspec/core/hooks_filtering_spec.rb
+++ b/spec/rspec/core/hooks_filtering_spec.rb
@@ -319,6 +319,23 @@ module RSpec::Core
         expect(filters).to eq([])
       end
 
+      it "does not run :all|:context hooks if the entire context is skipped" do
+        filters = []
+        RSpec.configure do |c|
+          c.before(:all) { filters << "before all in config"}
+          c.after(:all) { filters << "after all in config"}
+          c.before(:context) { filters << "before context in config"}
+          c.after(:context) { filters << "after context in config"}
+        end
+        group = RSpec.xdescribe("skipped describe") do
+          xcontext("skipped context") do
+            it("is skipped") {}
+          end
+        end
+        group.run
+        expect(filters).to eq([])
+      end
+
       context "when the hook filters apply to individual examples instead of example groups" do
         let(:each_filters) { [] }
         let(:all_filters) { [] }

--- a/spec/rspec/core/hooks_filtering_spec.rb
+++ b/spec/rspec/core/hooks_filtering_spec.rb
@@ -319,7 +319,24 @@ module RSpec::Core
         expect(filters).to eq([])
       end
 
-      it "does not run :all|:context hooks if the entire context is skipped" do
+      it "runs :all|:context hooks even if there are no unskipped examples in that context" do
+        filters = []
+        group = RSpec.describe("un-skipped describe") do
+          before(:all) { filters << "before all in group"}
+          after(:all) { filters << "after all in group"}
+
+          xcontext("skipped context") do
+            before(:context) { filters << "before context in group"}
+            after(:context) { filters << "after context in group"}
+
+            it("is skipped") {}
+          end
+        end
+        group.run
+        expect(filters).to eq(["before all in group", "after all in group"])
+      end
+
+      it "does not run :all|:context hooks in global config if the entire context is skipped" do
         filters = []
         RSpec.configure do |c|
           c.before(:all) { filters << "before all in config"}
@@ -328,7 +345,24 @@ module RSpec::Core
           c.after(:context) { filters << "after context in config"}
         end
         group = RSpec.xdescribe("skipped describe") do
-          xcontext("skipped context") do
+          context("skipped context") do
+            it("is skipped") {}
+          end
+        end
+        group.run
+        expect(filters).to eq([])
+      end
+
+      it "does not run local :all|:context hooks if the entire context is skipped" do
+        filters = []
+        group = RSpec.xdescribe("skipped describe") do
+          before(:all) { filters << "before all in group"}
+          after(:all) { filters << "after all in group"}
+
+          context("skipped context") do
+            before(:context) { filters << "before context in group"}
+            after(:context) { filters << "after context in group"}
+
             it("is skipped") {}
           end
         end


### PR DESCRIPTION
This skips any hooks for contexts that are entirely skipped. Since I don't know much about how all this stuff interacts, I'd be happy to go at this again if this looks like it will cause problems.

Resolves #2436 