### PR TITLE
[WIP] Update a development dependency rr to use the latest version.

### DIFF
--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "coderay",  "~> 1.1.1"
 
   s.add_development_dependency "mocha",        "~> 0.13.0"
-  s.add_development_dependency "rr",           "~> 1.0.4"
+  s.add_development_dependency "rr",           "~> 1.2"
   s.add_development_dependency "flexmock",     "~> 0.9.0"
   s.add_development_dependency "thread_order", "~> 1.1.0"
 end


### PR DESCRIPTION
I want to use latest version `rr` 1.2.
https://rubygems.org/gems/rr

Is it possible?

I updated as `~> X.Y` to avoid below warning.

```
-  s.add_development_dependency "rr",           "~> 1.0.4"
+  s.add_development_dependency "rr",           "~> 1.2"
```

```
$ gem build rspec-core.gemspec
...
WARNING:  pessimistic dependency on rr (~> 1.0.4, development) may be overly strict
  if rr is semantically versioned, use:
    add_development_dependency 'rr', '~> 1.0', '>= 1.0.4'
...
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: rspec-core
  Version: 3.8.pre
  File: rspec-core-3.8.pre.gem
```