### PR TITLE
Deprecate safe_level of `ERB.new` in Ruby 2.6

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -168,7 +168,13 @@ module RSpec
       end
 
       def options_file_as_erb_string(path)
-        ERB.new(File.read(path), nil, '-').result(binding)
+        # FIXME: Consider removing the following conditional branch after Ruby 2.6 is released.
+        #        https://github.com/ruby/ruby/commit/cc777d09f44fa909a336ba14f3aa802ffe16e010
+        if RUBY_VERSION >= '2.6'
+          ERB.new(File.read(path), :trim_mode => '-').result(binding)
+        else
+          ERB.new(File.read(path), nil, '-').result(binding)
+        end
       end
 
       def custom_options_file


### PR DESCRIPTION
This commit fixes the following build error of ruby-head (Ruby 2.6) .

```console
Failures:

  1) RSpec::Core::Formatters::ProgressFormatter produces the expected
  full output
     Failure/Error: @example_group_instance.instance_exec(*args, &block)

     RuntimeError:
       Warnings were generated:
       /home/travis/build/rspec/rspec-core/lib/rspec/core/configuration_options.rb:171:
       warning: Passing safe_level with the 2nd argument of ERB.new is
       deprecated. Do not use it, and specify other arguments as keyword
       arguments.
       /home/travis/build/rspec/rspec-core/lib/rspec/core/configuration_options.rb:171:
       warning: Passing trim_mode with the 3rd argument of ERB.new is
       deprecated. Use keyword argument like ERB.new(str, trim_mode:
       ...) instead.
     #
       /home/travis/build/rspec/rspec-support/lib/rspec/support/spec/stderr_splitter.rb:54:in
       `verify_no_warnings!'
     #
       /home/travis/build/rspec/rspec-support/lib/rspec/support/spec.rb:25:in
       `block (2 levels) in <top (required)>'
     # ./lib/rspec/core/example.rb:447:in `instance_exec'
     # ./lib/rspec/core/example.rb:447:in `instance_exec'
     # ./lib/rspec/core/hooks.rb:355:in `run'
     # ./lib/rspec/core/hooks.rb:507:in `block in run_owned_hooks_for'
     # ./lib/rspec/core/hooks.rb:506:in `each'
     # ./lib/rspec/core/hooks.rb:506:in `run_owned_hooks_for'
     # ./lib/rspec/core/hooks.rb:593:in `block in run_example_hooks_for'
     # ./lib/rspec/core/hooks.rb:592:in `each'
     # ./lib/rspec/core/hooks.rb:592:in `run_example_hooks_for'
     # ./lib/rspec/core/hooks.rb:463:in `run'
     # ./lib/rspec/core/example.rb:507:in `run_after_example'
     # ./lib/rspec/core/example.rb:273:in `block in run'
     # ./lib/rspec/core/example.rb:500:in `block in
       with_around_and_singleton_context_hooks'
     # ./lib/rspec/core/example.rb:457:in `block in
       with_around_example_hooks'
     # ./lib/rspec/core/hooks.rb:464:in `block in run'
     # ./lib/rspec/core/hooks.rb:604:in `block in
       run_around_example_hooks_for'
     # ./lib/rspec/core/example.rb:342:in `call'
     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in
       <top (required)>'
     # ./lib/rspec/core/sandbox.rb:29:in `sandboxed'
     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in
       <top (required)>'
     # ./lib/rspec/core/example.rb:447:in `instance_exec'
     # ./lib/rspec/core/example.rb:447:in `instance_exec'
     # ./lib/rspec/core/hooks.rb:373:in `execute_with'
     # ./lib/rspec/core/hooks.rb:606:in `block (2 levels) in
       run_around_example_hooks_for'
     # ./lib/rspec/core/example.rb:342:in `call'
     # ./lib/rspec/core/hooks.rb:607:in `run_around_example_hooks_for'
     # ./lib/rspec/core/hooks.rb:464:in `run'
     # ./lib/rspec/core/example.rb:457:in `with_around_example_hooks'
     # ./lib/rspec/core/example.rb:500:in
       `with_around_and_singleton_context_hooks'
     # ./lib/rspec/core/example.rb:251:in `run'
     # ./lib/rspec/core/example_group.rb:629:in `block in run_examples'
     # ./lib/rspec/core/example_group.rb:625:in `map'
     # ./lib/rspec/core/example_group.rb:625:in `run_examples'
     # ./lib/rspec/core/example_group.rb:591:in `run'
     # ./lib/rspec/core/runner.rb:116:in `block (3 levels) in run_specs'
     # ./lib/rspec/core/runner.rb:116:in `map'
     # ./lib/rspec/core/runner.rb:116:in `block (2 levels) in run_specs'
     # ./lib/rspec/core/configuration.rb:1975:in `with_suite_hooks'
     # ./lib/rspec/core/runner.rb:111:in `block in run_specs'
     # ./lib/rspec/core/reporter.rb:74:in `report'
     # ./lib/rspec/core/runner.rb:110:in `run_specs'
     # ./lib/rspec/core/runner.rb:87:in `run'
     # ./lib/rspec/core/runner.rb:71:in `run'
     # ./lib/rspec/core/runner.rb:45:in `invoke'
     # ./exe/rspec:4:in `<top (required)>'
     # script/rspec_with_simplecov:42:in `load'
     # script/rspec_with_simplecov:42:in `<main>'
```

https://travis-ci.org/rspec/rspec-core/jobs/346647744#L1004-L1060

The following addresses are related commits.

- ruby/ruby@cc777d0
- ruby/ruby@8b9a3ea