### PR TITLE
Updating usage of Aruba.

### DIFF
--- a/features/command_line/only_failures.feature
+++ b/features/command_line/only_failures.feature
@@ -105,9 +105,9 @@ Feature: Only Failures
 
   Scenario: Running `rspec --only-failures` with spec files that pass doesn't run anything
     When I run `rspec spec/passing_spec.rb --only-failures`
-    Then it should pass with "0 examples, 0 failures"
+    Then it should pass with output "0 examples, 0 failures"
 
   Scenario: Clear error given when using `--only-failures` without configuring `example_status_persistence_file_path`
     Given I have not configured `example_status_persistence_file_path`
      When I run `rspec --only-failures`
-     Then it should fail with "To use `--only-failures`, you must first set `config.example_status_persistence_file_path`."
+     Then it should fail with output "To use `--only-failures`, you must first set `config.example_status_persistence_file_path`."

--- a/features/configuration/fail_if_no_examples.feature
+++ b/features/configuration/fail_if_no_examples.feature
@@ -24,8 +24,8 @@ Feature: fail if no examples
 
   Scenario: Examples file name is not matched by RSpec pattern, thus there are no examples run
     When I run `rspec`
-    Then it should fail with "0 examples, 0 failures"
+    Then it should fail with output "0 examples, 0 failures"
 
   Scenario: Examples file name is matched by RSpec pattern, 1 example is run
     When I run `rspec --pattern spec/**/*.spec.rb`
-    Then it should pass with "1 example, 0 failures"
+    Then it should pass with output "1 example, 0 failures"

--- a/features/filtering/filter_run_when_matching.feature
+++ b/features/filtering/filter_run_when_matching.feature
@@ -44,7 +44,7 @@ Feature: filter_run_when_matching
 
   Scenario: The filter is ignored when nothing is focused
     When I run `rspec --format doc`
-    Then it should pass with "2 examples, 0 failures"
+    Then it should pass with output "2 examples, 0 failures"
     And the output should contain:
       """
       A group
@@ -56,7 +56,7 @@ Feature: filter_run_when_matching
   Scenario: Examples can be focused with `fit`
     Given I have changed `it "has a passing example"` to `fit "has a passing example"` in "spec/example_spec.rb"
     When I run `rspec --format doc`
-    Then it should pass with "1 example, 0 failures"
+    Then it should pass with output "1 example, 0 failures"
     And the output should contain:
       """
       A group
@@ -66,7 +66,7 @@ Feature: filter_run_when_matching
   Scenario: Groups can be focused with `fdescribe` or `fcontext`
     Given I have changed `context` to `fcontext` in "spec/example_spec.rb"
     When I run `rspec --format doc`
-    Then it should pass with "1 example, 0 failures"
+    Then it should pass with output "1 example, 0 failures"
     And the output should contain:
       """
       A group

--- a/features/formatters/configurable_colors.feature
+++ b/features/formatters/configurable_colors.feature
@@ -12,7 +12,7 @@ Feature: Configurable colors
   Colors are specified as symbols. Options are `:black`, `:red`, `:green`,
   `:yellow`, `:blue`, `:magenta`, `:cyan`, and `:white`.
 
-  @ansi
+  @keep-ansi-escape-sequences
   Scenario: Customizing the failure color
     Given a file named "custom_failure_color_spec.rb" with:
       """ruby

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -4,19 +4,19 @@ require './spec/support/formatter_support'
 
 Then /^the output should contain all of these:$/ do |table|
   table.raw.flatten.each do |string|
-    assert_partial_output(string, all_output)
+    expect(all_commands.map { |c| c.output }.join("\n")).to include(string)
   end
 end
 
 Then /^the output should not contain any of these:$/ do |table|
   table.raw.flatten.each do |string|
-    expect(all_output).not_to include(string)
+    expect(all_commands.map { |c| c.output }.join("\n")).not_to include(string)
   end
 end
 
 Then /^the output should contain one of the following:$/ do |table|
   matching_output = table.raw.flatten.select do |string|
-    all_output.include?(string)
+    all_commands.map { |c| c.output }.join("\n").include?(string)
   end
 
   expect(matching_output.count).to eq(1)
@@ -28,7 +28,7 @@ Then /^the example(?:s)? should(?: all)? pass$/ do
   step %q{the exit status should be 0}
 end
 
-Then /^it should pass with "(.*?)"$/ do |string|
+Then /^it should pass with output "(.*?)"$/ do |string|
   step %Q{the output should contain "#{string}"}
   step %q{the exit status should be 0}
 end
