### PR TITLE
Don't write status file during dry runs.

### DIFF
--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -184,6 +184,7 @@ module RSpec
     private
 
       def persist_example_statuses
+        return if @configuration.dry_run
         return unless (path = @configuration.example_status_persistence_file_path)
 
         ExampleStatusPersister.persist(@world.all_examples, path)

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -406,6 +406,15 @@ module RSpec::Core
             end
           end
 
+          context "with --dry-run" do
+            it "doesn't persist example status" do
+              config.example_status_persistence_file_path = "examples.txt"
+              config.dry_run = true
+              run
+              expect(ExampleStatusPersister).not_to have_received(:persist)
+            end
+          end
+
           context "when `example_status_persistence_file_path` is not configured" do
             it 'persists the status of all loaded examples' do
               config.example_status_persistence_file_path = nil


### PR DESCRIPTION
Doing a dry run currently fills the status file with near-zero runtimes, replacing any that are there. This seems wrong, since those times don't represent the actual runtime of any test code.

In case that's not convincing, here's why I ran into this. (But if it's convincing, this is just boring yak detail.)

- I'm writing a thing that gathers a list of all specs, then spawns multiple rspec processes, each with a subset.
- I want to balance the runtimes of the parallel subprocesses as much as possible, preventing a single subprocess from ending up with all of the slow specs.
- That requires looking at the status file to get the specs' runtimes.
- But I also need to catch new specs that aren't yet in the status file, which means doing a dry-run before spawning the parallel processes.
- The problem, then: doing a dry run to discover test names smashes the existing status, so I can't find out how long the tests take.
- I could pull the statuses before doing the dry run, thus giving me both pieces of data. But if I'm doing a parallel run of only a subset of the tests, this will smash the statuses of any tests not in that run. But in practice, I mostly do single-file runs. Smashing other files' statuses means that the parallel runner often won't have runtimes for the specs it's running.

Welcome to my yak shave.