### PR TITLE
Hyperlink failed examples

### DIFF
--- a/features/formatters/hyperlinks.feature
+++ b/features/formatters/hyperlinks.feature
@@ -1,0 +1,52 @@
+Feature: hyperlinks
+
+  RSpec allows text formatters to use shell escape codes to hyperlink to the files of failed examples.
+
+  * `hyperlink`: Should hyperlinks be displayed (default: `false`)
+
+  @keep-ansi-escape-sequences
+  Scenario: Hyperlinking failed examples
+    Given a file named "hyperlinks_spec.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.hyperlink = true
+      end
+
+      RSpec.describe "failure" do
+        it "fails and includes a hyperlink" do
+          expect(2).to eq(4)
+        end
+      end
+      """
+      When I run `rspec hyperlinks_spec.rb --format progress`
+      Then the failed example includes shell hyperlink escape codes
+
+  @keep-ansi-escape-sequences
+  Scenario: Hyperlinking failed shared examples
+    Given a file named "hyperlinks_in_shared_examples_spec.rb" with:
+      """ruby
+      RSpec.configure do |config|
+        config.hyperlink = true
+      end
+
+      RSpec.describe "shared examples" do
+        shared_examples_for "failure" do
+          it "fails and includes a hyperlink" do
+            expect(2).to eq(4)
+          end
+        end
+
+        context "first" do
+          it_behaves_like "failure"
+        end
+
+        context "second" do
+          it_behaves_like "failure"
+        end
+      end
+      """
+      When I run `rspec hyperlinks_in_shared_examples_spec.rb --format progress`
+      Then the failed shared examples includes shell hyperlink escape codes
+
+
+

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -82,6 +82,24 @@ Then /^the failing example is printed in magenta$/ do
   expect(all_output).to include("\e[35m" + "F" + "\e[0m")
 end
 
+Then /^the failed example includes shell hyperlink escape codes$/ do
+  open = "\e\\]8;;"
+  divider = "\e\\\\"
+  close = "\e\\]8;;"
+  uri = "rspec://.*/hyperlinks_spec.rb:6"
+  text = "./hyperlinks_spec.rb:6"
+  expect(all_output).to match(Regexp.new(open + uri + divider + text + close))
+end
+
+Then /^the failed shared examples includes shell hyperlink escape codes$/ do
+  open = "\e\\]8;;"
+  divider = "\e\\\\"
+  close = "\e\\]8;;"
+  uri = "rspec://.*/hyperlinks_in_shared_examples_spec.rb:7"
+  text = "./hyperlinks_in_shared_examples_spec.rb\\[[\\d:]+\\]"
+  expect(all_output).to match(Regexp.new(open + uri + divider + text + close))
+end
+
 Then /^the output from `([^`]+)` should contain "(.*?)"$/  do |cmd, expected_output|
   step %Q{I run `#{cmd}`}
   step %Q{the output from "#{cmd}" should contain "#{expected_output}"}

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -341,6 +341,11 @@ module RSpec
       add_setting :detail_color
 
       # @macro add_setting
+      # Hyperlink failed examples (default: `false`).
+      # @return [Boolean]
+      add_setting :hyperlink
+
+      # @macro add_setting
       # Don't print filter info i.e. "Run options: include {:focus=>true}"
       # (default `false`).
       # return [Boolean]

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -397,10 +397,17 @@ module RSpec::Core
 
       include RSpec::Core::ShellEscape
 
+      def hyperlink(example, text)
+        return text unless RSpec.configuration.hyperlink
+
+        uri = "rspec://#{File.expand_path(example.location)}"
+        "\e]8;;#{uri}\e\\#{text}\e]8;;\e\\\n"
+      end
+
       def rerun_argument_for(example)
         location = example.location_rerun_argument
-        return location unless duplicate_rerun_locations.include?(location)
-        conditionally_quote(example.id)
+        return hyperlink(example, location) unless duplicate_rerun_locations.include?(location)
+        conditionally_quote(hyperlink(example, example.id))
       end
 
       def duplicate_rerun_locations

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -140,6 +140,10 @@ module RSpec::Core
           options[:color_mode] = :automatic
         end
 
+        parser.on('--hyperlink', 'Enable shell hyperlinks') do |_o|
+          options[:hyperlink] = true
+        end
+
         parser.on('--force-color', '--force-colour', 'Force the output to be in color, even if the output is not a TTY') do |_o|
           if options[:color_mode] == :off
             abort "Please only use one of `--force-color` and `--no-color`"


### PR DESCRIPTION
Allow users to click on failed examples and have them open in their editor. Uses [terminal hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) to encode the file path in the output.

Unfortunately the file:// uri scheme doesn't have a way to specify line numbers. To get around this I've had to use a custom rspec:// uri scheme (naming open suggestions). The user registers a [custom handler](http://edoceo.com/howto/xfce-custom-uri-handler) for the rspec:// uri scheme. E.g.,

```
[Desktop Entry]
Name=RSpec uri scheme
GenericName=Open spec failures in your faviourite text editor
TryExec=gvim
Exec=rspec-scheme-handler %u
Terminal=false
Type=Application
Keywords=Text;editor;
Icon=gvim
Categories=Utility;TextEditor;
StartupNotify=true
MimeType=x-scheme-handler/rspec
X-Desktop-File-Install-Version=0.23
```

and write a wrapper to extract the path and line number like so:

```
#!/bin/bash

url=${1#rspec://}
filename=${url%%:*}
line=${url##*:}

gvim --servername GVIM --remote-tab +$line $filename
```