### PR TITLE
Add thousand spec

### DIFF
--- a/spec/integration/thousand_spec.rb
+++ b/spec/integration/thousand_spec.rb
@@ -10,7 +10,7 @@ module RSpec::Core
           yield dir
           start = Time.now
           path = File.absolute_path(Bundler.which(cmd))
-          Open3.popen3(path + ' ' + args.join(" "), chdir: dir) do |_, stdout, stderr|
+          Open3.popen3(path + ' ' + args.join(" "), :chdir => dir) do |_, stdout, stderr|
             stdout.read
             stderr.read
           end

--- a/spec/integration/thousand_spec.rb
+++ b/spec/integration/thousand_spec.rb
@@ -1,88 +1,109 @@
-require 'open3'
+require 'rspec/support/spec/in_sub_process'
 
 module RSpec::Core
-  RSpec.describe "Rspec", :slow do
-    def measure(cmd, *args)
-      Dir.mktmpdir do |dir|
-        yield dir
-        start = Time.now
-        path = File.absolute_path(Bundler.which(cmd))
-        Open3.popen3(path + ' ' + args.join(" "), chdir: dir) do |_, stdout, stderr|
-          stdout.read
-          stderr.read
+  include RSpec::Support::InSubProcess
+
+  if RUBY_VERSION.to_f >= 2.2
+    RSpec.describe "RSpec", :slow do
+      def measure(cmd, *args)
+        Dir.mktmpdir do |dir|
+          yield dir
+          start = Time.now
+          path = File.absolute_path(Bundler.which(cmd))
+          Open3.popen3(path + ' ' + args.join(" "), chdir: dir) do |_, stdout, stderr|
+            stdout.read
+            stderr.read
+          end
+          return Time.now - start
         end
-        return Time.now - start
       end
-    end
 
