### PR TITLE
Improve performance of bisect using new forking bisect runner

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,14 @@ Enhancements:
   that it works on `Pathname` objects. (Andrew Vit, #2479)
 * Nicely format errors encountered while loading files specified
   by `--require` option.  (Myron Marston, #2504)
+* Significantly improve the performance of `--bisect` on platforms that
+  support forking by replacing the shell-based runner with one that uses
+  forking so that RSpec and the application environment can be booted only
+  once, instead of once per spec run. (Myron Marston, #2511)
+* Provide a configuration API to pick which bisect runner is used for
+  `--bisect`. Pick a runner via `config.bisect_runner = :shell` or
+  `config.bisect_runner = :fork` in a file loaded by a `--require`
+  option passed at the command line or set in `.rspec`. (Myron Marston, #2511)
 
 ### 3.7.1 / 2018-01-02
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.7.0...v3.7.1)

--- a/features/command_line/bisect.feature
+++ b/features/command_line/bisect.feature
@@ -94,7 +94,7 @@ Feature: Bisect
     When I run `rspec --seed 1234 --bisect=verbose`
     Then bisect should succeed with output like:
       """
-      Bisect started using options: "--seed 1234"
+      Bisect started using options: "--seed 1234" and bisect runner: RSpec::Core::Bisect::ForkRunner
       Running suite to find failures... (0.16528 seconds)
        - Failing examples (1):
           - ./spec/calculator_1_spec.rb[1:1]
@@ -156,3 +156,23 @@ Feature: Bisect
       """
     When I run `rspec ./spec/calculator_10_spec.rb[1:1] ./spec/calculator_1_spec.rb[1:1] --seed 1234`
     Then the output should contain "2 examples, 1 failure"
+
+  Scenario: Pick a bisect runner via a config option
+    Given a file named "spec/spec_helper.rb" with:
+      """
+      RSpec.configure do |c|
+        c.bisect_runner = :shell
+      end
+      """
+    And a file named ".rspec" with:
+      """
+      --require spec_helper
+      """
+    When I run `rspec --seed 1234 --bisect=verbose`
+    Then bisect should succeed with output like:
+      """
+      Bisect started using options: "--seed 1234" and bisect runner: RSpec::Core::Bisect::ShellRunner
+      # ...
+      The minimal reproduction command is:
+        rspec ./spec/calculator_10_spec.rb[1:1] ./spec/calculator_1_spec.rb[1:1] --seed 1234
+      """

--- a/features/command_line/bisect.feature
+++ b/features/command_line/bisect.feature
@@ -94,7 +94,7 @@ Feature: Bisect
     When I run `rspec --seed 1234 --bisect=verbose`
     Then bisect should succeed with output like:
       """
-      Bisect started using options: "--seed 1234" and bisect runner: RSpec::Core::Bisect::ForkRunner
+      Bisect started using options: "--seed 1234" and bisect runner: :fork
       Running suite to find failures... (0.16528 seconds)
        - Failing examples (1):
           - ./spec/calculator_1_spec.rb[1:1]
@@ -171,7 +171,7 @@ Feature: Bisect
     When I run `rspec --seed 1234 --bisect=verbose`
     Then bisect should succeed with output like:
       """
-      Bisect started using options: "--seed 1234" and bisect runner: RSpec::Core::Bisect::ShellRunner
+      Bisect started using options: "--seed 1234" and bisect runner: :shell
       # ...
       The minimal reproduction command is:
         rspec ./spec/calculator_10_spec.rb[1:1] ./spec/calculator_1_spec.rb[1:1] --seed 1234

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -180,9 +180,14 @@ Then(/^bisect should (succeed|fail) with output like:$/) do |succeed, expected_o
     "Output:\n\n#{last_process.stdout}"
 
   expected = normalize_durations(expected_output)
-  actual   = normalize_durations(last_process.stdout)
+  actual   = normalize_durations(last_process.stdout).sub(/\n+\Z/, '')
 
-  expect(actual.sub(/\n+\Z/, '')).to eq(expected)
+  if expected.include?("# ...")
+    expected_start, expected_end = expected.split("# ...")
+    expect(actual).to start_with(expected_start).and end_with(expected_end)
+  else
+    expect(actual).to eq(expected)
+  end
 end
 
 When(/^I run `([^`]+)` and abort in the middle with ctrl\-c$/) do |cmd|

--- a/lib/rspec/core/bisect/example_minimizer.rb
+++ b/lib/rspec/core/bisect/example_minimizer.rb
@@ -111,7 +111,8 @@ module RSpec
         end
 
         def prep
-          notify(:bisect_starting, :original_cli_args => shell_command.original_cli_args)
+          notify(:bisect_starting, :original_cli_args => shell_command.original_cli_args,
+                                   :bisect_runner => runner.class)
 
           _, duration = track_duration do
             original_results    = runner.original_results

--- a/lib/rspec/core/bisect/example_minimizer.rb
+++ b/lib/rspec/core/bisect/example_minimizer.rb
@@ -112,7 +112,7 @@ module RSpec
 
         def prep
           notify(:bisect_starting, :original_cli_args => shell_command.original_cli_args,
-                                   :bisect_runner => runner.class)
+                                   :bisect_runner => runner.class.name)
 
           _, duration = track_duration do
             original_results    = runner.original_results

--- a/lib/rspec/core/bisect/fork_runner.rb
+++ b/lib/rspec/core/bisect/fork_runner.rb
@@ -40,6 +40,10 @@ module RSpec
           instance.shutdown
         end
 
+        def self.name
+          :fork
+        end
+
         def initialize(shell_command, spec_runner)
           @shell_command = shell_command
           @channel = Channel.new

--- a/lib/rspec/core/bisect/fork_runner.rb
+++ b/lib/rspec/core/bisect/fork_runner.rb
@@ -1,0 +1,130 @@
+require 'stringio'
+RSpec::Support.require_rspec_core "formatters/base_bisect_formatter"
+RSpec::Support.require_rspec_core "bisect/utilities"
+
+module RSpec
+  module Core
+    module Bisect
+      # A Bisect runner that runs requested subsets of the suite by forking
+      # sub-processes. The master process bootstraps RSpec and the application
+      # environment (including preloading files specified via `--require`) so
+      # that the individual spec runs do not have to re-pay that cost.  Each
+      # spec run happens in a forked process, ensuring that the spec files are
+      # not loaded in the main process.
+      #
+      # For most projects, bisections that use `ForkRunner` instead of
+      # `ShellRunner` will finish significantly faster, because the `ShellRunner`
+      # pays the cost of booting RSpec and the app environment on _every_ run of
+      # a subset. In contrast, `ForkRunner` pays that cost only once.
+      #
+      # However, not all projects can use `ForkRunner`. Obviously, on platforms
+      # that do not support forking (e.g. Windows), it cannot be used. In addition,
+      # it can cause problems for some projects that put side-effectful spec
+      # bootstrapping logic that should run on every spec run directly at the top
+      # level in a file loaded by `--require`, rather than in a `before(:suite)`
+      # hook. For example, consider a project that relies on some top-level logic
+      # in `spec_helper` to boot a Redis server for the test suite, intending the
+      # Redis bootstrapping to happen on every spec run. With `ShellRunner`, the
+      # bootstrapping logic will happen for each run of any subset of the suite,
+      # but for `ForkRunner`, such logic will only get run once, when the
+      # `RunDispatcher` boots the application environment. This might cause
+      # problems. The solution is for users to move the bootstrapping logic into
+      # a `before(:suite)` hook, or use the slower `ShellRunner`.
+      #
+      # @private
+      class ForkRunner
+        def self.start(shell_command, spec_runner)
+          instance = new(shell_command, spec_runner)
+          yield instance
+        ensure
+          instance.shutdown
+        end
+
+        def initialize(shell_command, spec_runner)
+          @shell_command = shell_command
+          @channel = Channel.new
+          @run_dispatcher = RunDispatcher.new(spec_runner, @channel)
+        end
+
+        def run(locations)
+          run_descriptor = ExampleSetDescriptor.new(locations, original_results.failed_example_ids)
+          dispatch_run(run_descriptor)
+        end
+
+        def original_results
+          @original_results ||= dispatch_run(ExampleSetDescriptor.new(
+            @shell_command.original_locations, []))
+        end
+
+        def shutdown
+          @channel.close
+        end
+
+      private
+
+        def dispatch_run(run_descriptor)
+          @run_dispatcher.dispatch_specs(run_descriptor)
+          @channel.receive.tap do |result|
+            if result.is_a?(String)
+              raise BisectFailedError.for_failed_spec_run(result)
+            end
+          end
+        end
+
+        # @private
+        class RunDispatcher
+          def initialize(runner, channel)
+            @runner = runner
+            @channel = channel
+
+            @spec_output = StringIO.new
+
+            runner.configuration.tap do |c|
+              c.reset_reporter
+              c.output_stream = @spec_output
+              c.error_stream = @spec_output
+            end
+          end
+
+          def dispatch_specs(run_descriptor)
+            pid = fork { run_specs(run_descriptor) }
+            Process.waitpid(pid)
+          end
+
+        private
+
+          def run_specs(run_descriptor)
+            $stdout = $stderr = @spec_output
+            formatter = CaptureFormatter.new(run_descriptor.failed_example_ids)
+
+            @runner.configuration.tap do |c|
+              c.files_or_directories_to_run = run_descriptor.all_example_ids
+              c.formatter = formatter
+              c.load_spec_files
+            end
+
+            # `announce_filters` has the side effect of implementing the logic
+            # that honors `config.run_all_when_everything_filtered` so we need
+            # to call it here. When we remove `run_all_when_everything_filtered`
+            # (slated for RSpec 4), we can remove this call to `announce_filters`.
+            @runner.world.announce_filters
+
+            @runner.run_specs(@runner.world.ordered_example_groups)
+            latest_run_results = formatter.results
+
+            if latest_run_results.nil? || latest_run_results.all_example_ids.empty?
+              @channel.send(@spec_output.string)
+            else
+              @channel.send(latest_run_results)
+            end
+          end
+        end
+
+        class CaptureFormatter < Formatters::BaseBisectFormatter
+          attr_accessor :results
+          alias_method :notify_results, :results=
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/core/bisect/shell_runner.rb
+++ b/lib/rspec/core/bisect/shell_runner.rb
@@ -10,7 +10,7 @@ module RSpec
       # Sets of specs are run by shelling out.
       # @private
       class ShellRunner
-        def self.start(shell_command)
+        def self.start(shell_command, _spec_runner=nil)
           Server.run do |server|
             yield new(server, shell_command)
           end

--- a/lib/rspec/core/bisect/shell_runner.rb
+++ b/lib/rspec/core/bisect/shell_runner.rb
@@ -10,7 +10,7 @@ module RSpec
       # Sets of specs are run by shelling out.
       # @private
       class ShellRunner
-        def self.start(shell_command, _spec_runner=nil)
+        def self.start(shell_command, _spec_runner)
           Server.run do |server|
             yield new(server, shell_command)
           end

--- a/lib/rspec/core/bisect/shell_runner.rb
+++ b/lib/rspec/core/bisect/shell_runner.rb
@@ -16,6 +16,10 @@ module RSpec
           end
         end
 
+        def self.name
+          :shell
+        end
+
         def initialize(server, shell_command)
           @server        = server
           @shell_command = shell_command

--- a/lib/rspec/core/formatters/bisect_progress_formatter.rb
+++ b/lib/rspec/core/formatters/bisect_progress_formatter.rb
@@ -8,8 +8,7 @@ module RSpec
       class BisectProgressFormatter < BaseTextFormatter
         def bisect_starting(notification)
           @round_count = 0
-          options = notification.original_cli_args.join(' ')
-          output.puts "Bisect started using options: #{options.inspect}"
+          output.puts bisect_started_message(notification)
           output.print "Running suite to find failures..."
         end
 
@@ -76,6 +75,13 @@ module RSpec
           output.puts "\n\nBisect aborted!"
           output.puts "\nThe most minimal reproduction command discovered so far is:\n  #{notification.repro}"
         end
+
+      private
+
+        def bisect_started_message(notification)
+          options = notification.original_cli_args.join(' ')
+          "Bisect started using options: #{options.inspect}"
+        end
       end
 
       # @private
@@ -125,6 +131,10 @@ module RSpec
           organized_ids = Formatters::Helpers.organize_ids(ids)
           formatted_ids = organized_ids.map { |id| "    - #{id}" }.join("\n")
           "#{description} (#{ids.size}):\n#{formatted_ids}"
+        end
+
+        def bisect_started_message(notification)
+          "#{super} and bisect runner: #{notification.bisect_runner}"
         end
       end
     end

--- a/lib/rspec/core/formatters/bisect_progress_formatter.rb
+++ b/lib/rspec/core/formatters/bisect_progress_formatter.rb
@@ -149,7 +149,7 @@ module RSpec
         end
 
         def bisect_started_message(notification)
-          "#{super} and bisect runner: #{notification.bisect_runner}"
+          "#{super} and bisect runner: #{notification.bisect_runner.inspect}"
         end
       end
     end

--- a/lib/rspec/core/formatters/bisect_progress_formatter.rb
+++ b/lib/rspec/core/formatters/bisect_progress_formatter.rb
@@ -6,6 +6,11 @@ module RSpec
       # @private
       # Produces progress output while bisecting.
       class BisectProgressFormatter < BaseTextFormatter
+        def initialize(output, bisect_runner)
+          super(output)
+          @bisect_runner = bisect_runner
+        end
+
         def bisect_starting(notification)
           @round_count = 0
           output.puts bisect_started_message(notification)
@@ -30,6 +35,16 @@ module RSpec
 
         def bisect_dependency_check_failed(_notification)
           output.puts " failure(s) do not require any non-failures to run first"
+
+          if @bisect_runner == :fork
+            output.puts
+            output.puts "=" * 80
+            output.puts "NOTE: this bisect run used `config.bisect_runner = :fork`, which generally"
+            output.puts "provides significantly faster bisection runs than the old shell-based runner,"
+            output.puts "but may inaccurately report that no non-failures are required. If this result"
+            output.puts "is unexpected, consider setting `config.bisect_runner = :shell` and trying again."
+            output.puts "=" * 80
+          end
         end
 
         def bisect_round_started(notification, include_trailing_space=true)

--- a/lib/rspec/core/invocations.rb
+++ b/lib/rspec/core/invocations.rb
@@ -26,27 +26,28 @@ module RSpec
 
       # @private
       class Bisect
-        def call(options, _err, _out)
+        def call(options, err, out)
           RSpec::Support.require_rspec_core "bisect/coordinator"
 
           success = RSpec::Core::Bisect::Coordinator.bisect_with(
+            Runner.new(options).tap { |r| r.configure(err, out) },
             options.args,
-            bisect_formatter_for(options.options[:bisect])
+            bisect_formatter_for(options.options[:bisect], out)
           )
 
           success ? 0 : 1
         end
 
-        private
+      private
 
-        def bisect_formatter_for(argument)
+        def bisect_formatter_for(argument, output)
           klass = if argument == "verbose"
                     Formatters::BisectDebugFormatter
                   else
                     Formatters::BisectProgressFormatter
                   end
 
-          klass.new(RSpec.configuration.output_stream)
+          klass.new(output)
         end
       end
 

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -94,9 +94,7 @@ module RSpec
       # @param err [IO] error stream
       # @param out [IO] output stream
       def setup(err, out)
-        @configuration.error_stream = err
-        @configuration.output_stream = out if @configuration.output_stream == $stdout
-        @options.configure(@configuration)
+        configure(err, out)
         @configuration.load_spec_files
         @world.announce_filters
       end
@@ -120,6 +118,13 @@ module RSpec
         end && !@world.non_example_failure
 
         success ? 0 : @configuration.failure_exit_code
+      end
+
+      # @private
+      def configure(err, out)
+        @configuration.error_stream = err
+        @configuration.output_stream = out if @configuration.output_stream == $stdout
+        @options.configure(@configuration)
       end
 
       # @private

--- a/spec/integration/bisect_runners_spec.rb
+++ b/spec/integration/bisect_runners_spec.rb
@@ -1,0 +1,133 @@
+require 'support/aruba_support'
+require 'rspec/core/bisect/shell_command'
+require 'rspec/core/bisect/shell_runner'
+require 'rspec/core/bisect/fork_runner'
+
+module RSpec::Core
+  RSpec.shared_examples_for "a bisect runner" do
+    include_context "aruba support"
+    before { clean_current_dir }
+
+    let(:shell_command) { Bisect::ShellCommand.new([]) }
+
+    def with_runner(&block)
+      handle_current_dir_change do
+        in_current_dir do
+          options = ConfigurationOptions.new(shell_command.original_cli_args)
+          runner = Runner.new(options)
+          output = StringIO.new
+          runner.configure(output, output)
+          described_class.start(shell_command, runner, &block)
+        end
+      end
+    end
+
+    it 'runs the specs in an isolated environment and reports the results' do
+      RSpec.configuration.formatter = 'progress'
+
+      write_file 'spec/a_spec.rb', "
+        formatters = RSpec.configuration.formatter_loader.formatters
+        if formatters.any? { |f| f.is_a?(RSpec::Core::Formatters::ProgressFormatter) }
+          raise 'Leaked progress formatter from host environment'
+        end
+
+        RSpec.describe 'A group' do
+          it('passes') { expect(1).to eq 1 }
+          it('fails')  { expect(1).to eq 2 }
+        end
+      "
+
+      with_runner do |runner|
+        expect(runner.original_results).to have_attributes(
+          :all_example_ids => %w[ ./spec/a_spec.rb[1:1] ./spec/a_spec.rb[1:2] ],
+          :failed_example_ids => %w[ ./spec/a_spec.rb[1:2] ]
+        )
+
+        expect(runner.run(%w[ ./spec/a_spec.rb[1:1] ])).to have_attributes(
+          :all_example_ids => %w[ ./spec/a_spec.rb[1:1] ],
+          :failed_example_ids => %w[]
+        )
+      end
+    end
+
+    it 'honors `run_all_when_everything_filtered`' do
+      write_file 'spec/a_spec.rb', "
+        RSpec.configure do |c|
+          c.filter_run :focus
+          c.run_all_when_everything_filtered = true
+        end
+
+        RSpec.describe 'A group' do
+          it('passes') { expect(1).to eq 1 }
+          it('fails')  { expect(1).to eq 2 }
+        end
+      "
+
+      with_runner do |runner|
+        expect(runner.original_results).to have_attributes(
+          :all_example_ids => %w[ ./spec/a_spec.rb[1:1] ./spec/a_spec.rb[1:2] ],
+          :failed_example_ids => %w[ ./spec/a_spec.rb[1:2] ]
+        )
+      end
+    end
+
+    it 'raises BisectFailedError with all run output when it encounters an error loading spec files' do
+      write_file 'spec/a_spec.rb', "
+        puts 'stdout in a_spec'
+        warn 'stderr in a_spec'
+
+        RSpec.escribe 'A group' do
+          it('passes') { expect(1).to eq 1 }
+          it('fails')  { expect(1).to eq 2 }
+        end
+      "
+
+      with_runner do |runner|
+        expect {
+          runner.original_results
+        }.to raise_error(Bisect::BisectFailedError, a_string_including(
+          "undefined method `escribe' for RSpec:Module",
+          'stdout in a_spec',
+          'stderr in a_spec'
+        ))
+      end
+    end
+  end
+
+  RSpec.describe Bisect::ShellRunner, :slow do
+    include_examples 'a bisect runner'
+  end
+
+  RSpec.describe Bisect::ForkRunner, :if => RSpec::Support::RubyFeatures.fork_supported? do
+    include_examples 'a bisect runner'
+
+    context 'when a `--require` option has been provided' do
+      let(:shell_command) { Bisect::ShellCommand.new(['--require', './spec/a_spec_helper']) }
+
+      it 'loads the specified file only once (rather than once per subset run)' do
+        write_file 'spec_helper_loads', ''
+        write_file 'spec/a_spec_helper.rb', "
+          File.open('spec_helper_loads', 'a') do |f|
+            f.print('.')
+          end
+        "
+
+        write_file 'spec/a_spec.rb', "
+          RSpec.describe 'A group' do
+            it('passes') { expect(1).to eq 1 }
+            it('fails')  { expect(1).to eq 2 }
+          end
+        "
+
+        with_runner do |runner|
+          runner.run(%w[ ./spec/a_spec.rb[1:1] ])
+          runner.run(%w[ ./spec/a_spec.rb[1:1] ])
+        end
+
+        in_current_dir do
+          expect(File.read('spec_helper_loads')).to eq(".")
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -9,10 +9,10 @@ module RSpec::Core
     end if ENV['APPVEYOR'] && RUBY_VERSION.to_f > 2.0
 
     def bisect(cli_args, expected_status=nil)
