### PR TITLE
Reduce JRuby flakyness by giving it more time to finish

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,7 +5,7 @@ Before do
   set_env('SHELL', '/usr/bin/bash')
 
   if RUBY_PLATFORM =~ /java/ || defined?(Rubinius)
-    @aruba_timeout_seconds = 60
+    @aruba_timeout_seconds = 120
   else
     @aruba_timeout_seconds = 10
   end


### PR DESCRIPTION
Startup time is still very much a problem with JRuby, hence
feature type aruba cukes that invoke rspec a lot of times
are still problematic. The bisect specs do this to the extreme,
resulting in long spec run times. Locally a single scenario
takes 36 seconds to run for me, on a 4-core desktop computer.
An overloaded CI might take longer, hence just double the timeout
and hope it's enough. Nothing much else we can do.

ref: #2442 

While I'm here, thanks for rspec it's :rocket: - and [shoes4](https://github.com/shoes/shoes4) is an OSS project that is rigorously tested with it :)