### PR TITLE
Remove unused variables in the spec code

### DIFF
--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -406,17 +406,12 @@ module RSpec::Core
 
           it "excludes examples in groups matching filter" do
             group = RSpec.describe("does something", spec_metadata)
-            [ group.example("first"), group.example("second") ]
 
             expect(group.filtered_examples).to be_empty
           end
 
           it "excludes examples directly matching filter" do
             group = RSpec.describe("does something")
-            [
-              group.example("first", spec_metadata),
-              group.example("second", spec_metadata)
-            ]
             unfiltered_example = group.example("third (not-filtered)")
 
             expect(group.filtered_examples).to eq([unfiltered_example])


### PR DESCRIPTION
I just want to remove the unused variables in the spec file.
That becomes unused variables by https://github.com/rspec/rspec-core/commit/648b344d8 .
or we might be able to put assertions (`should`) for the variables like this.

```
expect(group.example("first", spec_metadata)).to be_truthy
expect(group.example("second", spec_metadata)).to be_truthy
```