-      RSpec.configuration.output_stream = formatter_output
+      options = ConfigurationOptions.new(cli_args)
 
       expect {
-        status = RSpec::Core::Runner.run(cli_args + ["--bisect"])
+        status = Invocations::Bisect.new.call(options, formatter_output, formatter_output)
         expect(status).to eq(expected_status) if expected_status
       }.to avoid_outputting.to_stdout_from_any_process.and avoid_outputting.to_stderr_from_any_process
 

--- a/spec/rspec/core/bisect/coordinator_spec.rb
+++ b/spec/rspec/core/bisect/coordinator_spec.rb
@@ -49,7 +49,7 @@ module RSpec::Core
       output = normalize_durations(output.string)
 
       expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
-        |Bisect started using options: "" and bisect runner: FakeBisectRunner
+        |Bisect started using options: "" and bisect runner: "FakeBisectRunner"
         |Running suite to find failures... (n.nnnn seconds)
         | - Failing examples (2):
         |    - 2.rb[1:1]
@@ -150,7 +150,7 @@ module RSpec::Core
         output = normalize_durations(output.string)
 
         expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
-          |Bisect started using options: "" and bisect runner: FakeBisectRunner
+          |Bisect started using options: "" and bisect runner: "FakeBisectRunner"
           |Running suite to find failures... (n.nnnn seconds)
           | - Failing examples (1):
           |    - 2.rb[1:1]

