### PR TITLE
$SAFE became a global variable in Ruby 2.6

### DIFF
--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -1,5 +1,6 @@
 module RSpecHelpers
   SAFE_LEVEL_THAT_TRIGGERS_SECURITY_ERRORS = RUBY_VERSION >= '2.3' ? 1 : 3
+  SAFE_IS_GLOBAL_VARIABLE = RUBY_VERSION >= '2.6'
 
   def relative_path(path)
     RSpec::Core::Metadata.relative_path(path)
@@ -16,17 +17,21 @@ module RSpecHelpers
   def with_safe_set_to_level_that_triggers_security_errors
     result = nil
 
+    orig_safe = $SAFE
     Thread.new do
       ignoring_warnings { $SAFE = SAFE_LEVEL_THAT_TRIGGERS_SECURITY_ERRORS }
       result = yield
     end.join
 
     # $SAFE is not supported on Rubinius
-    unless defined?(Rubinius)
-      expect($SAFE).to eql 0 # $SAFE should not have changed in this thread.
+    # In Ruby 2.6, $SAFE became a global variable; previously it was local to a thread.
+    unless defined?(Rubinius) || SAFE_IS_GLOBAL_VARIABLE
+      # $SAFE should not have changed in this thread.
+      expect($SAFE).to eql orig_safe
     end
 
     result
+  ensure
+    $SAFE = orig_safe if orig_safe && SAFE_IS_GLOBAL_VARIABLE
   end
-
 end


### PR DESCRIPTION
Hi there, I'm @sorah from Ruby core team.

Recently we've changed `$SAFE` into a global variable (which was previously local to a thread) at our head (trunk, 2.6.0dev).

* r61510, ruby/ruby@e7c1cbe0d3cdfafddead824c30e5fa0ba72999c1
* https://bugs.ruby-lang.org/issues/14250

Looks like rspec-core test suite expecting `$SAFE` to be a thread local variable in MRI. This patch expects a global variable on Ruby 2.6 or higher.

----

P.S. Some tests still may fail. Looks like the current trunk is unintentionally broken, so I'm investigating why, and hit this error to run this test suite on the trunk.