### PR TITLE
Make specs and features global configuration proof

### DIFF
--- a/features/command_line/init.feature
+++ b/features/command_line/init.feature
@@ -25,6 +25,7 @@ Feature: `--init` option
   Scenario: Accept and use the recommended settings in `spec_helper` (which are initially commented out)
     Given I have a brand new project with no files
       And I have run `rspec --init`
+      And I unset XDG_CONFIG_HOME environment var
      When I accept the recommended settings by removing `=begin` and `=end` from `spec/spec_helper.rb`
       And I create "spec/addition_spec.rb" with the following content:
         """ruby

--- a/features/command_line/warnings_option.feature
+++ b/features/command_line/warnings_option.feature
@@ -25,5 +25,6 @@ Feature: `--warnings` option (run with warnings enabled)
         end
       end
       """
+    And I unset XDG_CONFIG_HOME environment var
     When I run `rspec example_spec.rb`
     Then the output should not contain "warning"

--- a/features/configuration/profile.feature
+++ b/features/configuration/profile.feature
@@ -73,6 +73,7 @@ Feature: Profile examples
       """
 
   Scenario: By default does not show profile
+    Given I unset XDG_CONFIG_HOME environment var
     When I run `rspec spec`
     Then the examples should all pass
     And the output should not contain "example 1"
@@ -92,6 +93,7 @@ Feature: Profile examples
       """ruby
       RSpec.configure { |c| c.profile_examples = true }
       """
+    And I unset XDG_CONFIG_HOME environment var
     When I run `rspec spec`
     Then the examples should all pass
     And the output should contain "Top 10 slowest examples"

--- a/features/formatters/configurable_colors.feature
+++ b/features/formatters/configurable_colors.feature
@@ -27,5 +27,6 @@ Feature: Configurable colors
         end
       end
       """