--- a/spec/rspec/core/bisect/coordinator_spec.rb
+++ b/spec/rspec/core/bisect/coordinator_spec.rb
@@ -6,7 +6,9 @@ module RSpec::Core
   RSpec.describe Bisect::Coordinator, :simulate_shell_allowing_unquoted_ids do
     include FormatterSupport
 
-    let(:fake_runner) do
+    let(:config) { instance_double(Configuration, :bisect_runner_class => fake_bisect_runner) }
+    let(:spec_runner) { instance_double(RSpec::Core::Runner, :configuration => config) }
+    let(:fake_bisect_runner) do
       FakeBisectRunner.new(
         1.upto(8).map { |i| "#{i}.rb[1:1]" },
         %w[ 2.rb[1:1] ],
@@ -15,12 +17,7 @@ module RSpec::Core
     end
 
     def find_minimal_repro(output, formatter=Formatters::BisectProgressFormatter)
-      allow(Bisect::Server).to receive(:run).and_yield(instance_double(Bisect::Server))
-      allow(Bisect::ShellRunner).to receive(:new).and_return(fake_runner)
-
-      Bisect::Coordinator.bisect_with([], formatter.new(output))
-    ensure
-      RSpec.reset # so that RSpec.configuration.output_stream isn't closed
+      Bisect::Coordinator.bisect_with(spec_runner, [], formatter.new(output))
     end
 
     it 'notifies the bisect progress formatter of progress and closes the output' do
@@ -52,7 +49,7 @@ module RSpec::Core
       output = normalize_durations(output.string)
 
       expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
-        |Bisect started using options: ""
+        |Bisect started using options: "" and bisect runner: FakeBisectRunner
         |Running suite to find failures... (n.nnnn seconds)
         | - Failing examples (2):
         |    - 2.rb[1:1]
@@ -100,7 +97,7 @@ module RSpec::Core
 
     context "with an order-independent failure" do
       it "detects the independent case and prints the minimal reproduction" do
-        fake_runner.dependent_failures = {}
+        fake_bisect_runner.dependent_failures = {}
         output = StringIO.new
         find_minimal_repro(output)
         output = normalize_durations(output.string)
@@ -120,13 +117,13 @@ module RSpec::Core
       end
 
       it "can use the debug formatter for detailed output" do
-        fake_runner.dependent_failures = {}
+        fake_bisect_runner.dependent_failures = {}
         output = StringIO.new
         find_minimal_repro(output, Formatters::BisectDebugFormatter)
         output = normalize_durations(output.string)
 
         expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
-          |Bisect started using options: ""
+          |Bisect started using options: "" and bisect runner: FakeBisectRunner
           |Running suite to find failures... (n.nnnn seconds)
           | - Failing examples (1):
           |    - 2.rb[1:1]

--- a/spec/rspec/core/bisect/utilities_spec.rb
+++ b/spec/rspec/core/bisect/utilities_spec.rb
@@ -23,4 +23,18 @@ module RSpec::Core
       }.not_to raise_error
     end
   end
