### PR TITLE
Escape patterns when passed through bisect shell runner

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,8 @@ Bug Fixes:
 * Fix `config.define_derived_metadata` so that cascades are not triggered
   until metadata has been assigned to the example or example group
   (Myron Marston, #2635).
+* Escape `--pattern` and `--exclude-pattern` options when passed through to the
+  bisect shell runner. (Jon Rowe, #2643)
 
 ### 3.8.1 / 2019-06-13
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.8.0...v3.8.1)

--- a/lib/rspec/core/bisect/shell_command.rb
+++ b/lib/rspec/core/bisect/shell_command.rb
@@ -87,6 +87,16 @@ module RSpec
               opts -= %W[ --drb-port #{port} ]
             end
 
+            if (pattern = parsed_original_cli_options[:pattern])
+              opts -= %W[ --pattern #{pattern} ]
+              opts += %W[ --pattern #{open3_safe_escape pattern} ]
+            end
+
+            if (exclusion_pattern = parsed_original_cli_options[:exclude_pattern])
+              opts -= %W[ --exclude-pattern #{exclusion_pattern} ]
+              opts += %W[ --exclude-pattern #{open3_safe_escape exclusion_pattern} ]
+            end
+
             parsed_original_cli_options.fetch(:formatters) { [] }.each do |(name, out)|
               opts -= %W[ --format #{name} -f -f#{name} ]
               opts -= %W[ --out #{out} -o -o#{out} ]

--- a/spec/rspec/core/bisect/shell_command_spec.rb
+++ b/spec/rspec/core/bisect/shell_command_spec.rb
@@ -16,7 +16,13 @@ module RSpec::Core
         $LOAD_PATH.replace(orig_load_path)
       end
 
-      let(:original_cli_args) { %w[ spec/unit -rfoo -Ibar --warnings --backtrace ] }
+      let(:original_cli_args) do
+        %w[
+          spec/unit -rfoo -Ibar --warnings --backtrace
+          --pattern spec/**{,/*/**}/*_spec.rb
+          --exclude-pattern spec/fixtures/**{,/*/**}/*.rb
+        ]
+      end
 
       it "includes the original CLI arg options" do
         cmd = command_for(%w[ spec/1.rb spec/2.rb ])
@@ -34,6 +40,19 @@ module RSpec::Core
           expect(cmd).to include("'path/with spaces/to/spec.rb'")
         else
           expect(cmd).to include('path/with\ spaces/to/spec.rb')
+        end
+      end
+
+      it 'escapes globs' do
+        cmd = command_for([])
+        if uses_quoting_for_escaping?
+          expect(cmd).to include("--pattern 'spec/**{,/*/**}/*_spec.rb'").and(
+            include("--exclude-pattern 'spec/fixtures/**{,/*/**}/*.rb'")
+          )
+        else
+          expect(cmd).to include("--pattern spec/\\*\\*\\{,/\\*/\\*\\*\\}/\\*_spec.rb").and(
+            include("--exclude-pattern spec/fixtures/\\*\\*\\{,/\\*/\\*\\*\\}/\\*.rb")
+          )
         end
       end
 


### PR DESCRIPTION
We need to remove pattern and exclude pattern from the normal shell args and run them through the escape process before handing them off to open3, as we parse strings in when we load them into RSpec so any existing quoting is lost.

Fixes #2638 