### PR TITLE
[docs] Use YARD deprecated to annotate treat_symbols_as_metadata_keys_with_true_values=

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -321,9 +321,9 @@ module RSpec
       # (default `false`).
       add_setting :silence_filter_announcements
 
-      # Deprecated. This config option was added in RSpec 2 to pave the way
-      # for this being the default behavior in RSpec 3. Now this option is
-      # a no-op.
+      # @deprecated This config option was added in RSpec 2 to pave the way
+      #   for this being the default behavior in RSpec 3. Now this option is
+      #   a no-op.
       def treat_symbols_as_metadata_keys_with_true_values=(_value)
         RSpec.deprecate(
           "RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=",


### PR DESCRIPTION
This PR uses the YARD tag `@deprecated` in one more place.

## Screenshots

This screenshot shows what the **_Methods_ search suggestions** renders it as, and what the description of the method looks like.

![screenshot 2017-10-31 06 10 25](https://user-images.githubusercontent.com/211/32208346-4097fb6e-be02-11e7-9ea8-67c64ba117dd.png)

This is what it looks like in the **instance method summary** (at the beginning of this page):

![screenshot 2017-10-31 06 12 16](https://user-images.githubusercontent.com/211/32208385-83cfb5fc-be02-11e7-8197-661e03d804cb.png)

(The `filter_run_when_matching` in the description is a hyperlink.)