-      When I run `rspec custom_failure_color_spec.rb --format progress`
-      Then the failing example is printed in magenta
+    And I unset XDG_CONFIG_HOME environment var
+    When I run `rspec custom_failure_color_spec.rb --format progress`
+    Then the failing example is printed in magenta

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -238,6 +238,13 @@ Given(/^I have changed `([^`]+)` to `([^`]+)` in "(.*?)"$/) do |old_code, new_co
   end
 end
 
+Given(/^I unset XDG_CONFIG_HOME environment var$/) do
+  step %q{I set the environment variables to:}, table(%{
+  | variable        | value |
+  | XDG_CONFIG_HOME |       |
+  })
+end
+
 module Normalization
   def normalize_failure_output(text)
     whitespace_normalized = text.lines.map { |line| line.sub(/\s+$/, '').sub(/:in .*$/, '') }.join

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Spec file load errors' do
     EOS
   end
 
-  it 'nicely handles load-time errors in user spec files' do
+  it 'nicely handles load-time errors in user spec files', :isolated_home => true do
     write_file_formatted "1_spec.rb", "
       boom
 

--- a/spec/integration/suite_hooks_errors_spec.rb
+++ b/spec/integration/suite_hooks_errors_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Suite hook errors' do
     normalize_durations(last_cmd_stdout)
   end
 
-  it 'nicely formats errors in `before(:suite)` hooks and exits with non-zero' do
+  it 'nicely formats errors in `before(:suite)` hooks and exits with non-zero', :isolated_home => true do
     output = run_spec_expecting_non_zero(:before)
     expect(output).to eq unindent(<<-EOS)
 
@@ -67,7 +67,7 @@ RSpec.describe 'Suite hook errors' do
     EOS
   end
 
-  it 'nicely formats errors in `after(:suite)` hooks and exits with non-zero' do
+  it 'nicely formats errors in `after(:suite)` hooks and exits with non-zero', :isolated_home => true do
     output = run_spec_expecting_non_zero(:after)
     expect(output).to eq unindent(<<-EOS)
       .
@@ -85,7 +85,7 @@ RSpec.describe 'Suite hook errors' do
     EOS
   end
 
-  it 'nicely formats errors from multiple :suite hooks of both types and exits with non-zero' do
+  it 'nicely formats errors from multiple :suite hooks of both types and exits with non-zero', :isolated_home => true do
     write_file "the_spec.rb", "
       RSpec.configure do |c|
         c.before(:suite) { raise 'before 1' }

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -100,7 +100,7 @@ root
     end
 
     # The backtrace is slightly different on JRuby/Rubinius so we skip there.
-    it 'produces the expected full output', :if => RSpec::Support::Ruby.mri? do
+    it 'produces the expected full output', :isolated_home => true, :if => RSpec::Support::Ruby.mri? do
       output = run_example_specs_with_formatter("doc")
       output.gsub!(/ +$/, '') # strip trailing whitespace
 

--- a/spec/rspec/core/formatters/html_formatter_spec.rb
+++ b/spec/rspec/core/formatters/html_formatter_spec.rb
@@ -57,8 +57,8 @@ module RSpec
           end
         end
 
-        describe 'produced HTML', :slow, :if => RUBY_VERSION >= '2.0.0' do
-          it "is identical to the one we designed manually", :pending => (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby') do
+        describe 'produced HTML', :slow, :isolated_home => true, :if => RUBY_VERSION >= '2.0.0' do
+          it 'is identical to the one we designed manually', :pending => (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby') do
             expect(actual_html).to eq(expected_html)
           end
 

--- a/spec/rspec/core/formatters/progress_formatter_spec.rb
+++ b/spec/rspec/core/formatters/progress_formatter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RSpec::Core::Formatters::ProgressFormatter do
   end
 
   # The backtrace is slightly different on JRuby/Rubinius so we skip there.
-  it 'produces the expected full output', :if => RSpec::Support::Ruby.mri? do
+  it 'produces the expected full output', :isolated_home => true, :if => RSpec::Support::Ruby.mri? do
     output = run_example_specs_with_formatter("progress")
     output.gsub!(/ +$/, '') # strip trailing whitespace
 

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -69,6 +69,12 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:18
         |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/isolated_home_directory.rb:13
+        |     # ./spec/spec_helper.rb:46:in `with_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:12
+        |     # ./spec/spec_helper.rb:57:in `without_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:11
+        |     # ./spec/support/isolated_home_directory.rb:7
         |     # ./spec/support/sandboxing.rb:16
         |     # ./spec/support/sandboxing.rb:7
         |
@@ -89,6 +95,12 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:37
         |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/isolated_home_directory.rb:13
+        |     # ./spec/spec_helper.rb:46:in `with_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:12
+        |     # ./spec/spec_helper.rb:57:in `without_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:11
+        |     # ./spec/support/isolated_home_directory.rb:7
         |     # ./spec/support/sandboxing.rb:16
         |     # ./spec/support/sandboxing.rb:7
         |
@@ -164,6 +176,12 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:18:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/isolated_home_directory.rb:13:in `block (5 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:46:in `with_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:12:in `block (4 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:57:in `without_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:11:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/isolated_home_directory.rb:7:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
@@ -184,6 +202,12 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/isolated_home_directory.rb:13:in `block (5 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:46:in `with_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:12:in `block (4 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:57:in `without_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:11:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/isolated_home_directory.rb:7:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |
@@ -215,6 +239,12 @@ module FormatterSupport
         |     # ./spec/rspec/core/resources/formatter_specs.rb:50:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
+        |     # ./spec/support/isolated_home_directory.rb:13:in `block (5 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:46:in `with_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:12:in `block (4 levels) in <top (required)>'
+        |     # ./spec/spec_helper.rb:57:in `without_env_vars'
+        |     # ./spec/support/isolated_home_directory.rb:11:in `block (3 levels) in <top (required)>'
+        |     # ./spec/support/isolated_home_directory.rb:7:in `block (2 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
         |


### PR DESCRIPTION
If a `~/.config/rspec/options` file contains the following:

    --color
    --profile 2
    --format progress
    --require pry

some specs and features fail, since they are run with options that
contradict the default ones, and expectations are not met.

Example failures:

     (RSpec::Expectations::ExpectationNotMetError)
    features/verifying_doubles/partial_doubles.feature:34:in `Then the output should contain "1 example, 1 failure"'
    ...
    LoadError:
      cannot load such file -- pry


    6) RSpec::Core::Formatters::ProgressFormatter produces the expected full output
    ...
       +Top 2 slowest example groups:
       +  pending command with block format
       +    n.nnnn seconds average (n.nnnn seconds / 2 examples) ./spec/rspec/core/resources/formatter_specs.rb:14
       +  failing spec
       +    n.nnnn seconds average (n.nnnn seconds / 2 examples) ./spec/rspec/core/resources/formatter_specs.rb:35
       +


This fixes https://github.com/rspec/rspec-dev/issues/217. Similar issues affect features of `rspec-mocks` and `rspec-expectations`, will send out pull requests shortly.

*NOTE*: Unfortunately, this doesn't fix the issue for configuration stored in `~/.rspec`. My advice is to move it over to `~/.config/rspec/options`.

*NOTE*: Unfortunately, this doesn't fix the issue for `--require pry` for features.