### PR TITLE
Use https:// instead of git:// for README URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ RSpec repos as well. Add the following to your `Gemfile`:
 
 ```ruby
 %w[rspec rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
-  gem lib, :git => "git://github.com/rspec/#{lib}.git", :branch => 'master'
+  gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => 'master'
 end
 ```
 


### PR DESCRIPTION
See https://github.com/rspec/rspec-core/pull/2327.

`git://` URLs are insecure and cause recent versions of Bundler to emit a warning.

If this PR is accepted, I'll make the same PR to other RSpec repos with `git://` URLs in their READMEs.