### PR TITLE
Fix documentation for nested described_class

### DIFF
--- a/features/metadata/described_class.feature
+++ b/features/metadata/described_class.feature
@@ -1,17 +1,20 @@
 Feature: described class
 
-  If the first argument to the outermost example group is a class, the class is
-  exposed to each example via the `described_class()` method.
+  If the first argument to an example group is a class, the class is exposed to
+  each example in that example group via the `described_class()` method.
 
   Scenario: Access the described class from the example
     Given a file named "spec/example_spec.rb" with:
       """ruby
       RSpec.describe Fixnum do
-        it "is available as described_class" do
-          expect(described_class).to eq(Fixnum)
+        describe 'inner' do
+          describe String do
+            it "is available as described_class" do
+              expect(described_class).to eq(String)
+            end
+          end
         end
       end
       """
     When I run `rspec spec/example_spec.rb`
     Then the example should pass
-

--- a/features/subject/implicit_subject.feature
+++ b/features/subject/implicit_subject.feature
@@ -1,7 +1,8 @@
 Feature: implicitly defined subject
 
-  If the first argument to the outermost example group is a class, an instance
-  of that class is exposed to each example via the `subject` method.
+  If the first argument to an example group is a class, an instance of that
+  class is exposed to each example in that example group via the `subject`
+  method.
 
   While the examples below demonstrate how `subject` can be used as a
   user-facing concept, we recommend that you reserve it for support of custom


### PR DESCRIPTION
Fixes #2627

Documentation for `described_class` was out of date, a change was made in early 3.0 in #1361, but was not reflected to the docs.

Also, documentation for implicit `subject` was off, even though there is [a feature describing how it behaves](https://github.com/rspec/rspec-core/pull/2629/files#diff-e0c7e4af6bc9f71e20b15ebda19ff1a0R23).