### PR TITLE
Add 'reproduction-order' flag for printing spec order in summary

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -327,6 +327,10 @@ module RSpec
       add_setting :default_color
 
       # @macro add_setting
+      # Prints the reproduction order of the specs (default: `false`).
+      add_setting :reproduction_order
+
+      # @macro add_setting
       # Color used when a pending example is fixed. Defaults to `:blue` but can
       # be set to one of the following: `[:black, :white, :red, :green,
       # :yellow, :blue, :magenta, :cyan]`
@@ -519,6 +523,7 @@ module RSpec
         @fixed_color = :blue
         @detail_color = :cyan
         @profile_examples = false
+        @reproduction_order = false
         @requires = []
         @libs = []
         @derived_metadata_blocks = FilterableItemRepository::QueryOptimized.new(:any?)

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -297,7 +297,8 @@ module RSpec::Core
     #                                                  the spec suite
     SummaryNotification = Struct.new(:duration, :examples, :failed_examples,
                                      :pending_examples, :load_time,
-                                     :errors_outside_of_examples_count)
+                                     :errors_outside_of_examples_count,
+                                     :reproduction_order)
     class SummaryNotification
       # @api
       # @return [Fixnum] the number of examples run
@@ -385,6 +386,11 @@ module RSpec::Core
         formatted = "\nFinished in #{formatted_duration} " \
                     "(files took #{formatted_load_time} to load)\n" \
                     "#{colorized_totals_line(colorizer)}\n"
+
+        if reproduction_order
+          formatted << "\nReproduce this spec order with:\n" \
+                       "rspec --seed ordered #{examples.map(&:location).join(' ')}\n"
+        end
 
         unless failed_examples.empty?
           formatted += (colorized_rerun_commands(colorizer) + "\n")

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -129,6 +129,10 @@ module RSpec::Core
           options[:deprecation_stream] = file
         end
 
+        parser.on('--reproduction-order', 'Print the order the specs ran in at the example level') do |_o|
+          options[:reproduction_order] = true
+        end
+
         parser.on('-b', '--backtrace', 'Enable full backtrace.') do |_o|
           options[:full_backtrace] = true
         end

--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -176,7 +176,8 @@ module RSpec::Core
         end
         notify :dump_summary, Notifications::SummaryNotification.new(@duration, @examples, @failed_examples,
                                                                      @pending_examples, @load_time,
-                                                                     @non_example_exception_count)
+                                                                     @non_example_exception_count,
+                                                                     @configuration.reproduction_order)
         notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
       end
     end


### PR DESCRIPTION
When running specs using the random ordering, it can often be useful to see the example order that the seed generated. 

This can be useful when you are doing a bisect over a large number of failing specs **yet** you know the first failing example should allow you to reproduce the order-dependent failure with smaller bisect-able bundle. With a large amount of failures, bisect tends to churn for hours and hours.

In the past I had used a combination of `--fail-fast` plus the `--format json` flag to parse out the actual spec ordering after the random seeding had taken place. The alternative is running in documentation mode to infer which examples ran in which order (kinda terrible).

Other folks have ran into [similar issues](https://stackoverflow.com/questions/29906212/listing-all-specs-in-order-determined-by-seed-in-rspec) and their solutions are similarly hacky

I plan to write specs/documentation if this seems like a palatable change.

#### Example output
```
rspec spec/speccy_the_spectacle.rb --order random --reproduction-order

Randomized with seed 21471
...

Finished in 0.21412 seconds (files took 7.1 seconds to load)
3 examples, 0 failures

Reproduce this spec order with:
rspec --seed ordered ./spec/speccy_the_spectacle.rb:50 ./spec/speccy_the_spectacle.rb:10 ./spec/speccy_the_spectacle.rb:20
```