+
+  RSpec.describe Bisect::Channel do
+    include RSpec::Support::InSubProcess
+
+    it "supports sending objects from a child process back to the parent" do
+      channel = Bisect::Channel.new
+
+      in_sub_process do
+        channel.send(:value_from_child)
+      end
+
+      expect(channel.receive).to eq :value_from_child
+    end
+  end
 end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1470,6 +1470,22 @@ module RSpec::Core
           config.bisect_runner_class
         }.to raise_error(/Unsupported value for `bisect_runner`/)
       end
+
+      it 'cannot be changed after the runner is in use' do
+        config.bisect_runner = :fork
+        config.bisect_runner_class
+
+        expect {
+          config.bisect_runner = :shell
+        }.to raise_error(/config.bisect_runner = :shell/)
+      end
+
+      it 'can be set to the same value after the runner is in use' do
+        config.bisect_runner = :shell
+        config.bisect_runner_class
+
+        expect { config.bisect_runner = :shell }.not_to raise_error
+      end
     end
 
     %w[formatter= add_formatter].each do |config_method|

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1443,6 +1443,35 @@ module RSpec::Core
       end
     end
 
+    describe "#bisect_runner_class" do
+      if RSpec::Support::RubyFeatures.fork_supported?
+        it 'defaults to the faster `Bisect::ForkRunner` since fork is supported on this platform' do
+          expect(config.bisect_runner_class).to be Bisect::ForkRunner
+        end
+      else
+        it 'defaults to the slower `Bisect::ShellRunner` since fork is not supported on this platform' do
+          expect(config.bisect_runner_class).to be Bisect::ShellRunner
+        end
+      end
+
+      it "returns `Bisect::ForkRunner` when `bisect_runner == :fork" do
+        config.bisect_runner = :fork
+        expect(config.bisect_runner_class).to be Bisect::ForkRunner
+      end
+
+      it "returns `Bisect::ShellRunner` when `bisect_runner == :shell" do
+        config.bisect_runner = :shell
+        expect(config.bisect_runner_class).to be Bisect::ShellRunner
+      end
+
+      it "raises a clear error when `bisect_runner` is configured to an unrecognized value" do
+        config.bisect_runner = :unknown
+        expect {
+          config.bisect_runner_class
+        }.to raise_error(/Unsupported value for `bisect_runner`/)
+      end
+    end
+
     %w[formatter= add_formatter].each do |config_method|
       describe "##{config_method}" do
         it "delegates to formatters#add" do

