### PR TITLE
use bin/rspec if you are using spring & rspec

### DIFF
--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -362,7 +362,7 @@ module RSpec::Core
       def colorized_rerun_commands(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
         "\nFailed examples:\n\n" +
         failed_examples.map do |example|
-          colorizer.wrap("rspec #{rerun_argument_for(example)}", RSpec.configuration.failure_color) + " " +
+          colorizer.wrap("#{rspec_shell_command} #{rerun_argument_for(example)}", RSpec.configuration.failure_color) + " " +
           colorizer.wrap("# #{example.full_description}",   RSpec.configuration.detail_color)
         end.join("\n")
       end
@@ -414,6 +414,24 @@ module RSpec::Core
           end
         end
       end
+
+      def rspec_shell_command
+        @rspec_shell_command ||= begin
+          if spring_rspec?
+            'bin/rspec'
+          else
+            'rspec'
+          end
+        end
+      end
+
+      def spring_rspec?
+        lockfile     = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+        spring       = lockfile.specs.detect { |spec| spec.name == "spring" }
+        spring_rspec = lockfile.specs.detect { |spec| spec.name == "spring-commands-rspec" }
+        spring.present? && spring_rspec.present?
+      end
+
     end
 
     # The `ProfileNotification` holds information about the results of running a


### PR DESCRIPTION
If spec failed, instead of 

rspec ./spec/controllers/account/cities_controller_spec.rb:47 

output in console:

bin/rspec ./spec/controllers/account/cities_controller_spec.rb:47 

if you are using Rails+Rspec+Spring