### PR TITLE
Rename minimal formatter to failure list formatter

### DIFF
--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -74,7 +74,7 @@ module RSpec::Core::Formatters
   autoload :JsonFormatter,            'rspec/core/formatters/json_formatter'
   autoload :BisectDRbFormatter,       'rspec/core/formatters/bisect_drb_formatter'
   autoload :ExceptionPresenter,       'rspec/core/formatters/exception_presenter'
-  autoload :MinimalFormatter,         'rspec/core/formatters/minimal_formatter'
+  autoload :FailureListFormatter,     'rspec/core/formatters/failure_list_formatter'
 
   # Register the formatter class
   # @param formatter_class [Class] formatter class to register
@@ -213,8 +213,8 @@ module RSpec::Core::Formatters
         JsonFormatter
       when 'bisect-drb'
         BisectDRbFormatter
-      when 'm', 'minimal'
-        MinimalFormatter
+      when 'f', 'failure_list'
+        FailureListFormatter
       end
     end
 

--- a/lib/rspec/core/formatters/failure_list_formatter.rb
+++ b/lib/rspec/core/formatters/failure_list_formatter.rb
@@ -4,7 +4,7 @@ module RSpec
   module Core
     module Formatters
       # @private
-      class MinimalFormatter < BaseFormatter
+      class FailureListFormatter < BaseFormatter
         Formatters.register self, :example_failed, :dump_profile, :message
 
         def example_failed(failure)
@@ -13,8 +13,8 @@ module RSpec
 
         # Discard profile and messages
         #
-        # These outputs are not really relevant in the context of this minimal
-        # formatter.
+        # These outputs are not really relevant in the context of this failure
+        # list formatter.
         def dump_profile(_profile); end
         def message(_message); end
       end

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -112,7 +112,7 @@ module RSpec::Core
                   '  [d]ocumentation (group and example names)',
                   '  [h]tml',
                   '  [j]son',
-                  '  [m]inimal (suitable for editors integration)',
+                  '  [f]ailure list (suitable for editors integration)',
                   '  custom formatter class name') do |o|
           options[:formatters] ||= []
           options[:formatters] << [o]

--- a/spec/rspec/core/formatters/failure_list_formatter_spec.rb
+++ b/spec/rspec/core/formatters/failure_list_formatter_spec.rb
@@ -1,11 +1,11 @@
-require 'rspec/core/formatters/minimal_formatter'
+require 'rspec/core/formatters/failure_list_formatter'
 
 module RSpec::Core::Formatters
-  RSpec.describe MinimalFormatter do
+  RSpec.describe FailureListFormatter do
     include FormatterSupport
 
     it 'produces the expected full output' do
-      output = run_example_specs_with_formatter('minimal')
+      output = run_example_specs_with_formatter('failure_list')
       expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
         |./spec/rspec/core/resources/formatter_specs.rb:4:is marked as pending but passes
         |./spec/rspec/core/resources/formatter_specs.rb:36:fails


### PR DESCRIPTION
Address Myron comment on formatter name https://github.com/rspec/rspec-core/pull/2614/files#r283952925
> "Minimal" is a subjective term -- I can imagine many different minimal formatters that output different things. Here it seems like this formatter is focused on printing a list of failures. WDYT about calling this FailureListFormatter? Seems like a more accurate name.

