### PR TITLE
Clarify @tag (cuke style) functionality in documentation

### DIFF
--- a/features/command_line/tag.feature
+++ b/features/command_line/tag.feature
@@ -17,7 +17,8 @@ Feature: `--tag` option
   `:name => 'bar'`.
 
   To be compatible with the Cucumber syntax, tags can optionally start with an
-  `@` symbol, which will be ignored.
+  `@` symbol, which will be ignored as part of the tag, e.g. `--tag @focus` is
+  treated the same as `--tag focus` and is expanded to `:focus => true`.
 
   Background:
     Given a file named "tagged_spec.rb" with:


### PR DESCRIPTION
With the previous documentation, it was unclear if the passed in tag using the `@` (cucumber style tagging) would be ignored similar to doing `~tag` (for `--tag @tag`), or if it would "ignore" the `@` when building the configuration option (`@tag` changes to `:tag`).

Looking at the implementation in `lib/rspec/core/option_parser.rb` confirms that it is the latter, so the wording has been updated to make that more clear.

* * *

I was reading through this documentation myself recently, and was unsure when I read this what this did, so this is simply phrasing it in a way that made it more clear to me.

Open to suggestions for a better way to phrase this.