### PR TITLE
Allow Pathname arguments to be escaped

### DIFF
--- a/lib/rspec/core/shell_escape.rb
+++ b/lib/rspec/core/shell_escape.rb
@@ -6,7 +6,7 @@ module RSpec
       module_function
 
       def quote(argument)
-        "'#{argument.gsub("'", "\\\\'")}'"
+        "'#{argument.to_s.gsub("'", "\\\\'")}'"
       end
 
       if RSpec::Support::OS.windows?
@@ -17,7 +17,7 @@ module RSpec
         require 'shellwords'
 
         def escape(shell_command)
-          shell_command.shellescape
+          Shellwords.escape(shell_command.to_s)
         end
       end
 

--- a/spec/rspec/core/bisect/runner_spec.rb
+++ b/spec/rspec/core/bisect/runner_spec.rb
@@ -148,6 +148,15 @@ module RSpec::Core
           expect(cmd).to first_include('-Il\ p/foo:l\ p/bar').then_include(RSpec::Core.path_to_executable)
         end
       end
+
+      it 'supports Pathnames in the load path' do
+        cmd = command_for([], :load_path => [Pathname('l p/foo'), Pathname('l p/bar') ])
+        if uses_quoting_for_escaping?
+          expect(cmd).to first_include("-I'l p/foo':'l p/bar'").then_include(RSpec::Core.path_to_executable)
+        else
+          expect(cmd).to first_include('-Il\ p/foo:l\ p/bar').then_include(RSpec::Core.path_to_executable)
+        end
+      end
     end
 
     describe "#repro_command_from", :simulate_shell_allowing_unquoted_ids do


### PR DESCRIPTION
An error is raised by using a Rails project that is configured with:

```
config.autoload_paths << config.root.join('app/decorators')
```

And then running `rspec bisect`:

```
Running suite to find failures...
/usr/local/bundle/gems/rspec-core-3.7.0/lib/rspec/core/shell_escape.rb:20:in `escape':
  undefined method `shellescape' for #<Pathname:/app/app/decorators> (NoMethodError)
```