### PR TITLE
Allow fail_fast to be passed as a string

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -202,10 +202,33 @@ module RSpec
         only_failures? && !example_status_persistence_file_path
       end
 
-      # @macro add_setting
+      # @macro define_reader
       # If specified, indicates the number of failures required before cleaning
-      # up and exit (default: `nil`).
-      add_setting :fail_fast
+      # up and exit (default: `nil`). Can also be `true` to fail and exit on first
+      # failure
+      define_reader :fail_fast
+
+      # @see fail_fast
+      def fail_fast=(value)
+        case value
+        when true, 'true'
+          @fail_fast = true
+        when false, 'false', 0
+          @fail_fast = false
+        when nil
+          @fail_fast = nil
+        else
+          @fail_fast = value.to_i
+
+          if value.to_i == 0
+            # TODO: in RSpec 4, consider raising an error here.
+            RSpec.warning "Cannot set `RSpec.configuration.fail_fast`" \
+              " to `#{value.inspect}`. Only `true`, `false`, `nil` and integers" \
+              " are valid values."
+            @fail_fast = true
+          end
+        end
+      end
 
       # @macro add_setting
       # Prints the formatter output of your suite without running any

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -41,6 +41,87 @@ module RSpec::Core
       end
     end
 
+    describe "#fail_fast=" do
+      context 'when true' do
+        it 'is set to true' do
+          config.fail_fast = true
+          expect(config.fail_fast).to eq true
+        end
+      end
+
+      context "when 'true'" do
+        it 'is set to true' do
+          config.fail_fast = 'true'
+          expect(config.fail_fast).to eq true
+        end
+      end
+
+      context "when false" do
+        it 'is set to false' do
+          config.fail_fast = false
+          expect(config.fail_fast).to eq false
+        end
+      end
+
+      context "when 'false'" do
+        it 'is set to false' do
+          config.fail_fast = 'false'
+          expect(config.fail_fast).to eq false
+        end
+      end
+
+      context "when 0" do
+        it 'is set to false' do
+          config.fail_fast = 0
+          expect(config.fail_fast).to eq false
+        end
+      end
+
+      context "when integer number" do
+        it 'is set to number' do
+          config.fail_fast = 5
+          expect(config.fail_fast).to eq 5
+        end
+      end
+
+      context "when floating point number" do
+        it 'is set to integer number' do
+          config.fail_fast = 5.9
+          expect(config.fail_fast).to eq 5
+        end
+      end
+
+      context "when string represeting an integer number" do
+        it 'is set to number' do
+          config.fail_fast = '5'
+          expect(config.fail_fast).to eq 5
+        end
+      end
+
+      context "when nil" do
+        it 'is nil' do
+          config.fail_fast = nil
+          expect(config.fail_fast).to eq nil
+        end
+      end
+
+      context "when unrecognized value" do
+        before do
+          allow(RSpec).to receive(:warning)
+        end
+
+        it 'prints warning' do
+          config.fail_fast = 'yes'
+          expect(RSpec).to have_received(:warning).with(/Cannot set `RSpec.configuration.fail_fast`/i)
+        end
+
+        it 'is set to true' do
+          config.fail_fast = 'yes'
+          expect(config.fail_fast).to eq true
+        end
+      end
+    end
+
     describe 'fail_if_no_examples' do
       it 'defaults to false' do
         expect(RSpec::Core::Configuration.new.fail_if_no_examples).to be(false)


### PR DESCRIPTION
I thought I'll contribute a small PR with my little knowledge of ruby and rspec.

But I gotta say it was far from smooth sailing. :/

NOTE: I understand most of these are my own issues due to not reading documentation. (more on that towards the end)
The reason why I'm writing this lengthy explanation is to show how difficult it was for me to contribute to this project. I wanted to make relatively small change and have a discussion about it, but it looks like it will turn into a discussion about how to setup rspec-core for local development. :/

I'm willing, given time, to help with the documentation.

Here's my first time contributing to rspec-core story:

I tried to skip reading most of the documentation (SORRY!), assuming "standard" stuff will work (git clone, `bin/setup` and that should be it). Especially since I read that I don't have to clone all the repos.

So I cloned `rspec-core` and (stupidly) also decided to checkout `v3.8.0` tag. Then I ran `bundle install` and that failed as it was fetching `3.9.0.pre` from github.
Eventually I checkout `master` and `bundle install` passed. Then I ran `script/run_build`, and that tells me I need to create missing binstubs. I run `bundle binstubs rspec-core rake cucumber` and rerun `script/run_build`, but it failed with `cannot load such file -- rspec/support`:

<details>
<summary>Stacktrace</summary>

```
> script/run_build
============= Starting binstub check ===============
Checking required binstubs
============= Ending binstub check ===============
============= Starting specs ===============
/Users/viktor/Developer/Ruby/rspec-core/bin/rspec
Coverage report generated for RSpec to /Users/viktor/Developer/Ruby/rspec-core/coverage. 1 / 2 LOC (50.0%) covered.
Traceback (most recent call last):
	5: from script/rspec_with_simplecov:42:in `<main>'
	4: from script/rspec_with_simplecov:42:in `load'
	3: from /Users/viktor/Developer/Ruby/rspec-core/exe/rspec:3:in `<top (required)>'
	2: from /Users/viktor/Developer/Ruby/rspec-core/exe/rspec:3:in `require'
	1: from /Users/viktor/Developer/Ruby/rspec-core/lib/rspec/core.rb:5:in `<top (required)>'
/Users/viktor/Developer/Ruby/rspec-core/lib/rspec/core.rb:5:in `require': cannot load such file -- rspec/support (LoadError)
```

</details>

So I ran `script/clone_all_rspec_repos` and that finally allowed me to run `script/run_build`. But, I got failure that nokogiri gem failed to install (I lost that stacktrace). I installed nokogiri (`gem install nokogiri -v '1.8.5' --source 'https://rubygems.org/'`), and rerun `script/run_build`. Now I getting this error:

<details>
<summary>Stacktrace</summary>

```
> script/run_build
============= Starting binstub check ===============
Checking required binstubs
============= Ending binstub check ===============
============= Starting specs ===============
/Users/viktor/Developer/Ruby/rspec-core/bin/rspec

An error occurred while loading ./spec/rspec/core/memoized_helpers_spec.rb.
Hint: Install the `did_you_mean` gem in order to provide suggestions for similarly named files.
Failure/Error: require 'thread_order'

LoadError:
  cannot load such file -- thread_order
# ./spec/rspec/core/memoized_helpers_spec.rb:1:in `require'
# ./spec/rspec/core/memoized_helpers_spec.rb:1:in `<top (required)>'
# ./lib/rspec/core/configuration.rb:2053:in `load'
# ./lib/rspec/core/configuration.rb:2053:in `load_file_handling_errors'
# ./lib/rspec/core/configuration.rb:1560:in `block in load_spec_files'
# ./lib/rspec/core/configuration.rb:1558:in `each'
# ./lib/rspec/core/configuration.rb:1558:in `load_spec_files'
# ./lib/rspec/core/runner.rb:102:in `setup'
# ./lib/rspec/core/runner.rb:86:in `run'
# ./lib/rspec/core/runner.rb:71:in `run'
# ./lib/rspec/core/runner.rb:45:in `invoke'
# ./exe/rspec:4:in `<top (required)>'
# script/rspec_with_simplecov:42:in `load'
# script/rspec_with_simplecov:42:in `<main>'
Run options: exclude {:ruby=>#<Proc:./spec/spec_helper.rb:99>}


Top 0 slowest examples (0 seconds, 0.0% of total time):

Finished in 0.00006 seconds (files took 0.63136 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

Coverage report generated for RSpec to /Users/viktor/Developer/Ruby/rspec-core/coverage. 2 / 2 LOC (100.0%) covered.
```

</details>

So, after trying `gem install thread_order` and still getting the same error, I decided to give up and just post what I came up with so far (as this PR) and check whether the tests on the CI will pass (locally, running `rspec` passes).