--- a/spec/rspec/core/invocations_spec.rb
+++ b/spec/rspec/core/invocations_spec.rb
@@ -77,13 +77,11 @@ module RSpec::Core
     end
 
     describe Invocations::Bisect do
-      let(:bisect) { nil }
-      let(:options) { { :bisect => bisect } }
-      let(:args) { double(:args) }
+      let(:original_cli_args) { %w[--bisect --seed 1234] }
+      let(:configuration_options) { ConfigurationOptions.new(original_cli_args) }
       let(:success) { true }
 
       before do
-        allow(configuration_options).to receive_messages(:args => args, :options => options)
         allow(RSpec::Core::Bisect::Coordinator).to receive(:bisect_with).and_return(success)
       end
 
@@ -91,7 +89,8 @@ module RSpec::Core
         run_invocation
 
         expect(RSpec::Core::Bisect::Coordinator).to have_received(:bisect_with).with(
-          args,
+          an_instance_of(Runner),
+          configuration_options.args,
           an_instance_of(Formatters::BisectProgressFormatter)
         )
       end
@@ -115,13 +114,14 @@ module RSpec::Core
       end
 
       context "and the verbose option is specified" do
-        let(:bisect) { "verbose" }
+        let(:original_cli_args) { %w[--bisect=verbose --seed 1234] }
 
         it "starts the bisection coordinator with the debug formatter" do
           run_invocation
 
           expect(RSpec::Core::Bisect::Coordinator).to have_received(:bisect_with).with(
-            args,
+            an_instance_of(Runner),
+            configuration_options.args,
             an_instance_of(Formatters::BisectDebugFormatter)
           )
         end

