### PR TITLE
Add basic report template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We welcome contributions from *everyone*. While contributing, please follow the 
 If you'd like to help make RSpec better, here are some ways you can contribute:
 
   - by running RSpec HEAD to help us catch bugs before new releases
-  - by [reporting bugs you encounter](https://github.com/rspec/rspec-core/issues/new)
+  - by [reporting bugs you encounter](https://github.com/rspec/rspec-core/issues/new) with [report template](#report-template)
   - by [suggesting new features](https://github.com/rspec/rspec-core/issues/new)
   - by improving RSpec's [Relish](https://relishapp.com/rspec) or [API](http://rspec.info/documentation/) documentation
   - by improving [RSpec's website](http://rspec.info/) ([source](https://github.com/rspec/rspec.github.io))
@@ -29,6 +29,46 @@ Thanks for helping us make RSpec better!
 These issue are ones that we be believe are best suited for new contributors to
 get started with. They represent a meaningful contribution to the project that
 should not be too hard to pull off.
+
+## Report template
+
+Having a way to reproduce your issue will be very helpful for others to help confirm, investigate and ultimately fix your issue. You can do this by providing an executable test case. To make this process easier, we have prepared one basic bug report templates for you to use as a starting point:
+
+```ruby
+# frozen_string_literal: true
+
+begin
+  require "bundler/inline"
+rescue LoadError => e
+  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
+  raise e
+end
+
+gemfile(true) do
+  source "https://rubygems.org"
+
+  gem 'aruba' # Needed to execute RSpec from Ruby code
+  gem "rspec", "3.7.0" # Activate the gem and version you are reporting the issue against.
+end
+
+puts "Ruby version is: #{RUBY_VERSION}"
+
+describe 'additions' do
+  it 'returns 2' do
+    expect(1 + 1).to eq(2)
+  end
+
+  it 'returns 1' do
+    expect(3 - 1).to eq(-1)
+  end
+end
+
+RSpec::Core::Runner.invoke
+```
+
+Simply copy the content of the appropriate template into a `.rb` file on your computer and make the necessary changes to demonstrate the issue. You can execute it by running `ruby the_file.rb` in your terminal.
+
+You can then share your executable test case as a [gist](https://gist.github.com), or simply paste the content into the issue description.
 
 ## Maintenance branches
 


### PR DESCRIPTION
Hello

After watching the [last talk of Sam at RailsConf](https://youtu.be/VMcMqrpjAjU). [I was wondering](https://github.com/rails/rails/pull/19818) about bug report template [like in Rails](https://github.com/rails/rails/pull/19818) for RSpec.

I faced two issues

1) I was not able to write a script without `aruba` gem. I'm surprised because I read other gist without seing this.

```ruby
# frozen_string_literal: true

begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  gem "rspec", "3.7.0" # Activate the gem and version you are reporting the issue against.
end

puts "Ruby version is: #{RUBY_VERSION}"

describe 'additions' do
  it 'returns 2' do
    expect(1 + 1).to eq(2)
  end

  it 'returns 1' do
    expect(3 - 1).to eq(-1)
  end
end

RSpec::Core::Runner.invoke
```
Result:
```
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Using bundler 1.16.0
Using diff-lcs 1.3
Using rspec-support 3.7.0
Using rspec-core 3.7.0
Using rspec-expectations 3.7.0
Using rspec-mocks 3.7.0
Using rspec 3.7.0
Ruby version is: 2.4.1
/Users/bti/code/rspec-core/spec/support/aruba_support.rb:4:in `require': cannot load such file -- aruba/api (LoadError)
	from /Users/bti/code/rspec-core/spec/support/aruba_support.rb:4:in `block in <module:ArubaLoader>'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-support-3.7.0/lib/rspec/support/spec/with_isolated_stderr.rb:7:in `with_isolated_stderr'
	from /Users/bti/code/rspec-core/spec/support/aruba_support.rb:3:in `<module:ArubaLoader>'
	from /Users/bti/code/rspec-core/spec/support/aruba_support.rb:1:in `<top (required)>'
	from /Users/bti/code/rspec-core/spec/spec_helper.rb:24:in `require'
	from /Users/bti/code/rspec-core/spec/spec_helper.rb:24:in `block in <top (required)>'
	from /Users/bti/code/rspec-core/spec/spec_helper.rb:17:in `map'
	from /Users/bti/code/rspec-core/spec/spec_helper.rb:17:in `<top (required)>'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `require'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `block in requires='
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `each'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `requires='
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:112:in `block in process_options_into'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:111:in `each'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:111:in `process_options_into'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:21:in `configure'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:99:in `setup'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:86:in `run'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:71:in `run'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:45:in `invoke'
	from report_template.rb:28:in `<main>'
```

2) At the beginning I wanted to add a report template for each RSpec gem (core, mock, expectations...). But maybe I'm too junior and I failed:

```ruby
# frozen_string_literal: true

begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  gem 'aruba' # Needed to execute rspec from Ruby code
  gem "rspec-core", "3.7.0" # Activate the gem and version you are reporting the issue against.
end

puts "Ruby version is: #{RUBY_VERSION}"

describe 'additions' do
  it 'returns 2' do
    expect(1 + 1).to eq(2)
  end

  it 'returns 1' do
    expect(3 - 1).to eq(-1)
  end
end

RSpec::Core::Runner.invoke
```

```
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Using ffi 1.9.18
Using childprocess 0.5.9
Using contracts 0.16.0
Using builder 3.2.3
Using backports 3.10.3
Using cucumber-tag_expressions 1.1.1
Using gherkin 5.0.0
Using cucumber-core 3.1.0
Using cucumber-expressions 5.0.7
Using cucumber-wire 0.0.1
Using diff-lcs 1.3
Using multi_json 1.12.2
Using multi_test 0.1.2
Using cucumber 3.1.0
Using rspec-support 3.7.0
Using rspec-expectations 3.7.0
Using thor 0.20.0
Using aruba 0.14.2
Using bundler 1.16.0
Using rspec-core 3.7.0
Ruby version is: 2.4.1
/Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/mocking_adapters/rspec.rb:1:in `require': cannot load such file -- rspec/mocks (LoadError)
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/mocking_adapters/rspec.rb:1:in `<top (required)>'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core.rb:8:in `require_relative'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core.rb:8:in `block in <top (required)>'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-support-3.7.0/lib/rspec/support.rb:19:in `block in define_optimized_require_for_rspec'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:678:in `mock_with'
	from /Users/bti/code/rspec-core/spec/spec_helper.rb:91:in `block in <top (required)>'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core.rb:98:in `configure'
	from /Users/bti/code/rspec-core/spec/spec_helper.rb:71:in `<top (required)>'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `require'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `block in requires='
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `each'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration.rb:1455:in `requires='
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:112:in `block in process_options_into'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:111:in `each'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:111:in `process_options_into'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/configuration_options.rb:21:in `configure'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:99:in `setup'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:86:in `run'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:71:in `run'
	from /Users/bti/.rvm/gems/ruby-2.4.1@app/gems/rspec-core-3.7.0/lib/rspec/core/runner.rb:45:in `invoke'
	from report_template.rb:34:in `<main>'
```

Thanks in advance for your help.