### PR TITLE
Mark failing examples on JRuby 9000 as pending

### DIFF
--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -436,6 +436,7 @@ module RSpec::Core
 
         context 'and the line count does not exceed RSpec.configuration.max_displayed_failure_line_count' do
           it 'returns all the lines' do
+            pending 'https://github.com/jruby/jruby/issues/4737' if RSpec::Support::Ruby.jruby_9000?
             expect(read_failed_lines).to eq([
               "            expect('RSpec').to be_a(String).",
               "                           and start_with('R').",
@@ -450,6 +451,7 @@ module RSpec::Core
           end
 
           it 'returns the lines without exceeding the max count' do
+            pending 'https://github.com/jruby/jruby/issues/4737' if RSpec::Support::Ruby.jruby_9000?
             expect(read_failed_lines).to eq([
               "            expect('RSpec').to be_a(String).",
               "                           and start_with('R')."


### PR DESCRIPTION
They have started failing after we made `ripper_supported?` return true on JRuby 9.1.9.0 or later in https://github.com/rspec/rspec-support/pull/326. However it's actually caused by a bug in JRuby's backtrace, neither Ripper nor our multiline snippet extraction.

https://github.com/jruby/jruby/issues/4737

```
Failures:

  1) RSpec::Core::Formatters::ExceptionPresenter#read_failed_lines when the failed expression spans multiple lines and the line count does not exceed RSpec.configuration.max_displayed_failure_line_count returns all the lines
     Failure/Error:
       expect(read_failed_lines).to eq([
         "            expect('RSpec').to be_a(String).",
         "                           and start_with('R').",
         "                           and end_with('z')"
       ])

       expected: ["            expect('RSpec').to be_a(String).", "                           and start_with('R').", "                           and end_with('z')"]
            got: ["                           and start_with('R').", "                           and end_with('z')"]

       (compared using ==)
```