### PR TITLE
fix ArgumentError: bad value for range

### DIFF
--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -379,6 +379,7 @@ module RSpec
                 parent_bt[index] != child_bt[index]
               end
 
+              return child if index_before_first_common_frame.nil?
               return child if index_before_first_common_frame == -1
 
               child = child.dup


### PR DESCRIPTION
If the two arrays are the same, `find()` returns `nil`. This case must be accounted for