@@ -37,7 +37,9 @@ Then /^the example(?:s)? should(?: all)? fail$/ do
   step %q{the output should not contain "0 examples"}
   step %q{the output should not contain "0 failures"}
   step %q{the exit status should be 1}
-  example_summary = /(\d+) examples?, (\d+) failures?/.match(all_output)
+  example_summary = /(\d+) examples?, (\d+) failures?/.match(
+    all_commands.map { |c| c.output }.join("\n")
+  )
   example_count, failure_count = example_summary.captures
   expect(failure_count).to eq(example_count)
 end
@@ -69,7 +71,7 @@ end
 Then /^the backtrace\-normalized output should contain:$/ do |partial_output|
   # ruby 1.9 includes additional stuff in the backtrace,
   # so we need to normalize it to compare it with our expected output.
-  normalized_output = all_output.split("\n").map do |line|
+  normalized_output = all_commands.map { |c| c.output }.map do |line|
     line =~ /(^\s+# [^:]+:\d+)/ ? $1 : line # http://rubular.com/r/zDD7DdWyzF
   end.join("\n")
 
@@ -84,7 +86,7 @@ end
 Then /^the failing example is printed in magenta$/ do
   # \e[35m = enable magenta
   # \e[0m  = reset colors
-  expect(all_output).to include("\e[35m" + "F" + "\e[0m")
+  expect(all_commands.map { |c| c.output }.join("\n")).to include("\e[35m" + "F" + "\e[0m")
 end
 
 Then /^the output from `([^`]+)` should contain "(.*?)"$/  do |cmd, expected_output|
@@ -98,24 +100,24 @@ Then /^the output from `([^`]+)` should not contain "(.*?)"$/  do |cmd, expected
 end
 
 Given /^I have a brand new project with no files$/ do
-  in_current_dir do
+  cd "." do
     expect(Dir["**/*"]).to eq([])
   end
 end
 
 Given /^I have run `([^`]*)`$/ do |cmd|
   fail_on_error = true
-  run_simple(unescape(cmd), fail_on_error)
+  run_simple(sanitize_text(cmd), fail_on_error)
 end
 
 Given(/^a vendored gem named "(.*?)" containing a file named "(.*?)" with:$/) do |gem_name, file_name, file_contents|
   gem_dir = "vendor/#{gem_name}-1.2.3"
   step %Q{a file named "#{gem_dir}/#{file_name}" with:}, file_contents
-  set_env('RUBYOPT', ENV['RUBYOPT'] + " -I#{gem_dir}/lib")
+  set_environment_variable('RUBYOPT', ENV['RUBYOPT'] + " -I#{gem_dir}/lib")
 end
 
 When "I accept the recommended settings by removing `=begin` and `=end` from `spec/spec_helper.rb`" do
-  in_current_dir do
+  cd "." do
     spec_helper = File.read("spec/spec_helper.rb")
     expect(spec_helper).to include("=begin", "=end")
 
@@ -138,7 +140,7 @@ Given(/^I have run `([^`]*)` once, resulting in "([^"]*)"$/) do |command, output
 end
 
 When(/^I fix "(.*?)" by replacing "(.*?)" with "(.*?)"$/) do |file_name, original, replacement|
-  in_current_dir do
+  cd "." do
     contents = File.read(file_name)
     expect(contents).to include(original)
     fixed = contents.sub(original, replacement)
@@ -146,12 +148,13 @@ When(/^I fix "(.*?)" by replacing "(.*?)" with "(.*?)"$/) do |file_name, origina
   end
 end
 
-Then(/^it should fail with "(.*?)"$/) do |snippet|
-  assert_failing_with(snippet)
+Then(/^it should fail with output "(.*?)"$/) do |snippet|
+  expect(all_commands).not_to include_an_object(be_successfully_executed)
+  expect(all_commands.map { |c| c.output }.join("\n")).to include(snippet)
 end
 
 Given(/^I have not configured `example_status_persistence_file_path`$/) do
-  in_current_dir do
+  cd "." do
     return unless File.exist?("spec/spec_helper.rb")
     return unless File.read("spec/spec_helper.rb").include?("example_status_persistence_file_path")
     File.open("spec/spec_helper.rb", "w") { |f| f.write("") }
