### PR TITLE
Single error when `--require`'d files fail to load

### DIFF
--- a/lib/rspec/core/reporter.rb
+++ b/lib/rspec/core/reporter.rb
@@ -77,6 +77,14 @@ module RSpec::Core
       end
     end
 
+    # @param exit_code [Integer] the exit_code to be return by the reporter
+    #
+    # Reports a run that exited early without having run any examples.
+    #
+    def exit_early(exit_code)
+      report(0) { exit_code }
+    end
+
     # @private
     def start(expected_example_count, time=RSpec::Core::Time.now)
       @start = time

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -102,7 +102,10 @@ module RSpec
       # @param out [IO] output stream
       def setup(err, out)
         configure(err, out)
-        @configuration.load_spec_files unless RSpec.world.wants_to_quit
+        return if RSpec.world.wants_to_quit
+
+        @configuration.load_spec_files
+      ensure
         @world.announce_filters
       end
 

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -84,8 +84,15 @@ module RSpec
       # @param out [IO] output stream
       def run(err, out)
         setup(err, out)
-        run_specs(@world.ordered_example_groups).tap do
-          persist_example_statuses
+
+        if RSpec.world.wants_to_quit
+          @configuration.reporter.report(0) do
+            @configuration.failure_exit_code
+          end
+        else
+          run_specs(@world.ordered_example_groups).tap do
+            persist_example_statuses
+          end
         end
       end
 
@@ -95,7 +102,7 @@ module RSpec
       # @param out [IO] output stream
       def setup(err, out)
         configure(err, out)
-        @configuration.load_spec_files
+        @configuration.load_spec_files unless RSpec.world.wants_to_quit
         @world.announce_filters
       end
 

--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -84,15 +84,10 @@ module RSpec
       # @param out [IO] output stream
       def run(err, out)
         setup(err, out)
+        return @configuration.reporter.exit_early(@configuration.failure_exit_code) if RSpec.world.wants_to_quit
 
-        if RSpec.world.wants_to_quit
-          @configuration.reporter.report(0) do
-            @configuration.failure_exit_code
-          end
-        else
-          run_specs(@world.ordered_example_groups).tap do
-            persist_example_statuses
-          end
+        run_specs(@world.ordered_example_groups).tap do
+          persist_example_statuses
         end
       end
 

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -54,6 +54,37 @@ RSpec.describe 'Spec file load errors' do
     EOS
   end
 
+  it 'prints a single error when it happens on --require files' do
+    write_file_formatted "helper_with_error.rb", "raise 'boom'; class Perry; end"
+
+    write_file_formatted "1_spec.rb", "
+      RSpec.describe Perry do
+        it 'will not run this example' do
+          expect(1).to eq 1
+        end
+      end
+    "
+
+    run_command "--require ./helper_with_error 1_spec.rb"
+    expect(last_cmd_exit_status).to eq(failure_exit_code)
+    output = normalize_durations(last_cmd_stdout)
+    expect(output).to eq unindent(<<-EOS)
+
+      An error occurred while loading ./helper_with_error.
+      Failure/Error: raise 'boom'; class Perry; end
+
+      RuntimeError:
+        boom
+      # ./helper_with_error.rb:1#{spec_line_suffix}
+      No examples found.
+
+
+      Finished in n.nnnn seconds (files took n.nnnn seconds to load)
+      0 examples, 0 failures, 1 error occurred outside of examples
+
+    EOS
+  end
+
   it 'nicely handles load-time errors in user spec files' do
     write_file_formatted "1_spec.rb", "
       boom

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -55,13 +55,11 @@ RSpec.describe 'Spec file load errors' do
   end
 
   it 'prints a single error when it happens on --require files' do
-    write_file_formatted "helper_with_error.rb", "raise 'boom'; class Perry; end"
+    write_file_formatted "helper_with_error.rb", "raise 'boom'"
 
     write_file_formatted "1_spec.rb", "
-      RSpec.describe Perry do
-        it 'will not run this example' do
-          expect(1).to eq 1
-        end
+      RSpec.describe 'A broken spec file that will raise when loaded' do
+        raise 'boom'
       end
     "
 
@@ -71,7 +69,7 @@ RSpec.describe 'Spec file load errors' do
     expect(output).to eq unindent(<<-EOS)
 
       An error occurred while loading ./helper_with_error.
-      Failure/Error: raise 'boom'; class Perry; end
+      Failure/Error: raise 'boom'
 
       RuntimeError:
         boom

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Spec file load errors' do
 
     write_file_formatted "1_spec.rb", "
       RSpec.describe 'A broken spec file that will raise when loaded' do
-        raise 'boom'
+        raise 'kaboom'
       end
     "
 

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -165,10 +165,13 @@ module RSpec::Core
         expect(reporter.exit_early(42)).to eq(42)
       end
 
-      it "reports zero examples" do
-        allow(reporter).to receive(:report)
+      it "sends a complete cycle of notifications" do
+        formatter = double("formatter")
+        %w[seed start start_dump dump_pending dump_failures dump_summary seed close].map(&:to_sym).each do |message|
+          reporter.register_listener formatter, message
+          expect(formatter).to receive(message).ordered
+        end
         reporter.exit_early(42)
-        expect(reporter).to have_received(:report).with(0)
       end
     end
 

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -160,6 +160,18 @@ module RSpec::Core
       end
     end
 
+    describe "#exit_early" do
+      it "returns the passed exit code" do
+        expect(reporter.exit_early(42)).to eq(42)
+      end
+
+      it "reports zero examples" do
+        allow(reporter).to receive(:report)
+        reporter.exit_early(42)
+        expect(reporter).to have_received(:report).with(0)
+      end
+    end
+
     describe "#report" do
       it "supports one arg (count)" do
         reporter.report(1) {}


### PR DESCRIPTION
When there's an error loading files specified via the `--require` flag, typically `rails_helper.rb` or `spec_helper.rb`, it's very common that most of the spec files won't load either since they depend on the helper file being loaded. In these situations, one gets hundreds of errors printed to the screen. That can be quite intimidating and contributes to hide the real culprit, which is the load error in the helper.