### PR TITLE
Handle RSpec description with japanese char in CP932 encoded files

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ before_test:
   - bundle --version
 
 test_script:
-  - bundle exec rspec --backtrace
+  - chcp 65001 && bundle exec rspec --backtrace
 
 environment:
   matrix:

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -81,7 +81,7 @@ module RSpec
 
         def fully_formatted_lines(failure_number, colorizer)
           lines = [
-            description,
+            encoded_description(description),
             detail_formatter.call(example, colorizer),
             formatted_message_and_backtrace(colorizer),
             extra_detail_formatter.call(failure_number, colorizer),
@@ -241,6 +241,16 @@ module RSpec
           encoding = encoding_of("")
           lines.map do |line|
             RSpec::Support::EncodedString.new(line, encoding)
+          end
+        end
+
+        def encoded_description(description)
+          return if description.nil?
+
+          if String.method_defined?(:encoding)
+            encoded_string(description)
+          else # for 1.8.7
+            description
           end
         end
 

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -244,12 +244,13 @@ module RSpec
           end
         end
 
-        def encoded_description(description)
-          return if description.nil?
-
-          if String.method_defined?(:encoding)
+        if  String.method_defined?(:encoding)
+          def encoded_description(description)
+            return if description.nil?
             encoded_string(description)
-          else # for 1.8.7
+          end
+        else # for 1.8.7
+          def encoded_description(description)
             description
           end
         end

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -94,6 +94,23 @@ module RSpec::Core
         EOS
       end
 
+      if String.method_defined?(:encoding)
+        it 'allows the caller to add encoded description' do
+          the_presenter = Formatters::ExceptionPresenter.new(exception, example,
+                                                             :description => "ジ".encode("CP932"))
+
+          expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |  1) ジ
+          |     Failure/Error: # The failure happened here!#{ encoding_check }
+          |
+          |       Boom
+          |       Bam
+          |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+          EOS
+        end
+      end
+
       it 'allows the caller to omit the description' do
         the_presenter = Formatters::ExceptionPresenter.new(exception, example,
                                                        :detail_formatter => Proc.new { "Detail!" },


### PR DESCRIPTION
When the user create a test with CP932 encoding and japanese chars RSpec
fail to properly display characters or crash with the error:

>  Encoding::CompatibilityError: incompatible character encodings: Windows-31J and UTF-8

Fix:
- https://github.com/rspec/rspec-core/issues/2570
- https://github.com/rspec/rspec-core/issues/2543