### PR TITLE
Assign `@metadata` before we apply derived metadata hooks.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,8 +25,9 @@ Bug Fixes:
 * When defining `let` methods that overwrite an existing method, prevent
   a warning being issued by removing the old definition. (Jon Rowe, #2593)
 * Prevent warning on Ruby 2.6.0-rc1 (Keiji Yoshimi, #2582)
-* Fix `config.define_derived_metadata` so that it supports cascades.
-  (Myron Marston, #2630).
+* Fix `config.define_derived_metadata` so that it supports cascades and
+  is not triggered until metadata has been assigned to the example or
+  example group (Myron Marston, #2630, #2635).
 
 ### 3.8.0 / 2018-08-04
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.7.1...v3.8.0)

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -203,10 +203,13 @@ module RSpec
           description, example_block
         )
 
+        config = RSpec.configuration
+        config.apply_derived_metadata_to(@metadata)
+
         # This should perhaps be done in `Metadata::ExampleHash.create`,
         # but the logic there has no knowledge of `RSpec.world` and we
         # want to keep it that way. It's easier to just assign it here.
-        @metadata[:last_run_status] = RSpec.configuration.last_run_statuses[id]
+        @metadata[:last_run_status] = config.last_run_statuses[id]
 
         @example_group_instance = @exception = nil
         @clock = RSpec::Core::Time

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -424,11 +424,15 @@ module RSpec
           superclass.method(:next_runnable_index_for),
           description, *args, &example_group_block
         )
+
+        config = RSpec.configuration
+        config.apply_derived_metadata_to(@metadata)
+
         ExampleGroups.assign_const(self)
 
         @currently_executing_a_context_hook = false
 
-        RSpec.configuration.configure_group(self)
+        config.configure_group(self)
       end
 
       # @private

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -136,7 +136,6 @@ module RSpec
 
           populate_location_attributes
           metadata.update(user_metadata)
-          RSpec.configuration.apply_derived_metadata_to(metadata)
         end
 
       private

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -286,6 +286,21 @@ module RSpec
               expect(host_ex_metadata[:foo]).to eq :host
               expect(shared_ex_metadata[:foo]).to eq :shared
             end
+
+            it "applies metadata from the shared group to the including group, when the shared group itself is loaded and included via metadata" do
+              RSpec.configure do |config|
+                config.when_first_matching_example_defined(:controller) do
+                  define_top_level_shared_group("controller support", :capture_logging) { }
+
+                  config.include_context "controller support", :controller
+                end
+              end
+
+              group = RSpec.describe("group", :controller)
+              ex = group.it
+
+              expect(ex.metadata).to include(:controller => true, :capture_logging => true)
+            end
           end
 
           context "when the group is included via `config.include_context` and matching metadata" do


### PR DESCRIPTION
Since derived metadata hooks can contain arbitrary user code,
the logic in them can trigger something that tries to access
and use `Example#metadata` or `ExampleGroup#metadata` before
initialization is done. It avoids problems if we allow
`@metadata` to be assigned before we run the hooks.