### PR TITLE
fixed warning: Object#=~ is deprecated; it always returns nil

### DIFF
--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -169,7 +169,7 @@ module RSpec
         end
 
         def description_separator(parent_part, child_part)
-          if parent_part.is_a?(Module) && child_part =~ /^(#|::|\.)/
+          if parent_part.is_a?(Module) && /^(?:#|::|\.)/.match(child_part.to_s)
             ''.freeze
           else
             ' '.freeze


### PR DESCRIPTION
ruby 2.6.0-rc1 was released.
https://www.ruby-lang.org/en/news/2018/12/06/ruby-2-6-0-rc1-released/

When I tested on 2.6.0-rc1. Following warnings is outputted:

```
$ bundle exec ./exe/rspec
/lib/rspec/core/metadata.rb:172: warning: Object#=~ is deprecated; it always returns nil
```

SEE ALSO: https://bugs.ruby-lang.org/issues/15231

