### PR TITLE
Rename option for FailureList formatter to "failures"

### DIFF
--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -213,7 +213,7 @@ module RSpec::Core::Formatters
         JsonFormatter
       when 'bisect-drb'
         BisectDRbFormatter
-      when 'f', 'failure_list'
+      when 'f', 'failures'
         FailureListFormatter
       end
     end

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -112,7 +112,7 @@ module RSpec::Core
                   '  [d]ocumentation (group and example names)',
                   '  [h]tml',
                   '  [j]son',
-                  '  [f]ailure list (suitable for editors integration)',
+                  '  [f]ailures ("file:line:reason", suitable for editors integration)',
                   '  custom formatter class name') do |o|
           options[:formatters] ||= []
           options[:formatters] << [o]

--- a/spec/rspec/core/formatters/failure_list_formatter_spec.rb
+++ b/spec/rspec/core/formatters/failure_list_formatter_spec.rb
@@ -5,7 +5,7 @@ module RSpec::Core::Formatters
     include FormatterSupport
 
     it 'produces the expected full output' do
-      output = run_example_specs_with_formatter('failure_list')
+      output = run_example_specs_with_formatter('failures')
       expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
         |./spec/rspec/core/resources/formatter_specs.rb:4:is marked as pending but passes
         |./spec/rspec/core/resources/formatter_specs.rb:36:fails


### PR DESCRIPTION
The name was not matching case statement in formatters.rb and it is much
simplier to have an argument with that name.

Discussion:
  - https://github.com/rspec/rspec-core/pull/2624/files#r284776400