### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.metadata = {
     'bug_tracker_uri'   => 'https://github.com/rspec/rspec-core/issues',
     'changelog_uri'     => 'https://github.com/rspec/rspec-core/blob/master/Changelog.md',
-    'documentation_uri' => 'https://relishapp.com/rspec/rspec-core/docs',
+    'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
     'source_code_uri'   => 'https://github.com/rspec/rspec-core',
   }

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri'   => 'https://github.com/rspec/rspec-core/issues',
-    'changelog_uri'     => 'https://github.com/rspec/rspec-core/blob/master/Changelog.md',
+    'changelog_uri'     => "https://github.com/rspec/rspec-core/blob/v#{s.version}/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
     'source_code_uri'   => 'https://github.com/rspec/rspec-core',

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -13,6 +13,14 @@ Gem::Specification.new do |s|
   s.summary     = "rspec-core-#{RSpec::Core::Version::STRING}"
   s.description = "BDD for Ruby. RSpec runner and example groups."
 
+  s.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/rspec/rspec-core/issues',
+    'changelog_uri'     => 'https://github.com/rspec/rspec-core/blob/master/Changelog.md',
+    'documentation_uri' => 'https://relishapp.com/rspec/rspec-core/docs',
+    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
+    'source_code_uri'   => 'https://github.com/rspec/rspec-core',
+  }
+
   s.files            = `git ls-files -- lib/*`.split("\n")
   s.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
   s.test_files       = []


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `mailing_list_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/rspec-core after the next release.