### PR TITLE
Use RSpec module on describe calls in docs

### DIFF
--- a/features/README.md
+++ b/features/README.md
@@ -1,6 +1,6 @@
 rspec-core provides the structure for RSpec code examples:
 
-    describe Account do
+    RSpec.describe Account do
       it "has a balance of zero when first opened" do
         # example code goes here - for more on the
         # code inside the examples, see rspec-expectations

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1106,7 +1106,7 @@ module RSpec
       #
       #   # This lets you do this:
       #
-      #   describe Thing do
+      #   RSpec.describe Thing do
       #     pending "does something" do
       #       thing = Thing.new
       #     end
@@ -1114,7 +1114,7 @@ module RSpec
       #
       #   # ... which is the equivalent of
       #
-      #   describe Thing do
+      #   RSpec.describe Thing do
       #     it "does something", :pending => true do
       #       thing = Thing.new
       #     end
@@ -1167,7 +1167,7 @@ module RSpec
       #
       #   # allows the user to include a shared example group like:
       #
-      #   describe Entity do
+      #   RSpec.describe Entity do
       #     it_has_behavior 'sortability' do
       #       let(:sortable) { Entity.new }
       #     end
@@ -1718,7 +1718,7 @@ module RSpec
       #     rspec.expose_current_running_example_as :example
       #   end
       #
-      #   describe MyClass do
+      #   RSpec.describe MyClass do
       #     before do
       #       # `example` can be used here because of the above config.
       #       do_something if example.metadata[:type] == "foo"

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -7,7 +7,7 @@ module RSpec
     # ExampleGroup and {Example} are the main structural elements of
     # rspec-core. Consider this example:
     #
-    #     describe Thing do
+    #     RSpec.describe Thing do
     #       it "does something" do
     #       end
     #     end
@@ -90,7 +90,7 @@ module RSpec
       # Returns the class or module passed to the `describe` method (or alias).
       # Returns nil if the subject is not a class or module.
       # @example
-      #     describe Thing do
+      #     RSpec.describe Thing do
       #       it "does something" do
       #         described_class == Thing
       #       end

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -74,11 +74,11 @@ module RSpec
       #       end
       #     end
       #
-      #     describe Something, :authorized => true do
+      #     RSpec.describe Something, :authorized => true do
       #       # The before hook will run in before each example in this group.
       #     end
       #
-      #     describe SomethingElse do
+      #     RSpec.describe SomethingElse do
       #       it "does something", :authorized => true do
       #         # The before hook will run before this example.
       #       end
@@ -159,7 +159,7 @@ module RSpec
       #
       # @example before(:example) declared in an {ExampleGroup}
       #
-      #     describe Thing do
+      #     RSpec.describe Thing do
       #       before(:example) do
       #         @thing = Thing.new
       #       end
@@ -171,7 +171,7 @@ module RSpec
       #
       # @example before(:context) declared in an {ExampleGroup}
       #
-      #     describe Parser do
+      #     RSpec.describe Parser do
       #       before(:context) do
       #         File.open(file_to_parse, 'w') do |f|
       #           f.write <<-CONTENT

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -10,7 +10,7 @@ module RSpec
       # @note `subject` was contributed by Joe Ferris to support the one-liner
       #   syntax embraced by shoulda matchers:
       #
-      #       describe Widget do
+      #       RSpec.describe Widget do
       #         it { is_expected.to validate_presence_of(:name) }
       #         # or
       #         it { should validate_presence_of(:name) }
@@ -23,7 +23,7 @@ module RSpec
       # @example
       #
       #   # Explicit declaration of subject.
-      #   describe Person do
+      #   RSpec.describe Person do
       #     subject { Person.new(:birthdate => 19.years.ago) }
       #     it "should be eligible to vote" do
       #       subject.should be_eligible_to_vote
@@ -32,7 +32,7 @@ module RSpec
       #   end
       #
       #   # Implicit subject => { Person.new }.
-      #   describe Person do
+      #   RSpec.describe Person do
       #     it "should be eligible to vote" do
       #       subject.should be_eligible_to_vote
       #       # ^ ^ explicit reference to subject not recommended
@@ -40,7 +40,7 @@ module RSpec
       #   end
       #
       #   # One-liner syntax - expectation is set on the subject.
-      #   describe Person do
+      #   RSpec.describe Person do
       #     it { is_expected.to be_eligible_to_vote }
       #     # or
       #     it { should be_eligible_to_vote }
@@ -67,7 +67,7 @@ module RSpec
       #
       # @example
       #
-      #   describe Person do
+      #   RSpec.describe Person do
       #     it { should be_eligible_to_vote }
       #   end
       #
@@ -86,7 +86,7 @@ module RSpec
       #
       # @example
       #
-      #   describe Person do
+      #   RSpec.describe Person do
       #     it { should_not be_eligible_to_vote }
       #   end
       #
@@ -270,7 +270,7 @@ EOS
         #
         # @example
         #
-        #   describe Thing do
+        #   RSpec.describe Thing do
         #     let(:thing) { Thing.new }
         #
         #     it "does something" do
@@ -323,7 +323,7 @@ EOS
         #     end
         #   end
         #
-        #   describe Thing do
+        #   RSpec.describe Thing do
         #     after(:example) { Thing.reset_count }
         #
         #     context "using let" do
@@ -379,13 +379,13 @@ EOS
         #
         # @example
         #
-        #   describe CheckingAccount, "with $50" do
+        #   RSpec.describe CheckingAccount, "with $50" do
         #     subject { CheckingAccount.new(Money.new(50, :USD)) }
         #     it { is_expected.to have_a_balance_of(Money.new(50, :USD)) }
         #     it { is_expected.not_to be_overdrawn }
         #   end
         #
-        #   describe CheckingAccount, "with a non-zero starting balance" do
+        #   RSpec.describe CheckingAccount, "with a non-zero starting balance" do
         #     subject(:account) { CheckingAccount.new(Money.new(50, :USD)) }
         #     it { is_expected.not_to be_overdrawn }
         #     it "has a balance equal to the starting balance" do
@@ -433,7 +433,7 @@ EOS
         #     end
         #   end
         #
-        #   describe Thing do
+        #   RSpec.describe Thing do
         #     after(:example) { Thing.reset_count }
         #
         #     context "using subject" do

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -7,7 +7,7 @@ module RSpec
     # In addition to metadata that is used internally, this also stores
     # user-supplied metadata, e.g.
     #
-    #     describe Something, :type => :ui do
+    #     RSpec.describe Something, :type => :ui do
     #       it "does something", :slow => true do
     #         # ...
     #       end

--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -76,7 +76,7 @@ module RSpec
       #     end
       #   end
       #
-      #   describe Account do
+      #   RSpec.describe Account do
       #     it_behaves_like "auditable" do
       #       let(:auditable) { Account.new }
       #     end


### PR DESCRIPTION
Hello! I've noticed that the README in https://relishapp.com/rspec/rspec-core/v/3-8/docs didn't use the `RSpec` module on the describe call; the module is used in mostly all examples across the documentation: [[1]](https://relishapp.com/rspec/rspec-core/v/3-8/docs/subject/implicitly-defined-subject), [[2]](https://relishapp.com/rspec/rspec-core/v/3-8/docs/subject/explicit-subject), [[3]](https://relishapp.com/rspec/rspec-core/v/3-8/docs/formatters/configurable-colors).

I've took the opportunity to also update other places that didn't use the RSpec module. 

To find those I used this regex, just in case is useful to someone: `\sdescribe [A-Z]` (any describe prefixed with a space where the subject starts with a capital letter, presumably a class)