@@ -173,10 +176,10 @@ Given(/^files "(.*?)" through "(.*?)" with an unrelated passing spec in each fil
 end
 
 Then(/^bisect should (succeed|fail) with output like:$/) do |succeed, expected_output|
-  last_process = only_processes.last
+  last_process = all_commands.last
   expected_status = succeed == "succeed" ? 0 : 1
-  expect(last_exit_status).to eq(expected_status),
-    "Expected exit status of #{expected_status} but got #{last_exit_status} \n\n" \
+  expect(last_process.exit_status).to eq(expected_status),
+    "Expected exit status of #{expected_status} but got #{last_process.exit_status} \n\n" \
     "Output:\n\n#{last_process.stdout}"
 
   expected = normalize_durations(expected_output)
@@ -186,18 +189,18 @@ Then(/^bisect should (succeed|fail) with output like:$/) do |succeed, expected_o
 end
 
 When(/^I run `([^`]+)` and abort in the middle with ctrl\-c$/) do |cmd|
-  set_env('RUBYOPT', ENV['RUBYOPT'] + " -r#{File.expand_path("../../support/send_sigint_during_bisect.rb", __FILE__)}")
+  set_environment_variable('RUBYOPT', ENV['RUBYOPT'] + " -r#{File.expand_path("../../support/send_sigint_during_bisect.rb", __FILE__)}")
   step "I run `#{cmd}`"
 end
 
 Then(/^it should fail and list all the failures:$/) do |string|
   step %q{the exit status should not be 0}
-  expect(normalize_failure_output(all_output)).to include(normalize_failure_output(string))
+  expect(normalize_failure_output(all_commands.map { |c| c.output }.join("\n"))).to include(normalize_failure_output(string))
 end
 
 Then(/^it should pass and list all the pending examples:$/) do |string|
   step %q{the exit status should be 0}
-  expect(normalize_failure_output(all_output)).to include(normalize_failure_output(string))
+  expect(normalize_failure_output(all_commands.map { |c| c.output }.join("\n"))).to include(normalize_failure_output(string))
 end
 
 Then(/^the output should report "slow before context hook" as the slowest example group$/) do
