### PR TITLE
Avoid using `RSpec.configuration` from the bisect coordinator.

### DIFF
--- a/lib/rspec/core/bisect/example_minimizer.rb
+++ b/lib/rspec/core/bisect/example_minimizer.rb
@@ -7,13 +7,13 @@ module RSpec
       # Contains the core bisect logic. Searches for examples we can ignore by
       # repeatedly running different subsets of the suite.
       class ExampleMinimizer
-        attr_reader :shell_command, :runner, :reporter, :all_example_ids, :failed_example_ids
+        attr_reader :shell_command, :runner, :all_example_ids, :failed_example_ids
         attr_accessor :remaining_ids
 
-        def initialize(shell_command, runner, reporter)
+        def initialize(shell_command, runner, notifier)
           @shell_command = shell_command
           @runner        = runner
-          @reporter      = reporter
+          @notifier      = notifier
         end
 
         def find_minimal_repro
@@ -164,7 +164,7 @@ module RSpec
         end
 
         def notify(*args)
-          reporter.publish(*args)
+          @notifier.publish(*args)
         end
       end
     end

--- a/lib/rspec/core/bisect/utilities.rb
+++ b/lib/rspec/core/bisect/utilities.rb
@@ -11,6 +11,22 @@ module RSpec
               spec_output)
         end
       end
+
+      # Wraps a `formatter` providing a simple means to notify it in place
+      # of an `RSpec::Core::Reporter`, without involving configuration in
+      # any way.
+      # @private
+      class Notifier
+        def initialize(formatter)
+          @formatter = formatter
+        end
+
+        def publish(event, *args)
+          return unless @formatter.respond_to?(event)
+          notification = Notifications::CustomNotification.for(*args)
+          @formatter.__send__(event, notification)
+        end
+      end
     end
   end
 end

--- a/lib/rspec/core/formatters/bisect_progress_formatter.rb
+++ b/lib/rspec/core/formatters/bisect_progress_formatter.rb
@@ -6,15 +6,6 @@ module RSpec
       # @private
       # Produces progress output while bisecting.
       class BisectProgressFormatter < BaseTextFormatter
-        # We've named all events with a `bisect_` prefix to prevent naming collisions.
-        Formatters.register self, :bisect_starting, :bisect_original_run_complete,
-                            :bisect_round_started, :bisect_individual_run_complete,
-                            :bisect_complete, :bisect_repro_command,
-                            :bisect_failed, :bisect_aborted,
-                            :bisect_round_ignoring_ids, :bisect_round_detected_multiple_culprits,
-                            :bisect_dependency_check_started, :bisect_dependency_check_passed,
-                            :bisect_dependency_check_failed
-
         def bisect_starting(notification)
           @round_count = 0
           options = notification.original_cli_args.join(' ')
@@ -88,13 +79,10 @@ module RSpec
       end
 
       # @private
-      # Produces detailed debug output while bisecting. Used when
-      # bisect is performed while the `DEBUG_RSPEC_BISECT` ENV var is used.
-      # Designed to provide details for us when we need to troubleshoot bisect bugs.
+      # Produces detailed debug output while bisecting. Used when bisect is
+      # performed with `--bisect=verbose`. Designed to provide details for
+      # us when we need to troubleshoot bisect bugs.
       class BisectDebugFormatter < BisectProgressFormatter
-        Formatters.register self, :bisect_original_run_complete, :bisect_individual_run_start,
-                            :bisect_individual_run_complete, :bisect_round_ignoring_ids
-
         def bisect_original_run_complete(notification)
           output.puts " (#{Helpers.format_duration(notification.duration)})"
 

--- a/lib/rspec/core/invocations.rb
+++ b/lib/rspec/core/invocations.rb
@@ -31,7 +31,6 @@ module RSpec
 
           success = RSpec::Core::Bisect::Coordinator.bisect_with(
             options.args,
-            RSpec.configuration,
             bisect_formatter_for(options.options[:bisect])
           )
 
@@ -41,8 +40,13 @@ module RSpec
         private
 
         def bisect_formatter_for(argument)
-          return Formatters::BisectDebugFormatter if argument == "verbose"
-          Formatters::BisectProgressFormatter
+          klass = if argument == "verbose"
+                    Formatters::BisectDebugFormatter
+                  else
+                    Formatters::BisectProgressFormatter
+                  end
+
+          klass.new(RSpec.configuration.output_stream)
         end
       end
 

--- a/spec/rspec/core/bisect/coordinator_spec.rb
+++ b/spec/rspec/core/bisect/coordinator_spec.rb
@@ -18,8 +18,7 @@ module RSpec::Core
       allow(Bisect::Server).to receive(:run).and_yield(instance_double(Bisect::Server))
       allow(Bisect::ShellRunner).to receive(:new).and_return(fake_runner)
 
-      RSpec.configuration.output_stream = output
-      Bisect::Coordinator.bisect_with([], RSpec.configuration, formatter)
+      Bisect::Coordinator.bisect_with([], formatter.new(output))
     ensure
       RSpec.reset # so that RSpec.configuration.output_stream isn't closed
     end

--- a/spec/rspec/core/bisect/utilities_spec.rb
+++ b/spec/rspec/core/bisect/utilities_spec.rb
@@ -1,0 +1,26 @@
+require 'rspec/core/bisect/utilities'
+
+module RSpec::Core
+  RSpec.describe Bisect::Notifier do
+    class ExampleFormatterClass
+      def foo(notification); end
+    end
+
+    let(:formatter) { instance_spy(ExampleFormatterClass) }
+    let(:notifier) { Bisect::Notifier.new(formatter) }
+
+    it 'publishes events to the wrapped formatter' do
+      notifier.publish :foo, :length => 15, :width => 12
+
+      expect(formatter).to have_received(:foo).with(an_object_having_attributes(
+        :length => 15, :width => 12
+      ))
+    end
+
+    it 'does not publish events the formatter does not recognize' do
+      expect {
+        notifier.publish :unrecognized_event, :length => 15, :width => 12
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/rspec/core/invocations_spec.rb
+++ b/spec/rspec/core/invocations_spec.rb
@@ -92,8 +92,7 @@ module RSpec::Core
 
         expect(RSpec::Core::Bisect::Coordinator).to have_received(:bisect_with).with(
           args,
-          RSpec.configuration,
-          Formatters::BisectProgressFormatter
+          an_instance_of(Formatters::BisectProgressFormatter)
         )
       end
 
@@ -123,8 +122,7 @@ module RSpec::Core
 
           expect(RSpec::Core::Bisect::Coordinator).to have_received(:bisect_with).with(
             args,
-            RSpec.configuration,
-            Formatters::BisectDebugFormatter
+            an_instance_of(Formatters::BisectDebugFormatter)
           )
         end
       end


### PR DESCRIPTION
Use a simple `Notifier` instead of the full-fledged `Reporter`
(which required the use of config). Avoiding config is necessary
for us to be able to use the new forking runner for bisect.

This builds on top #2504.