### PR TITLE
Add filter_examples method

### DIFF
--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -21,6 +21,16 @@ module RSpec
         configuration.world = self
         @example_groups = []
         @example_group_counts_by_spec_file = Hash.new(0)
+        prepare_example_filtering
+      end
+
+      # @api public
+      #
+      # Creates the list of filtered examples given current configuration.
+      #
+      # This is a separate method so that filters can be modified/replaced and
+      # examples refiltered during a process's lifetime.
+      def prepare_example_filtering
         @filtered_examples = Hash.new do |hash, group|
           hash[group] = filter_manager.prune(group.examples)
         end


### PR DESCRIPTION
I am working on a parallel rspec test runner and it performs what effectively are multiple test runs in the same process. To achieve correct hook invocation I am using rspec's built in filtering functionality to set up filters to run a single example at a time.

The issue is that rspec loads examples and filters them in one operation, whereas I need to load them once and filter multiple times. The filter_examples extraction allows for this use case.