--- a/spec/rspec/core/resources/inconsistently_ordered_specs.rb
+++ b/spec/rspec/core/resources/inconsistently_ordered_specs.rb
@@ -1,12 +1,12 @@
 # Deliberately named _specs.rb to avoid being loaded except when specified
 
 RSpec.configure do |c|
-  c.register_ordering(:global, &:shuffle)
+  c.register_ordering(:shuffled, &:shuffle)
 end
 
-10.times do |i|
-  RSpec.describe "Group #{i}" do
-    it("passes") {      }
-    it("fails")  { fail }
+RSpec.describe "Group", :order => :shuffled do
+  10.times do |i|
+    it("passes #{i}") {      }
+    it("fails #{i}")  { fail }
   end
 end

--- a/spec/support/fake_bisect_runner.rb
+++ b/spec/support/fake_bisect_runner.rb
@@ -1,6 +1,10 @@
 require 'rspec/core/bisect/utilities'
 
 FakeBisectRunner = Struct.new(:all_ids, :always_failures, :dependent_failures) do
+  def start(_shell_command, _spec_runner)
+    yield self
+  end
+
   def original_results
     failures = always_failures | dependent_failures.keys
     RSpec::Core::Bisect::ExampleSetDescriptor.new(all_ids, failures.sort)


