### PR TITLE
Fix `define_derived_metadata` so that it supports cascades.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,8 @@ Bug Fixes:
 * When defining `let` methods that overwrite an existing method, prevent
   a warning being issued by removing the old definition. (Jon Rowe, #2593)
 * Prevent warning on Ruby 2.6.0-rc1 (Keiji Yoshimi, #2582)
+* Fix `config.define_derived_metadata` so that it supports cascades.
+  (Myron Marston, #2630).
 
 ### 3.8.0 / 2018-08-04
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.7.1...v3.8.0)


### PR DESCRIPTION
For example:

```
RSpec.configure do |c|
  c.define_derived_metadata(:elasticsearch) do |meta|
    meta[:vcr] = true
  end

  c.define_derived_metadata(:vcr) do |meta|
    meta[:retries] = 2
  end
end
```

With this configuration, an example or group tagged with `:elasticsearch`
should get tagged with `:vcr` as well, which in turn should add
`retries: 2` metadata to the example or group. Before this change,
this did not work properly, because we did look to see if additional
metadata blocks should apply after applying them once.