-    # Calculates how many tests / second given tool can run
-    def benchmark(files, tests, delay)
-      minitest_timing = measure 'ruby', 'test.rb' do |dir|
-        File.write File.join(dir, 'test.rb'), """
-          $:<<'spec'  # add to load path
-          files = Dir.glob('spec/**/*.rb')
-          files.each{|file| require file.gsub(/^spec\\/|\\.rb$/,'')}
-        """
-
-        Dir.mkdir File.join(dir, 'spec')
-        files.times do |i|
-          File.write File.join(dir, 'spec', "test#{i}_spec.rb"), """
-            require 'minitest/autorun'
-            class TestMeme#{i} < Minitest::Test
-              def setup
-                sleep(#{delay/2})
-                @answer = 42
-              end
-          """ + (1..tests).map { |j| """
-              def test_#{j}
-                sleep(#{delay/2})
-                assert_equal @answer + #{j}, #{42 + j}
-              end
-          """ }.join("\n") + """
-            end
+      # Calculates how many tests / second given tool can run
+      def benchmark(files, tests, delay)
+        ruby_timing = measure 'ruby', 'test.rb' do |dir|
+          File.write File.join(dir, 'test.rb'), """
+            $:<<'spec'  # add to load path
+            files = Dir.glob('spec/**/*.rb')
+            files.each{|file| require file.gsub(/^spec\\/|\\.rb$/,'')}
           """
+
+          Dir.mkdir File.join(dir, 'spec')
+          files.times do |i|
+            File.write File.join(dir, 'spec', "test#{i}_spec.rb"), """
+              require 'test/unit'
+
+              class TestMeme#{i} < Test::Unit::TestCase
+                def setup
+                  sleep(#{delay/2})
+                  @answer = 42
+                end
+            """ + (1..tests).map { |j| """
+                def test_simple_#{j}
+                  sleep(#{delay/2})
+                  assert_equal(#{42 + j}, @answer + #{j})
+                end
+            """ }.join("\n") + """
+              end
+            """
+          end
+        end
+
+        rspec_timing = measure('exe/rspec') do |dir|
+          Dir.mkdir File.join(dir, 'spec')
+          files.times do |i|
+            File.write File.join(dir, 'spec', "test#{i}_spec.rb"), """
+              RSpec.describe 'test#{i}' do
+                before(:each) do
+                  sleep(#{delay/2})
+                  @answer = 42
+                end
+            """ + (1..tests).map { |j| """
+                it 'works' do
+                  sleep(#{delay/2})
+                  expect(@answer + #{j}).to be(#{42 + j})
+                end
+            """ }.join("\n") + """
+              end
+            """
+          end
+        end
+
+        [
+          rspec_timing,
+          ruby_timing
+        ]
+      end
+
+      it 'executes 1000 tiny specs in 100 files as fast as minitest' do
+        in_sub_process do
+          require 'bundler'
+          require 'open3'
+
+          rspec_timing, ruby_timing = benchmark(100, 10, 0.0001)
+          expect(rspec_timing / ruby_timing).to be < 1.2 # can we do better?
         end
       end
 
-      rspec_timing = measure('exe/rspec') do |dir|
-        Dir.mkdir File.join(dir, 'spec')
-        files.times do |i|
-          File.write File.join(dir, 'spec', "test#{i}_spec.rb"), """
-            RSpec.describe 'test#{i}' do
-              before(:each) do
-                sleep(#{delay/2})
-                @answer = 42
-              end
-          """ + (1..tests).map { |j| """
-              it 'works' do
-                sleep(#{delay/2})
-                expect(@answer + #{j}).to be(#{42 + j})
-              end
-          """ }.join("\n") + """
-            end
-          """
+      it 'executes 1000 small specs in 100 files as fast as minitest' do
+        in_sub_process do
+          require 'bundler'
+          require 'open3'
+
+          rspec_timing, ruby_timing = benchmark(100, 10, 0.001)
+          expect(rspec_timing / ruby_timing).to be < 1.1 # can we do better?
         end
       end
 
-      [
-        rspec_timing,
-        minitest_timing
-      ]
-    end
+      it 'executes 100 specs in 50 files as fast as minitest' do
+        in_sub_process do
+          require 'bundler'
+          require 'open3'
 
-    it 'executes 1000 tiny specs in 100 files as fast as minitest' do
-      rspec_timing, minitest_timing = benchmark(100, 10, 0.0001)
-      expect(rspec_timing / minitest_timing).to be < 1.6 # can we do better?
-    end
-
-    it 'executes 1000 small specs in 100 files as fast as minitest' do
-      rspec_timing, minitest_timing = benchmark(100, 10, 0.001)
-      expect(rspec_timing / minitest_timing).to be < 1.2 # can we do better?
-    end
-
-    it 'executes 100 specs in 50 files as fast as minitest' do
-      rspec_timing, minitest_timing = benchmark(50, 2, 0.01)
-      expect(rspec_timing / minitest_timing).to be < 1.1 # can we do better?
+          rspec_timing, ruby_timing = benchmark(50, 2, 0.01)
+          expect(rspec_timing / ruby_timing).to be < 1.05 # can we do better?
+        end
+      end
     end
   end
+
 end

--- a/spec/integration/thousand_spec.rb
+++ b/spec/integration/thousand_spec.rb
@@ -1,0 +1,88 @@
+require 'open3'
+
+module RSpec::Core
+  RSpec.describe "Rspec", :slow do
+    def measure(cmd, *args)
+      Dir.mktmpdir do |dir|
+        yield dir
+        start = Time.now
+        path = File.absolute_path(Bundler.which(cmd))
+        Open3.popen3(path + ' ' + args.join(" "), chdir: dir) do |_, stdout, stderr|
+          stdout.read
+          stderr.read
+        end
+        return Time.now - start
+      end
+    end
+
+    # Calculates how many tests / second given tool can run
+    def benchmark(files, tests, delay)
+      minitest_timing = measure 'ruby', 'test.rb' do |dir|
+        File.write File.join(dir, 'test.rb'), """
+          $:<<'spec'  # add to load path
+          files = Dir.glob('spec/**/*.rb')
+          files.each{|file| require file.gsub(/^spec\\/|\\.rb$/,'')}
+        """
+
+        Dir.mkdir File.join(dir, 'spec')
+        files.times do |i|
+          File.write File.join(dir, 'spec', "test#{i}_spec.rb"), """
+            require 'minitest/autorun'
+            class TestMeme#{i} < Minitest::Test
+              def setup
+                sleep(#{delay/2})
+                @answer = 42
+              end
+          """ + (1..tests).map { |j| """
+              def test_#{j}
+                sleep(#{delay/2})
+                assert_equal @answer + #{j}, #{42 + j}
+              end
+          """ }.join("\n") + """
+            end
+          """
+        end
+      end
+
+      rspec_timing = measure('exe/rspec') do |dir|
+        Dir.mkdir File.join(dir, 'spec')
+        files.times do |i|
+          File.write File.join(dir, 'spec', "test#{i}_spec.rb"), """
+            RSpec.describe 'test#{i}' do
+              before(:each) do
+                sleep(#{delay/2})
+                @answer = 42
+              end
+          """ + (1..tests).map { |j| """
+              it 'works' do
+                sleep(#{delay/2})
+                expect(@answer + #{j}).to be(#{42 + j})
+              end
+          """ }.join("\n") + """
+            end
+          """
+        end
+      end
+
+      [
+        rspec_timing,
+        minitest_timing
+      ]
+    end
+
+    it 'executes 1000 tiny specs in 100 files as fast as minitest' do
+      rspec_timing, minitest_timing = benchmark(100, 10, 0.0001)
+      expect(rspec_timing / minitest_timing).to be < 1.6 # can we do better?
+    end
+
+    it 'executes 1000 small specs in 100 files as fast as minitest' do
+      rspec_timing, minitest_timing = benchmark(100, 10, 0.001)
+      expect(rspec_timing / minitest_timing).to be < 1.2 # can we do better?
+    end
+
+    it 'executes 100 specs in 50 files as fast as minitest' do
+      rspec_timing, minitest_timing = benchmark(50, 2, 0.01)
+      expect(rspec_timing / minitest_timing).to be < 1.1 # can we do better?
+    end
+  end
+end


### PR DESCRIPTION
Hello :)

I'd like to contribute something I've called "thousand spec" that tests real world performance of executing specs of different sizes, from .5ms to 10ms. Tests spawn external processes so we're 100% sure whole thing is correctly measured.

I hope in the future this test will be expanded to include more real-world code, but I think for now is good enough and does few important things:

1. It is a regression test so rspec real-world performance isn't slower than its main competitor
2. Tells rspec how much overhead rspec currently have compared to its main competitor

It turns out RSpec is just max 1.1 (normal tests) - 1.6 (micro tests) times slower

Let's improve this 🔥 