### PR TITLE
Add support for XDG base directory support for configuration file

### DIFF
--- a/Filtering.md
+++ b/Filtering.md
@@ -114,10 +114,10 @@ focus them.
 
 ## Options files and command line overrides
 
-Command line option declarations can be stored in `.rspec`, `~/.rspec`, or a custom
-options file. This is useful for storing defaults. For example, let's
-say you've got some slow specs that you want to suppress most of the
-time. You can tag them like this:
+Command line option declarations can be stored in `.rspec`, `~/.rspec`,
+`$XDG_CONFIG_HOME/rspec/options` or a custom options file. This is useful for
+storing defaults. For example, let's say you've got some slow specs that you
+want to suppress most of the time. You can tag them like this:
 
 ``` ruby
 RSpec.describe Something, :slow => true do

--- a/features/configuration/default_path.feature
+++ b/features/configuration/default_path.feature
@@ -5,8 +5,7 @@ Feature: Setting the default spec path
   This is supported by a `--default-path` option, which is set to `spec` by
   default. If you prefer to keep your specs in a different directory, or assign
   an individual file to `--default-path`, you can do so on the command line or
-  in a configuration file (`.rspec`, `~/.rspec`,
-  `$XDG_CONFIG_HOME/rspec/options`, or a custom file).
+  in a configuration file (for example `.rspec`).
 
   **NOTE:** this option is not supported on `RSpec.configuration`, as it needs to be
   set before spec files are loaded.

--- a/features/configuration/default_path.feature
+++ b/features/configuration/default_path.feature
@@ -5,7 +5,8 @@ Feature: Setting the default spec path
   This is supported by a `--default-path` option, which is set to `spec` by
   default. If you prefer to keep your specs in a different directory, or assign
   an individual file to `--default-path`, you can do so on the command line or
-  in a configuration file (`.rspec`, `~/.rspec`, or a custom file).
+  in a configuration file (`.rspec`, `~/.rspec`,
+  `$XDG_CONFIG_HOME/rspec/options`, or a custom file).
 
   **NOTE:** this option is not supported on `RSpec.configuration`, as it needs to be
   set before spec files are loaded.

--- a/features/configuration/read_options_from_file.feature
+++ b/features/configuration/read_options_from_file.feature
@@ -9,12 +9,18 @@ Feature: read command line configuration options from files
     * Project:  `./.rspec` (i.e. in the project's root directory, usually
       checked into the project)
 
-    * Global: `~/.rspec` (i.e. in the user's home directory)
+    * Global (HOME): `~/.rspec` (i.e. in the user's home directory)
 
-  Configuration options are loaded from `~/.rspec`, `.rspec`, `.rspec-local`,
-  command line switches, and the `SPEC_OPTS` environment variable (listed in
-  lowest to highest precedence; for example, an option in `~/.rspec` can be
-  overridden by an option in `.rspec-local`).
+    * Global (XDG): `$XDG_CONFIG_HOME/rspec/options` (i.e. in the user's
+      [the XDG Base Directory
+      Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+      config directory)
+
+  Configuration options are loaded from `$XDG_CONFIG_HOME/rspec/options`,
+  `~/.rspec`, `.rspec`, `.rspec-local`, command line switches, and the
+  `SPEC_OPTS` environment variable (listed in lowest to highest precedence; for
+  example, an option in `~/.rspec` can be overridden by an option in
+  `.rspec-local`).
 
   Scenario: Color set in `.rspec`
     Given a file named ".rspec" with:

--- a/features/configuration/read_options_from_file.feature
+++ b/features/configuration/read_options_from_file.feature
@@ -1,26 +1,32 @@
 Feature: read command line configuration options from files
 
-  RSpec reads command line configuration options from files in three different
-  locations:
+  RSpec reads command line configuration options from several different files,
+  all conforming to a specific level of specificity. Options from a higher
+  specificity will override conflicting options from lower specificity files.
 
-    * Local: `./.rspec-local` (i.e. in the project's root directory, can be
-      gitignored)
+  The locations are:
 
-    * Project:  `./.rspec` (i.e. in the project's root directory, usually
+    * **Global options:** First file from the following list (i.e. the user's
+      personal global options)
+
+      * `$XDG_CONFIG_HOME/rspec/options` ([XDG Base Directory
+        Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+        config)
+      * `~/.rspec`
+
+    * **Project options:**  `./.rspec` (i.e. in the project's root directory, usually
       checked into the project)
 
-    * Global (HOME): `~/.rspec` (i.e. in the user's home directory)
+    * **Local:** `./.rspec-local` (i.e. in the project's root directory, can be
+      gitignored)
 
-    * Global (XDG): `$XDG_CONFIG_HOME/rspec/options` (i.e. in the user's
-      [the XDG Base Directory
-      Specification](https://specifications.freedesktop.org/basedir-spec/latest/)
-      config directory)
+  Options specified at the command-line has even higher specificity, as does
+  the `SPEC_OPTS` environment variable. That means that a command-line option
+  would overwrite a project-specific option, which overrides the global value
+  of that option.
 
-  Configuration options are loaded from `$XDG_CONFIG_HOME/rspec/options`,
-  `~/.rspec`, `.rspec`, `.rspec-local`, command line switches, and the
-  `SPEC_OPTS` environment variable (listed in lowest to highest precedence; for
-  example, an option in `~/.rspec` can be overridden by an option in
-  `.rspec-local`).
+  The default options files can all be ignored using the `--options`
+  command-line argument, which selects a custom file to load options from.
 
   Scenario: Color set in `.rspec`
     Given a file named ".rspec" with:

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -9,10 +9,11 @@ module RSpec
 
     # Stores runtime configuration information.
     #
-    # Configuration options are loaded from `~/.rspec`, `.rspec`,
-    # `.rspec-local`, command line switches, and the `SPEC_OPTS` environment
-    # variable (listed in lowest to highest precedence; for example, an option
-    # in `~/.rspec` can be overridden by an option in `.rspec-local`).
+    # Configuration options are loaded from `$XDG_CONFIG_HOME/rspec/options`,
+    # `~/.rspec`, `.rspec`, `.rspec-local`, command line switches, and the
+    # `SPEC_OPTS` environment variable (listed in lowest to highest precedence;
+    # for example, an option in `~/.rspec` can be overridden by an option in
+    # `.rspec-local`).
     #
     # @example Standard settings
     #     RSpec.configure do |c|

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -9,11 +9,24 @@ module RSpec
 
     # Stores runtime configuration information.
     #
-    # Configuration options are loaded from `$XDG_CONFIG_HOME/rspec/options`,
-    # `~/.rspec`, `.rspec`, `.rspec-local`, command line switches, and the
-    # `SPEC_OPTS` environment variable (listed in lowest to highest precedence;
-    # for example, an option in `~/.rspec` can be overridden by an option in
-    # `.rspec-local`).
+    # Configuration options are loaded from multiple files and joined together
+    # with command-line switches and the `SPEC_OPTS` environment variable.
+    #
+    # Precedence order (where later entries overwrite earlier entries on
+    # conflicts):
+    #
+    #   * Global (`$XDG_CONFIG_HOME/rspec/options`, or `~/.rspec` if it does
+    #     not exist)
+    #   * Project-specific (`./.rspec`)
+    #   * Local (`./.rspec-local`)
+    #   * Command-line options
+    #   * `SPEC_OPTS`
+    #
+    # For example, an option set in the local file will override an option set
+    # in your global file.
+    #
+    # The global, project-specific and local files can all be overridden with a
+    # separate custom file using the --options command-line parameter.
     #
     # @example Standard settings
     #     RSpec.configure do |c|

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -206,11 +206,18 @@ module RSpec
       end
 
       def global_xdg_options_file
-        xdg_config_home = ENV.fetch("XDG_CONFIG_HOME", "~/.config")
-        File.join(File.expand_path(xdg_config_home), "rspec", "options")
+        xdg_config_home = resolve_xdg_config_home
+        if xdg_config_home
+          File.join(xdg_config_home, "rspec", "options")
+        end
+      end
+
+      def resolve_xdg_config_home
+        File.expand_path(ENV.fetch("XDG_CONFIG_HOME", "~/.config"))
       rescue ArgumentError
         # :nocov:
-        RSpec.warning "Unable to find $XDG_CONFIG_HOME/rspec/options because the HOME environment variable is not set"
+        # On Ruby 2.4, `File.expand("~")` works even if `ENV['HOME']` is not set.
+        # But on earlier versions, it fails.
         nil
         # :nocov:
       end

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -122,7 +122,7 @@ module RSpec
         if custom_options_file
           [custom_options]
         else
-          [global_xdg_options, global_options, project_options, local_options]
+          [global_options, project_options, local_options]
         end
       end
 
@@ -153,10 +153,6 @@ module RSpec
 
       def global_options
         @global_options ||= options_from(global_options_file)
-      end
-
-      def global_xdg_options
-        @global_xdg_options ||= options_from(global_xdg_options_file)
       end
 
       def options_from(path)
@@ -197,6 +193,17 @@ module RSpec
       end
 
       def global_options_file
+        xdg_options_file_if_exists || home_options_file_path
+      end
+
+      def xdg_options_file_if_exists
+        path = xdg_options_file_path
+        if path && File.exist?(path)
+          path
+        end
+      end
+
+      def home_options_file_path
         File.join(File.expand_path("~"), ".rspec")
       rescue ArgumentError
         # :nocov:
@@ -205,7 +212,7 @@ module RSpec
         # :nocov:
       end
 
-      def global_xdg_options_file
+      def xdg_options_file_path
         xdg_config_home = resolve_xdg_config_home
         if xdg_config_home
           File.join(xdg_config_home, "rspec", "options")

--- a/spec/support/isolated_home_directory.rb
+++ b/spec/support/isolated_home_directory.rb
@@ -21,7 +21,8 @@ module HomeFixtureHelpers
     path = Pathname.new(file_name).expand_path
     if !path.exist?
       path.dirname.mkpath
-      path.write(contents)
+      # Pathname#write does not exist in all supported Ruby versions
+      File.open(path.to_s, 'w') { |file| file << contents }
     else
       # Abort just in case we're about to destroy something important.
       raise "File at #{path} already exists!"

--- a/spec/support/isolated_home_directory.rb
+++ b/spec/support/isolated_home_directory.rb
@@ -1,20 +1,35 @@
 require 'tmpdir'
 require 'fileutils'
+require 'pathname'
 
 RSpec.shared_context "isolated home directory" do
   around do |ex|
     Dir.mktmpdir do |tmp_dir|
-      original_home = ENV['HOME']
-      begin
-        ENV['HOME'] = tmp_dir
-        ex.call
-      ensure
-        ENV['HOME'] = original_home
+      # If user has a custom $XDG_CONFIG_HOME, also clear that out when
+      # changing $HOME so tests don't touch the user's real config files.
+      without_env_vars "XDG_CONFIG_HOME" do
+        with_env_vars "HOME" => tmp_dir do
+          ex.call
+        end
       end
+    end
+  end
+end
+
+module HomeFixtureHelpers
+  def create_fixture_file(file_name, contents)
+    path = Pathname.new(file_name).expand_path
+    if !path.exist?
+      path.dirname.mkpath
+      path.write(contents)
+    else
+      # Abort just in case we're about to destroy something important.
+      raise "File at #{path} already exists!"
     end
   end
 end
 
 RSpec.configure do |c|
   c.include_context "isolated home directory", :isolated_home => true
+  c.include HomeFixtureHelpers, :isolated_home => true
 end

--- a/spec/support/isolated_home_directory.rb
+++ b/spec/support/isolated_home_directory.rb
@@ -5,8 +5,9 @@ require 'pathname'
 RSpec.shared_context "isolated home directory" do
   around do |ex|
     Dir.mktmpdir do |tmp_dir|
-      # If user has a custom $XDG_CONFIG_HOME, also clear that out when
-      # changing $HOME so tests don't touch the user's real config files.
+      # If user running this test suite has a custom $XDG_CONFIG_HOME, also
+      # clear that out when changing $HOME so tests don't touch the user's real
+      # configuration files.
       without_env_vars "XDG_CONFIG_HOME" do
         with_env_vars "HOME" => tmp_dir do
           ex.call


### PR DESCRIPTION
This is an [XDG Base Directory Specification][xdg]-compatible alternative to `~/.rspec`.

`~/.rspec` has higher precedence in order to reduce risk in cases where users have a file like this dormant. It is unlikely, but this way the risk is lower.

If `$XDG_CONFIG_HOME` is not set, it will fall back to `~/.config`, per the specification.

## Name of the file

I chose the name `rspec/options` over, say `rspec/config`, because:

* it's referred to as an "options file" in some parts of the documentation
* it leaves space for the possibility of having a config file that is not based on CLI options (Ruby DSL, YAML, etc.)

It is trivial to change before merging, of course. I think you get to pick a name, so this is just a suggestion.

## Other changes

The "isolated home" example tag has been extended with a `create_fixture_file` helper that also expands the filename and takes care to create the directory where the file resides in, if it does not already exist.
Other file creations have been migrated to this method for consistency.

The method is only available when an example is tagged with `:isolated_home => true`, for safety.

In case the developer running these tests have a custom `$XDG_CONFIG_HOME` set, it is cleared out when using an isolated home so their real files are not touched.

## References

* #1773 (CC @jasonkarns)
* [XDG Base Directory Specification][xdg]
* [XDG Base Directory support (Arch Wiki)][wiki]

[xdg]: https://specifications.freedesktop.org/basedir-spec/latest/
[wiki]: https://specifications.freedesktop.org/basedir-spec/latest/