### PR TITLE
Add let! alias method 'make'.

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -357,6 +357,8 @@ EOS
           before { __send__(name) }
         end
 
+        alias_method :make, :let!
+
         # Declares a `subject` for an example group which can then be wrapped
         # with `expect` using `is_expected` to make it the target of an
         # expectation in a concise, one-line example.

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -588,16 +588,18 @@ module RSpec::Core
     end
   end
 
-  RSpec.describe "#let!" do
-    subject { [1,2,3] }
-    let!(:popped) { subject.pop }
+  [:let!, :make].each do |registration_method|
+    RSpec.describe "##{registration_method}" do
+      subject { [1,2,3] }
+      send(registration_method, :popped) { subject.pop }
 
-    it "evaluates the value non-lazily" do
-      expect(subject).to eq([1,2])
-    end
+      it "evaluates the value non-lazily" do
+        expect(subject).to eq([1,2])
+      end
 
-    it "returns memoized value from first invocation" do
-      expect(popped).to eq(3)
+      it "returns memoized value from first invocation" do
+        expect(popped).to eq(3)
+      end
     end
   end
 


### PR DESCRIPTION
RSpec's `let` and `let!` is a bit confusing when you writing specs which need to have some let and let! together.

For example, 
```
let!(:test1) { create(:sample, name: 'test1') }
let(:test2) { create(:sample, name: 'test2') } 
let(:test3) { create(:sample, name: 'test3') } 
```

This code create test1 before spec run but create test2 and test3 when spec call them.
This cause us confused. So, we sometimes make rules like 'Cannot use let!, use before if you need`.

So, I make a alias method of let!. Then it will be like this.

```
make(:test1) { create(:sample, name: 'test1') }
let(:test2) { create(:sample, name: 'test2') } 
let(:test3) { create(:sample, name: 'test3') } 
```

This code is easy to understand its behavior.
