### PR TITLE
Replace "should" with "is expected to" in Generated Descriptions

### DIFF
--- a/features/command_line/line_number_appended_to_path.feature
+++ b/features/command_line/line_number_appended_to_path.feature
@@ -155,5 +155,5 @@ Feature: line number appended to file path
   Scenario: Matching one-liners
     When I run `rspec one_liner_spec.rb:3 --format doc`
     Then the examples should all pass
-    Then the output should contain "should be > 8"
-    But the output should not contain "should be < 10"
+    Then the output should contain "is expected to be > 8"
+    But the output should not contain "is expected to be < 10"

--- a/features/subject/one_liner_syntax.feature
+++ b/features/subject/one_liner_syntax.feature
@@ -46,8 +46,8 @@ Feature: One-liner syntax
        """
        Array
          when first created
-           should be empty
-           should be empty
+           is expected to be empty
+           is expected to be empty
        """
 
   Scenario: Explicit subject
@@ -68,6 +68,6 @@ Feature: One-liner syntax
        """
        Array
          with 3 items
-           should not be empty
-           should not be empty
+           is expected not to be empty
+           is expected not to be empty
        """

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -187,13 +187,13 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       it "uses the matcher-generated description" do
         example_group.example { expect(5).to eq(5) }
         example_group.run
-        expect(example_group.examples.first.description).to eq("should eq 5")
+        expect(example_group.examples.first.description).to eq("is expected to eq 5")
       end
 
       it "uses the matcher-generated description in the full description" do
         example_group.example { expect(5).to eq(5) }
         example_group.run
-        expect(example_group.examples.first.full_description).to eq("group description should eq 5")
+        expect(example_group.examples.first.full_description).to eq("group description is expected to eq 5")
       end
 
       it "uses the file and line number if there is no matcher-generated description" do
@@ -213,7 +213,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
         it "still uses the matcher-generated description if a matcher ran" do
           example = example_group.example { pending; expect(4).to eq(5) }
           example_group.run
-          expect(example.description).to eq("should eq 5")
+          expect(example.description).to eq("is expected to eq 5")
         end
 
         it "uses the file and line number of the example if no matcher ran" do
@@ -232,7 +232,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
             after { raise "boom" }
           end.run
 
-          expect(ex.description).to eq("should eq 2")
+          expect(ex.description).to eq("is expected to eq 2")
         end
       end
 
@@ -268,7 +268,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
             after { expect(true).to eq(true) }
           end.run
 
-          expect(ex).to pass.and have_attributes(:description => "should be nil")
+          expect(ex).to pass.and have_attributes(:description => "is expected to be nil")
         end
       end
     end
@@ -279,7 +279,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       it "uses the matcher-generated description" do
         example_group.example { expect(5).to eq(5) }
         example_group.run
-        expect(example_group.examples.first.description).to eq("should eq 5")
+        expect(example_group.examples.first.description).to eq("is expected to eq 5")
       end
 
       it "uses the file and line number if there is no matcher-generated description" do

--- a/spec/rspec/core/pending_example_spec.rb
+++ b/spec/rspec/core/pending_example_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "an example" do
           end
         end.run
 
-        expect(ex.description).to eq('should eq "gnirts"')
+        expect(ex.description).to eq('is expected to eq "gnirts"')
       end
     end
 


### PR DESCRIPTION
#### Context

Described in more detail in https://github.com/rspec/rspec-expectations/pull/1080

#### Change

 - Fix specs that broke in https://travis-ci.org/rspec/rspec-expectations/builds/440916268?utm_source=github_status&utm_medium=notification
 - Fix cucumbers