### PR TITLE
Fix spec name/assertion mismatch.

### DIFF
--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -407,7 +407,7 @@ module RSpec::Core
           end
 
           context "when `example_status_persistence_file_path` is not configured" do
-            it 'persists the status of all loaded examples' do
+            it "doesn't persist example status" do
               config.example_status_persistence_file_path = nil
               run
               expect(ExampleStatusPersister).not_to have_received(:persist)


### PR DESCRIPTION
Looks like the spec name was copy/pasted from one above it, but this spec is the inverse of the one that its name was copied from.