### PR TITLE
Update memoized_helpers.rb

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -61,6 +61,11 @@ module RSpec
         end
       end
 
+      # The description of the inner-most `describe`/`context` block.
+      def description
+        self.class.metadata.fetch(:description_args).first
+      end
+      
       # When `should` is called with no explicit receiver, the call is
       # delegated to the object returned by `subject`. Combined with an
       # implicit subject this supports very concise expressions.


### PR DESCRIPTION
I would like to write specs like this:

```ruby
	context '#localhost?' do
		let(:url_string) {"https://localhost"}
		let(:hostname) {self.class.metadata.fetch(:description_args).first}
		subject {Async::HTTP::Endpoint.parse(url_string, hostname: hostname)}
		
		describe 'localhost' do
			it "should be localhost" do
				is_expected.to be_localhost
			end
		end
		
		describe 'hello.localhost' do
			it "should be localhost" do
				is_expected.to be_localhost
			end
		end
		
		describe 'localhost.' do
			it "should be localhost" do
				is_expected.to be_localhost
			end
		end
		
		describe 'hello.localhost.' do
			it "should be localhost" do
				is_expected.to be_localhost
			end
		end
	end
```

but right now it's very cumbersome to get the actual inner most description.