### PR DESCRIPTION
Until now, `--bisect` has shelled out to run each subset.  I've realized this is pretty inefficient: you keep paying the cost to boot RSpec and the application environment over and over again.  I thought we could perhaps improve performance by running the specs using `fork` instead of shelling out.  This PR is the result of my attempt.

## Results

The improvement of the new forking bisect runner can make a big difference, but the amount of improvement depends a lot on an individual project's spec suite.  Spec suites that boot quickly, and have a runtime dominated by the specs themselves, will see only marginal improvements.  Any spec suite that has significant boot up time (e.g. to load rails or some other heavyweight dependency) should see a noticeable improvement.

I did some testing using the unit specs of [plines](https://github.com/seomoz/plines), and old project I worked on years ago.  It contains 343 unit specs which run pretty quickly (`time bin/rspec spec/unit` takes about 2 seconds).  Running `bin/rspec spec/unit --bisect` using the existing shell runner takes 9.8 seconds.  With the new fork runner, it drops to 6.3 seconds--about a 33% improvement.

However, if we simulate the typical boot time of a rails app by adding a `sleep 5` to `spec_helper`, the difference is _much_ more dramatic.  With the shell runner, a bisect run takes 108.9 seconds.  With the fork runner, it takes 11.7 seconds.

If you really care about speed, you can pass additional `--require` options (or even require a file that pre-loads all of your application) when bisecting to ensure as much is pre-loaded as possible.

## Compatibility concerns

As nice as the performance improvements from the fork runner are, I don't think it's going to work for all spec suites.  Here are some potential issues:

* **Platforms that don't support `fork`**. AFAIK, this is only windows, but we have to support it, obviously.  We can keep using the shell runner for these environments.  This PR does that by checking `Process.respond_to?(:fork)` before deciding which bisect runner to default to.
* **Projects that use spring or some other forking runner**.  I don't know much about spring (or any of the other similar projects: zeus, spork, etc), but I understand it uses forking to work.  I don't know if there will be any conflict, if RSpec uses forking internally for `--bisect` and spring also does.
* **Projects that put one-time setup at the top level of `spec_helper` instead of in a `before(:suite)` hook**.  The forking runner loads `--require` files only once (which is a big part of where it gets its perf improvements!) but that means that spec suite bootstrapping logic written at the top level of `spec_helper` will only get executed once, and not once per spec run, as with the shell runner.  Usually this isn't a big deal, but imagine a spec suite that booted selenium at the top level of `spec_helper`, and then shut down selenium in an `after(:suite)` hook.  In such a case, selenium would get shutdown after the first spec run, and it would not be available for use in subsequent spec runs.  With the shell runner, this isn't a problem, because it re-loads `spec_helper` each time.

Given these compatibility concerns, I'm not sure if we should default to the new `:fork` runner on platforms that support `:fork` or not.  If we stick with `:shell` as the default and make users opt-in to `:fork`, most users will miss out on the performance improvement.  But I also don't want to break bisect for some users.  Then again, I spent a bunch of time trying to create a situation like that last case, and failed to actually trigger a problem.  So maybe the forking runner isn't going to cause problems for any users.

What do others think?