### PR TITLE
Allow at_exit handlers to run when aborting runs

### DIFF
--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -182,7 +182,7 @@ module RSpec
       # @private
       def self.handle_interrupt
         if RSpec.world.wants_to_quit
-          exit!(1)
+          exit(1)
         else
           RSpec.world.wants_to_quit = true
           $stderr.puts "\nRSpec is shutting down and will print the summary report... Interrupt again to force quit."

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -93,7 +93,7 @@ module RSpec::Core
     end
 
     describe "interrupt handling" do
-      before { allow(Runner).to receive(:exit!) }
+      before { allow(Runner).to receive(:exit) }
 
       it 'prints a message the first time, then exits the second time' do
         expect {
@@ -101,13 +101,13 @@ module RSpec::Core
         }.to output(/shutting down/).to_stderr_from_any_process &
           change { RSpec.world.wants_to_quit }.from(a_falsey_value).to(true)
 
-        expect(Runner).not_to have_received(:exit!)
+        expect(Runner).not_to have_received(:exit)
 
         expect {
           Runner.handle_interrupt
         }.not_to output.to_stderr_from_any_process
 
-        expect(Runner).to have_received(:exit!)
+        expect(Runner).to have_received(:exit)
       end
     end
 
@@ -149,7 +149,7 @@ module RSpec::Core
       context "with SIGINT twice" do
         it "exits immediately" do
           Runner.send(:trap_interrupt)
-          expect(Runner).to receive(:exit!).with(1)
+          expect(Runner).to receive(:exit).with(1)
           expect { interrupt }.to output(//).to_stderr
           interrupt
         end


### PR DESCRIPTION
At the moment, if you hit Ctrl-C twice to abort a run, rspec uses `exit!` to exit, so `at_exit` handlers aren't run.  This means, for example, that Capybara doesn't send a quit message to its browser, so I often end up with dead Google Chrome processes lying around.

I'm not sure what the rational was for choosing `exit!` vs `exit` (/cc @dchelimsky ?), so I'm not 100% convinced this PR is correct/desired behaviour.  Would welcome any thoughts on it.