### PR TITLE
on_example_group_definition_callbacks support for example groups created via shared example groups

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -310,6 +310,7 @@ module RSpec
             find_and_eval_shared("examples", name, the_caller.first, *args, &customization_block)
           end
           group.metadata[:shared_group_name] = name
+          RSpec.world.record(group, true)
           group
         end
       end

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -57,9 +57,9 @@ module RSpec
       # @api private
       #
       # Records an example group.
-      def record(example_group)
+      def record(example_group, is_shared_example_group=false)
         @configuration.on_example_group_definition_callbacks.each { |block| block.call(example_group) }
-        @example_group_counts_by_spec_file[example_group.metadata[:absolute_file_path]] += 1
+        @example_group_counts_by_spec_file[example_group.metadata[:absolute_file_path]] += 1 unless is_shared_example_group
       end
 
       # @private

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -23,15 +23,29 @@ module RSpec::Core
       before do
         RSpec.configure do |c|
           c.on_example_group_definition do |example_group|
-            example_group.examples.first.metadata[:new_key] = :new_value
+            example = example_group.examples.first
+            example.metadata[:new_key] = :new_value unless example.nil?
           end
         end
       end
 
-      it 'successfully invokes the block' do
-        RSpec.describe("group") { it "example 1" do; end}
-        example = RSpec.world.example_groups.first.examples.first
-        expect(example.metadata[:new_key]).to eq(:new_value)
+      context 'when example group is defined' do
+        it 'successfully invokes the block' do
+          RSpec.describe("group") { it "example 1" do; end}
+          example = RSpec.world.example_groups.first.examples.first
+          expect(example.metadata[:new_key]).to eq(:new_value)
+        end
+      end
+
+      context 'when shared example group is defined' do
+        it 'successfully invokes the block' do
+          RSpec.shared_examples("shared example group") { it "example 1" do; end}
+          RSpec.describe("group") { it_behaves_like "shared example group"}
+          example_group = RSpec.world.example_groups.first
+          nested_example_group = example_group.children.first
+          nested_example_group_example = nested_example_group.examples.first
+          expect(nested_example_group_example.metadata[:new_key]).to eq(:new_value)
+        end
       end
     end
 


### PR DESCRIPTION
Hey all,

I was trying to use `on_example_group_definition_callbacks` for example groups defined via shared examples however this does not seem to work. Example groups defined via shared examples do not run the callbacks. 

For example if have something like:

```
describe 'Alphabet' do

  shared_examples_for 'a letter' do
    it 'is printable' do
      expect { p letter }.to_not raise_exception
    end
  end

  context 'when A' do
    it_behaves_like 'a letter'
  end
end
```

When doing:

```
RSpec.configure do |c|
  c.on_example_group_definition_callbacks do |group|
    ... # BehavesLikeAletter will never end up here
  end
end
```

Like it says in the comment the behaves like a letter example group created due to the shared example would never appear as a group.

My reasoning for the cause of this problem is that `RSpec.world.record(group)` is never run for these kinds of groups because they are not defined via an _example group method_ but instead via a _nested shared group method_. 

I am not sure if this behaviour is actually intended. I attempt to fix this in this PR. I am not confident if the approach I took is sound. Please let me know.
