### PR TITLE
[Feature Idea] Combine context and let into one method. 

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -466,6 +466,13 @@ EOS
           subject(name, &block)
           before { subject }
         end
+        
+        def with(name, value, description = nil, &block)
+          context description || "When #{name} is #{value}" do
+            let(name) { value }
+            instance_exec(name, value, &block)
+          end
+        end
       end
 
       # @private


### PR DESCRIPTION
When we use rspec, we often write code like below.

```
context 'When name is Mike' do
  let(:name) { 'Mike' }
  ...
end
```

In this case, context and let say same thing.
If this will be one line, its easy to write and read.

So, I propose a method `with` .

```
with(:name, 'Mike') do
   ...
end
```

This code have same meaning of the code above.

How do you think about this? @rspec/rspec
