### PR TITLE
Keep rubocop comment directives out of Yardoc

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -413,6 +413,8 @@ module RSpec
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
+
+      # Build an object to store runtime configuration options and set defaults
       def initialize
         # rubocop:disable Style/GlobalVars
         @start_time = $_rspec_core_load_started_at || ::RSpec::Core::Time.now

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -3,6 +3,7 @@ RSpec::Support.require_rspec_support 'recursive_const_methods'
 module RSpec
   module Core
     # rubocop:disable Metrics/ClassLength
+
     # ExampleGroup and {Example} are the main structural elements of
     # rspec-core. Consider this example:
     #

--- a/lib/rspec/core/formatters/html_snippet_extractor.rb
+++ b/lib/rspec/core/formatters/html_snippet_extractor.rb
@@ -21,7 +21,9 @@ module RSpec
         end
 
         # rubocop:disable Style/ClassVars
+        # @private
         @@converter = NullConverter
+
         begin
           require 'coderay'
           RSpec::Support.require_rspec_core 'formatters/syntax_highlighter'


### PR DESCRIPTION
This is in response to https://github.com/rspec/rspec-core/issues/2440

It looks like yard was taking some of the rubocop comments and putting them in the documentation. There isn't a straightforward way to really ignore this, but with a few tricks I was able to get all the instances I could find (using grep across the doc directory) resolved. There are still two others in the html source, which are in the source of a method and therefore belong there IMHO.