### PR TITLE
Configure Simplecov correctly

### DIFF
--- a/script/rspec_with_simplecov
+++ b/script/rspec_with_simplecov
@@ -28,9 +28,9 @@ begin
     require 'simplecov'
 
     SimpleCov.start do
-      add_filter "./bundle/"
-      add_filter "./tmp/"
-      add_filter "./spec/"
+      add_filter "bundle/"
+      add_filter "tmp/"
+      add_filter "spec/"
       minimum_coverage(100)
     end
   end

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Spec file load errors' do
   let(:failure_exit_code) { rand(97) + 2 } # 2..99
 
   if RSpec::Support::Ruby.jruby_9000?
-    let(:spec_line_suffix) { ":in `<top>'" }
+    let(:spec_line_suffix) { ":in `<main>'" }
   elsif RSpec::Support::Ruby.jruby?
     let(:spec_line_suffix) { ":in `(root)'" }
   elsif RUBY_VERSION == "1.8.7"

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -284,10 +284,6 @@ module RSpec::Core
 
     describe "#notify_non_example_exception" do
       it "sends a `message` notification that contains the formatted exception details" do
-        if RSpec::Support::Ruby.jruby_9000?
-          pending "RSpec gets `Unable to find matching line from backtrace` on JRuby 9000"
-        end
-
         formatter_out = StringIO.new
         formatter = Formatters::ProgressFormatter.new(formatter_out)
         reporter.register_listener formatter, :message


### PR DESCRIPTION
Simplecov 0.15.x allows regexps for filtering paths that seems to break our naively configured relative paths, unsure if we were correct beforehand but this change fixes the build.