@@ -213,19 +216,21 @@ Then(/^the output should report "slow before context hook" as the slowest exampl
   # - "Nested" group listed (it should be the outer group)
   # - The example group class name is listed (it should be the location)
 
-  expect(all_output).not_to match(/nested/i)
-  expect(all_output).not_to match(/inf/i)
-  expect(all_output).not_to match(/\b0 examples/i)
+  output = all_commands.map { |c| c.output }.join("\n")
+
+  expect(output).not_to match(/nested/i)
+  expect(output).not_to match(/inf/i)
+  expect(output).not_to match(/\b0 examples/i)
 
   seconds = '\d+(?:\.\d+)? seconds'
 
-  expect(all_output).to match(
+  expect(output).to match(
     %r{Top 1 slowest example groups?:\n\s+slow before context hook\n\s+#{seconds} average \(#{seconds} / 1 example\) \./spec/example_spec\.rb:1}
   )
 end
 
 Given(/^I have changed `([^`]+)` to `([^`]+)` in "(.*?)"$/) do |old_code, new_code, file_name|
-  in_current_dir do
+  cd "." do
     file_content = File.read(file_name)
     expect(file_content).to include(old_code)
     new_file_content = file_content.sub(old_code, new_code)

--- a/features/step_definitions/core_standalone_steps.rb
+++ b/features/step_definitions/core_standalone_steps.rb
@@ -2,13 +2,13 @@ Given(/^only rspec-core is installed$/) do
   if RUBY_VERSION.to_f >= 1.9 # --disable-gems is invalid on 1.8.7
     # Ensure the gem versions of rspec-mocks and rspec-expectations
     # won't be loaded if available on the developers machine.
-    set_env('RUBYOPT', ENV['RUBYOPT'] + ' --disable-gems')
+    set_environment_variable('RUBYOPT', ENV['RUBYOPT'] + ' --disable-gems')
   end
 
   # This will make `require_expect_syntax_in_aruba_specs.rb` (loaded
   # automatically when the specs run) remove rspec-mocks and
   # rspec-expectations from the load path.
-  set_env('REMOVE_OTHER_RSPEC_LIBS_FROM_LOAD_PATH', 'true')
+  set_environment_variable('REMOVE_OTHER_RSPEC_LIBS_FROM_LOAD_PATH', 'true')
 end
 
 Given(/^rspec-expectations is not installed$/) do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,7 +2,7 @@ require 'aruba/cucumber'
 
 Before do
   # Force ids to be printed unquoted for consistency
-  set_env('SHELL', '/usr/bin/bash')
+  set_environment_variable('SHELL', '/usr/bin/bash')
 
   if RUBY_PLATFORM =~ /java/ || defined?(Rubinius)
     @aruba_timeout_seconds = 120
@@ -13,12 +13,12 @@ end
 
 Aruba.configure do |config|
   config.before_cmd do |cmd|
-    set_env('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
+    set_environment_variable('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
   end
 end if RUBY_PLATFORM == 'java'
 
 Aruba.configure do |config|
   config.before_cmd do |cmd|
-    set_env('RBXOPT', "-Xint=true #{ENV['RBXOPT']}") # disable JIT since these processes are so short lived
+    set_environment_variable('RBXOPT', "-Xint=true #{ENV['RBXOPT']}") # disable JIT since these processes are so short lived
   end
 end if defined?(Rubinius)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,13 +12,13 @@ Before do
 end
 
 Aruba.configure do |config|
-  config.before_cmd do |cmd|
+  config.before(:command) do |cmd|
     set_environment_variable('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
   end
 end if RUBY_PLATFORM == 'java'
 
 Aruba.configure do |config|
-  config.before_cmd do |cmd|
+  config.before(:command) do |cmd|
     set_environment_variable('RBXOPT', "-Xint=true #{ENV['RBXOPT']}") # disable JIT since these processes are so short lived
   end
 end if defined?(Rubinius)

--- a/features/support/require_expect_syntax_in_aruba_specs.rb
+++ b/features/support/require_expect_syntax_in_aruba_specs.rb
@@ -1,11 +1,11 @@
 if defined?(Cucumber)
   require 'shellwords'
   Before('~@allow-should-syntax', '~@with-clean-spec-opts') do
-    set_env('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
+    set_environment_variable('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
   end
 
   Before('@oneliner-should') do
-    set_env('ALLOW_ONELINER_SHOULD', 'true')
+    set_environment_variable('ALLOW_ONELINER_SHOULD', 'true')
   end
 else
   if ENV['REMOVE_OTHER_RSPEC_LIBS_FROM_LOAD_PATH']

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "cucumber", "~> 1.3"
   s.add_development_dependency "minitest", "~> 5.3"
-  s.add_development_dependency "aruba",    "~> 0.6.2" # 0.7 is broken on ruby 1.8.7
+  s.add_development_dependency "aruba",    "~> 0.14.2" # 0.7 is broken on ruby 1.8.7
 
   s.add_development_dependency "coderay",  "~> 1.1.1"
 

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "cucumber", "~> 1.3"
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.14.2" # 0.7 is broken on ruby 1.8.7
+  s.add_development_dependency "contracts", "< 0.16" # 0.16 does not work with Ruby 1.8.7
 
   s.add_development_dependency "coderay",  "~> 1.1.1"
 

--- a/spec/integration/fail_if_no_examples_spec.rb
+++ b/spec/integration/fail_if_no_examples_spec.rb
@@ -2,7 +2,7 @@ require 'support/aruba_support'
 
 RSpec.describe 'Fail if no examples' do
   include_context "aruba support"
-  before { clean_current_dir }
+  before { setup_aruba }
 
   context 'when 1 passing example' do
     def passing_example(fail_if_no_examples)

--- a/spec/integration/failed_line_detection_spec.rb
+++ b/spec/integration/failed_line_detection_spec.rb
@@ -2,7 +2,7 @@ require 'support/aruba_support'
 
 RSpec.describe 'Failed line detection' do
   include_context "aruba support"
-  before { clean_current_dir }
+  before { setup_aruba }
 
   it "finds the source of a failure in a spec file that is defined at the current directory instead of in the normal `spec` subdir" do
     write_file "the_spec.rb", "
@@ -32,7 +32,7 @@ RSpec.describe 'Failed line detection' do
       end
     "
 
-    file = in_current_dir { "#{Dir.pwd}/failing_spec.rb" }
+    file = cd(".") { "#{Dir.pwd}/failing_spec.rb" }
     load file
     run_command "passing_spec.rb"
 

--- a/spec/integration/filtering_spec.rb
+++ b/spec/integration/filtering_spec.rb
@@ -2,7 +2,7 @@ require 'support/aruba_support'
 
 RSpec.describe 'Filtering' do
   include_context "aruba support"
-  before { clean_current_dir }
+  before { setup_aruba }
 
   it 'prints a rerun command for shared examples in external files that works to rerun' do
     write_file "spec/support/shared_examples.rb", "
@@ -205,7 +205,7 @@ RSpec.describe 'Filtering' do
       expect(last_cmd_stdout).to match(/3 examples, 0 failures/)
 
       # Using absolute paths...
-      spec_root = in_current_dir { File.expand_path("spec") }
+      spec_root = cd(".") { File.expand_path("spec") }
       run_command "#{spec_root}/file_1_spec.rb[1:1,1:3] #{spec_root}/file_2_spec.rb[1:2]"
       expect(last_cmd_stdout).to match(/3 examples, 0 failures/)
     end

--- a/spec/integration/order_spec.rb
+++ b/spec/integration/order_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'command line', :ui do
   end
 
   describe '--order defined on CLI with --order rand in .rspec' do
-    after { remove_file '.rspec' }
+    after { remove '.rspec' }
 
     it "overrides --order rand with --order defined" do
       write_file '.rspec', '--order rand'
@@ -147,7 +147,7 @@ RSpec.describe 'command line', :ui do
   end
 
   context 'when a custom order is configured' do
-    after { remove_file 'spec/custom_order_spec.rb' }
+    after { remove 'spec/custom_order_spec.rb' }
 
     before do
       write_file 'spec/custom_order_spec.rb', "

--- a/spec/integration/output_stream_spec.rb
+++ b/spec/integration/output_stream_spec.rb
@@ -2,7 +2,7 @@ require 'support/aruba_support'
 
 RSpec.describe 'Output stream' do
   include_context 'aruba support'
-  before { clean_current_dir }
+  before { setup_aruba }
 
   context 'when a formatter set in a configure block' do
     it 'writes to the right output stream' do
@@ -21,7 +21,7 @@ RSpec.describe 'Output stream' do
 
       run_command ''
       expect(last_cmd_stdout).to be_empty
-      in_current_dir do
+      cd "." do
         expect(File.read('saved_output')).to include('1 example, 0 failures')
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe 'Output stream' do
 
       run_command ''
       expect(last_cmd_stdout).to be_empty
-      in_current_dir do
+      cd "." do
         expect(File.read('saved_output')).to include('1 example, 0 failures')
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe 'Output stream' do
 
       run_command ''
       expect(last_cmd_stdout).to be_empty
-      in_current_dir do
+      cd "." do
         expect(File.read('saved_output')).to include('1 example, 0 failures')
       end
     end

--- a/spec/integration/persistence_failures_spec.rb
+++ b/spec/integration/persistence_failures_spec.rb
@@ -2,7 +2,7 @@ require 'support/aruba_support'
 
 RSpec.describe 'Persistence failures' do
   include_context "aruba support"
-  before { clean_current_dir }
+  before { setup_aruba }
 
   context "when `config.example_status_persistence_file_path` is configured" do
     context "to an invalid file path (e.g. spec/spec_helper.rb/examples.txt)" do
@@ -38,7 +38,7 @@ RSpec.describe 'Persistence failures' do
         "
 
         write_file_formatted "spec/examples.txt", ""
-        in_current_dir do
+        cd "." do
           FileUtils.chmod 0000, "spec/examples.txt"
         end
       end

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -20,9 +20,11 @@ RSpec.describe 'Spec file load errors' do
   before do
     # get out of `aruba` sub-dir so that `filter_gems_from_backtrace 'aruba'`
     # below does not filter out our spec file.
-    expect(dirs.pop).to eq "aruba"
+    Aruba.configure do |config|
+      config.working_directory = "tmp"
+    end
 
-    clean_current_dir
+    setup_aruba
 
     RSpec.configure do |c|
       c.filter_gems_from_backtrace "aruba"

--- a/spec/integration/suite_hooks_errors_spec.rb
+++ b/spec/integration/suite_hooks_errors_spec.rb
@@ -20,9 +20,11 @@ RSpec.describe 'Suite hook errors' do
   before do
     # get out of `aruba` sub-dir so that `filter_gems_from_backtrace 'aruba'`
     # below does not filter out our spec file.
-    expect(dirs.pop).to eq "aruba"
+    Aruba.configure do |config|
+      config.working_directory = "tmp"
+    end
 
-    clean_current_dir
+    setup_aruba
 
     RSpec.configure do |c|
       c.filter_gems_from_backtrace "aruba"

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -23,7 +23,7 @@ RSpec.shared_context "aruba support" do
     cmd_parts = Shellwords.split(cmd)
 
     handle_current_dir_change do
-      in_current_dir do
+      cd "." do
         @last_cmd_exit_status = RSpec::Core::Runner.run(cmd_parts, temp_stderr, temp_stdout)
       end
     end


### PR DESCRIPTION
This gets both specs and features passing without deprecation warnings using Aruba 0.14.2, as discussed in #2437.

Two caveats:
* There is a 1.0.0 pre-release version of Aruba, but it requires Cucumber 2, and that’s a whole different can of worms to open.
* The gemspec notes that Aruba 0.7 is broken on MRI 1.8.7. I’m not sure if 0.14 is happier, but perhaps Travis will tell us. If it’s not, I guess this change can’t be merged in until RSpec 4 is on the cards?

Also: my focus here was on getting things working with no deprecation warnings and no failures. Feedback on preferred syntax/approaches is very much welcome :)