### PR TITLE
Ruby 2.5 fixes

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1808,6 +1808,12 @@ module RSpec
         handle_suite_hook(scope, meta) do
           @before_suite_hooks << Hooks::BeforeHook.new(block, {})
         end || begin
+          # defeat Ruby 2.5 lazy proc allocation to ensure
+          # the methods below are passed the same proc instances
+          # so `Hook` equality is preserved. For more info, see:
+          # https://bugs.ruby-lang.org/issues/14045#note-5
+          block.__id__
+
           add_hook_to_existing_matching_groups(meta, scope) { |g| g.before(scope, *meta, &block) }
           super(scope, *meta, &block)
         end
@@ -1831,6 +1837,12 @@ module RSpec
         handle_suite_hook(scope, meta) do
           @before_suite_hooks.unshift Hooks::BeforeHook.new(block, {})
         end || begin
+          # defeat Ruby 2.5 lazy proc allocation to ensure
+          # the methods below are passed the same proc instances
+          # so `Hook` equality is preserved. For more info, see:
+          # https://bugs.ruby-lang.org/issues/14045#note-5
+          block.__id__
+
           add_hook_to_existing_matching_groups(meta, scope) { |g| g.prepend_before(scope, *meta, &block) }
           super(scope, *meta, &block)
         end
@@ -1849,6 +1861,12 @@ module RSpec
         handle_suite_hook(scope, meta) do
           @after_suite_hooks.unshift Hooks::AfterHook.new(block, {})
         end || begin
+          # defeat Ruby 2.5 lazy proc allocation to ensure
+          # the methods below are passed the same proc instances
+          # so `Hook` equality is preserved. For more info, see:
+          # https://bugs.ruby-lang.org/issues/14045#note-5
+          block.__id__
+
           add_hook_to_existing_matching_groups(meta, scope) { |g| g.after(scope, *meta, &block) }
           super(scope, *meta, &block)
         end
@@ -1872,6 +1890,12 @@ module RSpec
         handle_suite_hook(scope, meta) do
           @after_suite_hooks << Hooks::AfterHook.new(block, {})
         end || begin
+          # defeat Ruby 2.5 lazy proc allocation to ensure
+          # the methods below are passed the same proc instances
+          # so `Hook` equality is preserved. For more info, see:
+          # https://bugs.ruby-lang.org/issues/14045#note-5
+          block.__id__
+
           add_hook_to_existing_matching_groups(meta, scope) { |g| g.append_after(scope, *meta, &block) }
           super(scope, *meta, &block)
         end
@@ -1881,6 +1905,12 @@ module RSpec
       #
       # See {Hooks#around} for full `around` hook docs.
       def around(scope=nil, *meta, &block)
+        # defeat Ruby 2.5 lazy proc allocation to ensure
+        # the methods below are passed the same proc instances
+        # so `Hook` equality is preserved. For more info, see:
+        # https://bugs.ruby-lang.org/issues/14045#note-5
+        block.__id__
+
         add_hook_to_existing_matching_groups(meta, scope) { |g| g.around(scope, *meta, &block) }
         super(scope, *meta, &block)
       end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -503,7 +503,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       end
     end
 
-    it "leaves raised exceptions unmodified (GH-1103)" do
+    it "leaves raised exceptions unmodified (GH-1103)", :if => RUBY_VERSION < '2.5' do
       # set the backtrace, otherwise MRI will build a whole new object,
       # and thus mess with our expectations. Rubinius and JRuby are not
       # affected.

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -631,7 +631,7 @@ module RSpec::Core
   end
 
   RSpec.describe 'Module#define_method' do
-    it 'is still a private method' do
+    it 'retains its normal private visibility on Ruby versions where it is normally private', :if => RUBY_VERSION < '2.5' do
       a_module = Module.new
       expect { a_module.define_method(:name) { "implementation" } }.to raise_error NoMethodError
     end

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -730,10 +730,9 @@ module RSpec
           end
 
           it 'can access the parent example group attributes via [:example_group][:example_group]' do
-            parent = child = nil
+            child = nil
             parent_line = __LINE__ + 1
             RSpec.describe(Object, "group", :foo => 3) do
-              parent = metadata
               describe("nested") { child = metadata }
             end
 

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe RSpec do
     it 'clears the deprecation buffer' do
       RSpec.configuration.deprecation_stream = StringIO.new
 
-      group = RSpec.describe do
+      RSpec.describe do
         example { RSpec.deprecate("first deprecation") }
       end.run
 
@@ -258,7 +258,7 @@ RSpec.describe RSpec do
 
       RSpec.configuration.deprecation_stream = StringIO.new(deprecations = "".dup)
 
-      group = RSpec.describe do
+      RSpec.describe do
         example { RSpec.deprecate("second deprecation") }
       end.run
 


### PR DESCRIPTION
This should get our test suite to green on Ruby 2.5.  Note that https://bugs.ruby-lang.org/issues/14045 introduces a regression in RSpec (see my comment on note #5) so we'll probably need to backport this to the 3-7-maintenance branch and cut a release.

