### PR TITLE
[WIP] Allow before(:all) blocks to play nicely with rspec-retry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ platforms :jruby do
   end
 end
 
+gem 'rspec-retry', '~> 0.6'
+
 gem 'simplecov', '~> 0.8'
 
 # No need to run rubocop on earlier versions

--- a/benchmarks/module_inclusion_filtering.rb
+++ b/benchmarks/module_inclusion_filtering.rb
@@ -28,13 +28,13 @@ module RSpecConfigurationOverrides
 
   def self.prepare_implementation(prefix)
     RSpec.world = RSpec::Core::World.new # clear our state
-    RSpec::Core::Configuration.class_eval do
+    RSpec::Core::ConfigurationOverlay.class_eval do
       alias_method :configure_group, :"#{prefix}_configure_group"
     end
   end
 end
 
-RSpec::Core::Configuration.class_eval do
+RSpec::Core::ConfigurationOverlay.class_eval do
   prepend RSpecConfigurationOverrides
   alias new_configure_group configure_group
 end

--- a/benchmarks/singleton_example_groups/helper.rb
+++ b/benchmarks/singleton_example_groups/helper.rb
@@ -18,7 +18,7 @@ RSpec::Core::Hooks::HookCollections.class_eval do
   alias_method :new_register_global_singleton_context_hooks, :register_global_singleton_context_hooks
 end
 
-RSpec::Core::Configuration.class_eval do
+RSpec::Core::ConfigurationOverlay.class_eval do
   def old_configure_example(*)
     # no-op: this method didn't exist before
   end
@@ -36,7 +36,7 @@ class BenchmarkHelpers
     RSpec.world = RSpec::Core::World.new # clear our state
     RSpec::Core::Example.__send__ :alias_method, :with_around_and_singleton_context_hooks, :"#{prefix}_with_around_and_singleton_context_hooks"
     RSpec::Core::Hooks::HookCollections.__send__ :alias_method, :register_global_singleton_context_hooks, :"#{prefix}_register_global_singleton_context_hooks"
-    RSpec::Core::Configuration.__send__ :alias_method, :configure_example, :"#{prefix}_configure_example"
+    RSpec::Core::ConfigurationOverlay.__send__ :alias_method, :configure_example, :"#{prefix}_configure_example"
   end
 
   @@runner = RSpec::Core::Runner.new(RSpec::Core::ConfigurationOptions.new([]))

--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -83,7 +83,7 @@ module RSpec
   # @see RSpec.configure
   # @see Core::Configuration
   def self.configuration
-    @configuration ||= RSpec::Core::Configuration.new
+    @configuration ||= RSpec::Core::ConfigurationOverlay.new
   end
 
   # Yields the global configuration to a block.

--- a/lib/rspec/core/rspec-retry-extension.rb
+++ b/lib/rspec/core/rspec-retry-extension.rb
@@ -1,0 +1,616 @@
+require 'rspec/core'
+require 'rspec/retry/version'
+require 'rspec_ext/rspec_ext'
+require 'optparse'
+
+ module RSpec
+  module Core
+    class ConfigurationOverlay < Configuration
+      def with_suite_hooks(retries)
+        return yield if dry_run?
+
+         begin
+          run_suite_hooks("a `before(:suite)` hook", @before_suite_hooks, retries)
+          yield
+        ensure
+          run_suite_hooks("an `after(:suite)` hook", @after_suite_hooks)
+        end
+      end
+
+       def run_suite_hooks(hook_description, hooks, retries = 3)
+        context = SuiteHookContext.new(hook_description, reporter)
+
+         hooks.each do |hook|
+          hook_remaining_retries = try_to_execute_hook(hook, context, retries)
+          # Do not run subsequent `before` hooks if one fails.
+          # But for `after` hooks, we run them all so that all
+          # cleanup bits get a chance to complete, minimizing the
+          # chance that resources get left behind.
+          if hooks.equal?(@before_suite_hooks) and hook_remaining_retries == 0
+            break
+          end
+        end
+      end
+
+       def try_to_execute_hook(hook, context, retries)
+        if retries > 0
+          begin
+            hook.run(context, retries)
+          rescue Net::ReadTimeout => ex
+            context.set_exception(ex)
+            log_info("There was a Net::ReadTimeout exception: " + ex.to_s)
+            refresh_page
+            try_to_execute_hook(hook, context, retries - 1)
+          rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
+            context.set_exception(ex)
+            refresh_page
+            try_to_execute_hook(hook, context, retries - 1)
+          end
+        end
+
+         retries
+      end
+    end
+  end
+end
+
+ # rubocop:disable Style/CaseEquality
+module RSpec
+  module Core
+    # Provides `before`, `after` and `around` hooks as a means of
+    # supporting common setup and teardown. This module is extended
+    # onto {ExampleGroup}, making the methods available from any `describe`
+    # or `context` block and included in {Configuration}, making them
+    # available off of the configuration object to define global setup
+    # or teardown logic.
+    module Hooks
+      def run(context, retries)
+        loop do
+          if attempts > 0
+            RSpec.configuration.formatters.each { |f| f.retry(example) if f.respond_to? :retry }
+            if verbose_retry?
+              message = "RSpec::Retry: #{ordinalize(attempts + 1)} try #{example.location}"
+              message = "\n" + message if attempts == 1
+              RSpec.configuration.reporter.message(message)
+            end
+          end
+
+           example.metadata[:retry_attempts] = attempts
+
+           example.clear_exception
+          ex.run
+
+           self.attempts += 1
+
+           break if example.exception.nil?
+
+           break if attempts >= retry_count
+
+           if exceptions_to_hard_fail.any?
+            break if exception_exists_in?(exceptions_to_hard_fail, example.exception)
+          end
+
+           if exceptions_to_retry.any?
+            break unless exception_exists_in?(exceptions_to_retry, example.exception)
+          end
+
+           if verbose_retry? && display_try_failure_messages?
+            if attempts != retry_count
+              exception_strings =
+                if ::RSpec::Core::MultipleExceptionError::InterfaceTag === example.exception
+                  example.exception.all_exceptions.map(&:to_s)
+                else
+                  [example.exception.to_s]
+                end
+
+               try_message = "\n#{ordinalize(attempts)} Try error in #{example.location}:\n#{exception_strings.join "\n"}\n"
+              RSpec.configuration.reporter.message(try_message)
+            end
+          end
+
+           example.example_group_instance.clear_lets if clear_lets
+
+           # If the callback is defined, let's call it
+          if RSpec.configuration.retry_callback
+            example.example_group_instance.instance_exec(example, &RSpec.configuration.retry_callback)
+          end
+
+           sleep sleep_interval if sleep_interval.to_f > 0
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Style/CaseEquality
+
+ module RSpec
+  module Core
+    # Provides the main entry point to run a suite of RSpec examples.
+    class RunnerRetry < Runner
+      # Runs the suite of specs and exits the process with an appropriate exit
+      # code.
+      def self.invoke
+        disable_autorun!
+        status = run(ARGV, $stderr, $stdout).to_i
+        exit(status) if status != 0
+      end
+
+       # Run a suite of RSpec examples. Does not exit.
+      #
+      # This is used internally by RSpec to run a suite, but is available
+      # for use by any other automation tool.
+      #
+      # If you want to run this multiple times in the same process, and you
+      # want files like `spec_helper.rb` to be reloaded, be sure to load `load`
+      # instead of `require`.
+      #
+      # @param args [Array] command-line-supported arguments
+      # @param err [IO] error stream
+      # @param out [IO] output stream
+      # @return [Fixnum] exit status code. 0 if all specs passed,
+      #   or the configured failure exit code (1 by default) if specs
+      #   failed.
+      def self.run(args, err = $stderr, out = $stdout)
+        trap_interrupt
+        options = ConfigurationOptions.new(args)
+
+         if options.options[:runner]
+          options.options[:runner].call(options, err, out)
+        else
+          new(options).run_with_retries(err, out, 3)
+        end
+      end
+
+       def run_with_retries(err, out, retries)
+        setup(err, out)
+        run_specs_with_retries(@world.ordered_example_groups, retries).tap do
+          persist_example_statuses
+        end
+      end
+
+       def run_specs_with_retries(example_groups, retries)
+        examples_count = @world.example_count(example_groups)
+        success = @configuration.reporter.report(examples_count) do |reporter|
+          @configuration.with_suite_hooks_retries(retries) do
+            if examples_count == 0 && @configuration.fail_if_no_examples
+              return @configuration.failure_exit_code
+            end
+
+             example_groups.map { |g| g.run_with_retries(reporter, retries) }.all?
+          end
+        end && !@world.non_example_failure
+
+         success ? 0 : @configuration.failure_exit_code
+      end
+    end
+  end
+end
+
+ module RSpec
+  module Core
+    class ExampleGroup
+      # Runs all the examples in this group.
+      def self.run_with_retries(reporter = RSpec::Core::NullReporter, retries)
+        return if RSpec.world.wants_to_quit
+        reporter.example_group_started(self)
+
+         should_run_context_hooks = descendant_filtered_examples.any?
+        begin
+          run_before_context_hooks_with_retries(new('before(:context) hook'), retries) if should_run_context_hooks
+          result_for_this_group = run_examples(reporter)
+          results_for_descendants = ordering_strategy.order(children).map { |child| child.run(reporter) }.all?
+          result_for_this_group && results_for_descendants
+        rescue Pending::SkipDeclaredInExample => ex
+          for_filtered_examples(reporter) { |example| example.skip_with_exception(reporter, ex) }
+          true
+        rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
+          for_filtered_examples(reporter) { |example| example.fail_with_exception(reporter, ex) }
+          RSpec.world.wants_to_quit = true if reporter.fail_fast_limit_met?
+          false
+        ensure
+          run_after_context_hooks(new('after(:context) hook')) if should_run_context_hooks
+          reporter.example_group_finished(self)
+        end
+      end
+
+       def self.run_before_context_hooks_with_retries(example_group_instance, retries)
+        set_ivars(example_group_instance, superclass_before_context_ivars)
+
+         @currently_executing_a_context_hook = true
+
+         ContextHookMemoized::Before.isolate_for_context_hook(example_group_instance) do
+          hooks.run_with_retries(:before, :context, example_group_instance, retries)
+        end
+      ensure
+        store_before_context_ivars(example_group_instance)
+        @currently_executing_a_context_hook = false
+      end
+    end
+  end
+end
+
+ # rubocop:disable Lint/RescueException
+module RSpec
+  module Core
+    module Hooks
+      class BeforeHook < Hook
+        def run_with_retries(example, retries)
+          example.instance_exec(example, &block)
+        rescue Exception => e
+          raise "Issue after #{RETRY_COUNT} number of retries: #{e}" if retries == 1
+          Capybara.reset!
+          run_with_retries(example, retries - 1)
+        end
+      end
+
+       class HookCollections
+        # Runs all of the blocks stored with the hook in the context of the
+        # example. If no example is provided, just calls the hook directly.
+        def run_with_retries(position, scope, example_or_group, retries)
+          return if RSpec.configuration.dry_run?
+
+           if scope == :context
+            unless example_or_group.class.metadata[:skip]
+              run_owned_hooks_with_retries_for(position, :context, example_or_group, retries)
+            end
+          else
+            case position
+            when :before then run_example_hooks_with_retries_for(example_or_group, :before, :reverse_each, retries)
+            when :after  then run_example_hooks_for(example_or_group, :after,  :each)
+            when :around then run_around_example_hooks_for(example_or_group) { yield }
+            end
+          end
+        end
+
+         def run_example_hooks_with_retries_for(example, position, each_method, retries)
+          owner_parent_groups.__send__(each_method) do |group|
+            group.hooks.run_owned_hooks_with_retries_for(position, :example, example, retries)
+          end
+        end
+
+         def run_owned_hooks_with_retries_for(position, scope, example_or_group, retries)
+          matching_hooks_for(position, scope, example_or_group).each do |hook|
+            hook.run_with_retries(example_or_group, retries)
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Lint/RescueException
+
+ # rubocop:disable Style/ClassAndModuleChildren
+module RSpec::Core
+  class ParserWithRetries < Parser
+    def self.parse(args, source = nil)
+      new(args).parse(source)
+    end
+
+     attr_reader :original_args
+
+     def initialize(original_args)
+      @original_args = original_args
+    end
+
+     def parse_with_retries(source = nil)
+      return { :files_or_directories_to_run => [] } if original_args.empty?
+      args = original_args.dup
+
+       options = args.delete('--tty') ? { :tty => true } : {}
+      begin
+        parser_with_retries(options).parse!(args)
+      rescue OptionParser::InvalidOption => e
+        failure = e.message
+        failure << " (defined in #{source})" if source
+        abort "#{failure}\n\nPlease use --help for a listing of valid options"
+      end
+
+       options[:files_or_directories_to_run] = args
+      options
+    end
+
+     private
+
+     def parser_with_retries(options)
+      OptionParser.new do |parser|
+        parser.summary_width = 34
+
+         parser.banner = "Usage: rspec [options] [files or directories]\n\n"
+
+         parser.on('-I PATH', 'Specify PATH to add to $LOAD_PATH (may be used more than once).') do |dirs|
+          options[:libs] ||= []
+          options[:libs].concat(dirs.split(File::PATH_SEPARATOR))
+        end
+
+         parser.on('-r', '--require PATH', 'Require a file.') do |path|
+          options[:requires] ||= []
+          options[:requires] << path
+        end
+
+         parser.on('-O', '--options PATH', 'Specify the path to a custom options file.') do |path|
+          options[:custom_options_file] = path
+        end
+
+         parser.on('--order TYPE[:SEED]', 'Run examples by the specified order type.',
+          '  [defined] examples and groups are run in the order they are defined',
+          '  [rand]    randomize the order of groups and examples',
+          '  [random]  alias for rand',
+          '  [random:SEED] e.g. --order random:123') do |o|
+          options[:order] = o
+        end
+
+         parser.on('--seed SEED', Integer, 'Equivalent of --order rand:SEED.') do |seed|
+          options[:order] = "rand:#{seed}"
+        end
+
+         parser.on('--bisect[=verbose]', 'Repeatedly runs the suite in order to isolate the failures to the ',
+          '  smallest reproducible case.') do |argument|
+          options[:bisect] = argument || true
+          options[:runner] = RSpec::Core::Invocations::Bisect.new
+        end
+
+         parser.on('--[no-]fail-fast[=COUNT]', 'Abort the run after a certain number of failures (1 by default).') do |argument|
+          if argument == true
+            value = 1
+          elsif argument == false || argument == 0
+            value = false
+          else
+            begin
+              value = Integer(argument)
+            rescue ArgumentError
+              RSpec.warning "Expected an integer value for `--fail-fast`, got: #{argument.inspect}", :call_site => nil
+            end
+          end
+          set_fail_fast(options, value)
+        end
+
+         parser.on('--failure-exit-code CODE', Integer,
+          'Override the exit code used when there are failing specs.') do |code|
+          options[:failure_exit_code] = code
+        end
+
+         parser.on('-X', '--[no-]drb', 'Run examples via DRb.') do |use_drb|
+          options[:drb] = use_drb
+          options[:runner] = RSpec::Core::Invocations::DRbWithFallbackWithRetries.new if use_drb
+        end
+
+         parser.on('--drb-port PORT', 'Port to connect to the DRb server.') do |o|
+          options[:drb_port] = o.to_i
+        end
+
+         parser.separator("\n  **** Output ****\n\n")
+
+         parser.on('-f', '--format FORMATTER', 'Choose a formatter.',
+          '  [p]rogress (default - dots)',
+          '  [d]ocumentation (group and example names)',
+          '  [h]tml',
+          '  [j]son',
+          '  custom formatter class name') do |o|
+          options[:formatters] ||= []
+          options[:formatters] << [o]
+        end
+
+         parser.on('-o', '--out FILE',
+          'Write output to a file instead of $stdout. This option applies',
+          '  to the previously specified --format, or the default format',
+          '  if no format is specified.'
+        ) do |o|
+          options[:formatters] ||= [['progress']]
+          options[:formatters].last << o
+        end
+
+         parser.on('--deprecation-out FILE', 'Write deprecation warnings to a file instead of $stderr.') do |file|
+          options[:deprecation_stream] = file
+        end
+
+         parser.on('-b', '--backtrace', 'Enable full backtrace.') do |_o|
+          options[:full_backtrace] = true
+        end
+
+         parser.on('-c', '--color', '--colour', '') do |_o|
+          # flag will be excluded from `--help` output because it is deprecated
+          options[:color] = true
+          options[:color_mode] = :automatic
+        end
+
+         parser.on('--force-color', '--force-colour', 'Force the output to be in color, even if the output is not a TTY') do |_o|
+          if options[:color_mode] == :off
+            abort "Please only use one of `--force-color` and `--no-color`"
+          end
+          options[:color_mode] = :on
+        end
+
+         parser.on('--no-color', '--no-colour', 'Force the output to not be in color, even if the output is a TTY') do |_o|
+          if options[:color_mode] == :on
+            abort "Please only use one of --force-color and --no-color"
+          end
+          options[:color_mode] = :off
+        end
+
+         parser.on('-p', '--[no-]profile [COUNT]',
+          'Enable profiling of examples and list the slowest examples (default: 10).') do |argument|
+          options[:profile_examples] =
+            if argument.nil?
+              true
+            elsif argument == false
+              false
+            else
+              begin
+                Integer(argument)
+              rescue ArgumentError
+                RSpec.warning "Non integer specified as profile count, separate " \
+                            "your path from options with -- e.g. " \
+                            "`rspec --profile -- #{argument}`",
+                  :call_site => nil
+                true
+              end
+            end
+        end
+
+         parser.on('--dry-run', 'Print the formatter output of your suite without',
+          '  running any examples or hooks') do |_o|
+          options[:dry_run] = true
+        end
+
+         parser.on('-w', '--warnings', 'Enable ruby warnings') do
+          $VERBOSE = true
+        end
+
+         parser.separator <<-FILTERING
+  **** Filtering/tags ****
+    In addition to the following options for selecting specific files, groups, or
+    examples, you can select individual examples by appending the line number(s) to
+    the filename:
+      rspec path/to/a_spec.rb:37:87
+    You can also pass example ids enclosed in square brackets:
+      rspec path/to/a_spec.rb[1:5,1:6] # run the 5th and 6th examples/groups defined in the 1st group
+        FILTERING
+
+         parser.on('--only-failures', "Filter to just the examples that failed the last time they ran.") do
+          configure_only_failures(options)
+        end
+
+         parser.on("-n", "--next-failure", "Apply `--only-failures` and abort after one failure.",
+          "  (Equivalent to `--only-failures --fail-fast --order defined`)") do
+          configure_only_failures(options)
+          set_fail_fast(options, 1)
+          options[:order] ||= 'defined'
+        end
+
+         parser.on('-P', '--pattern PATTERN', 'Load files matching pattern (default: "spec/**/*_spec.rb").') do |o|
+          if options[:pattern]
+            options[:pattern] += ',' + o
+          else
+            options[:pattern] = o
+          end
+        end
+
+         parser.on('--exclude-pattern PATTERN',
+          'Load files except those matching pattern. Opposite effect of --pattern.') do |o|
+          options[:exclude_pattern] = o
+        end
+
+         parser.on('-e', '--example STRING', "Run examples whose full nested names include STRING (may be",
+          "  used more than once)") do |o|
+          (options[:full_description] ||= []) << Regexp.compile(Regexp.escape(o))
+        end
+
+         parser.on('-t', '--tag TAG[:VALUE]',
+          'Run examples with the specified tag, or exclude examples',
+          'by adding ~ before the tag.',
+          '  - e.g. ~slow',
+          '  - TAG is always converted to a symbol') do |tag|
+          filter_type = /^~/.match?(tag) ? :exclusion_filter : :inclusion_filter
+
+           name, value = tag.gsub(/^(~@|~|@)/, '').split(':', 2)
+          name = name.to_sym
+
+           parsed_value =
+            case value
+            when nil then true # The default value for tags is true
+            when 'true'      then true
+            when 'false'     then false
+            when 'nil'       then nil
+            when /^:/        then value[1..-1].to_sym
+            when /^\d+$/     then Integer(value)
+            when /^\d+.\d+$/ then Float(value)
+            else
+              value
+            end
+
+           add_tag_filter(options, filter_type, name, parsed_value)
+        end
+
+         parser.on('--default-path PATH', 'Set the default path where RSpec looks for examples (can',
+          '  be a path to a file or a directory).') do |path|
+          options[:default_path] = path
+        end
+
+         parser.separator("\n  **** Utility ****\n\n")
+
+         parser.on('--init', 'Initialize your project with RSpec.') do |_cmd|
+          options[:runner] = RSpec::Core::Invocations::InitializeProject.new
+        end
+
+         parser.on('-v', '--version', 'Display the version.') do
+          options[:runner] = RSpec::Core::Invocations::PrintVersion.new
+        end
+
+         # These options would otherwise be confusing to users, so we forcibly
+        # prevent them from executing.
+        #
+        #   * --I is too similar to -I.
+        #   * -d was a shorthand for --debugger, which is removed, but now would
+        #     trigger --default-path.
+        invalid_options = %w[-d --I]
+
+         hidden_options = invalid_options + %w[-c]
+
+         parser.on_tail('-h', '--help', "You're looking at it.") do
+          options[:runner] = RSpec::Core::Invocations::PrintHelp.new(parser, hidden_options)
+        end
+
+         # This prevents usage of the invalid_options.
+        invalid_options.each do |option|
+          parser.on(option) do
+            raise OptionParser::InvalidOption
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Style/ClassAndModuleChildren
+
+ module RSpec
+  module Core
+    # @private
+    module Invocations
+      class DRbWithFallbackWithRetries
+        def call(options, err, out)
+          require 'rspec/core/drb'
+          begin
+            return DRbRunner.new(options).run(err, out)
+          rescue DRb::DRbConnError
+            err.puts "No DRb server is running. Running in local process instead ..."
+          end
+          RSpec::Core::RunnerRetry.new(options).run_with_retries(err, out, 3)
+        end
+      end
+    end
+  end
+end
+
+ module RSpec
+  module Core
+    class ConfigurationOptionsRetries < ConfigurationOptions
+      def initialize(args)
+        @args = args.dup
+        organize_options_with_retries
+      end
+
+       private
+
+       def organize_options_with_retries
+        @filter_manager_options = []
+
+         #@before_suite_hooks << Hooks::BeforeHook.new(block, {})
+
+         @options = (file_options << command_line_options_with_retries << env_options).each do |opts|
+          @filter_manager_options << [:include, opts.delete(:inclusion_filter)] if opts.key?(:inclusion_filter)
+          @filter_manager_options << [:exclude, opts.delete(:exclusion_filter)] if opts.key?(:exclusion_filter)
+        end
+
+         @options = @options.inject(:libs => [], :requires => []) do |hash, opts|
+          hash.merge(opts) do |key, oldval, newval|
+            [:libs, :requires].include?(key) ? oldval + newval : newval
+          end
+        end
+      end
+
+       def command_line_options_with_retries
+        @command_line_options ||= ParserWithRetries.parse(@args)
+      end
+    end
+  end
+end

--- a/lib/rspec/core/sandbox.rb
+++ b/lib/rspec/core/sandbox.rb
@@ -23,7 +23,7 @@ module RSpec
         orig_world   = RSpec.world
         orig_example = RSpec.current_example
 
-        RSpec.configuration = RSpec::Core::Configuration.new
+        RSpec.configuration = RSpec::Core::ConfigurationOverlay.new
         RSpec.world         = RSpec::Core::World.new(RSpec.configuration)
 
         yield RSpec.configuration

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
   end
 
   describe "#configure" do
-    let(:config) { RSpec::Core::Configuration.new }
+    let(:config) { RSpec::Core::ConfigurationOverlay.new }
 
     it "configures deprecation_stream before loading requires (since required files may issue deprecations)" do
       opts = config_options_object(*%w[--deprecation-out path/to/log --require foo])
@@ -383,7 +383,7 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
 
   describe "default_path" do
     it "gets set before files_or_directories_to_run" do
-      config = RSpec::Core::Configuration.new
+      config = RSpec::Core::ConfigurationOverlay.new
       expect(config).to receive(:force).with(:default_path => 'foo').ordered
       expect(config).to receive(:get_files_to_run).ordered
       opts = config_options_object("--default-path", "foo")
@@ -528,7 +528,7 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
     it "prefers CLI over file options for filter inclusion" do
       create_fixture_file("./.rspec", "--tag ~slow")
       opts = config_options_object("--tag", "slow")
-      config = RSpec::Core::Configuration.new
+      config = RSpec::Core::ConfigurationOverlay.new
       opts.configure(config)
       expect(config.inclusion_filter.rules).to have_key(:slow)
       expect(config.exclusion_filter.rules).not_to have_key(:slow)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -37,7 +37,7 @@ module RSpec::Core
 
     describe "#fail_fast" do
       it "defaults to `nil`" do
-        expect(RSpec::Core::Configuration.new.fail_fast).to be(nil)
+        expect(RSpec::Core::ConfigurationOverlay.new.fail_fast).to be(nil)
       end
     end
 
@@ -124,7 +124,7 @@ module RSpec::Core
 
     describe 'fail_if_no_examples' do
       it 'defaults to false' do
-        expect(RSpec::Core::Configuration.new.fail_if_no_examples).to be(false)
+        expect(RSpec::Core::ConfigurationOverlay.new.fail_if_no_examples).to be(false)
       end
 
       it 'can be set to true' do

--- a/spec/rspec/core/drb_spec.rb
+++ b/spec/rspec/core/drb_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec/core/drb'
 
 RSpec.describe RSpec::Core::DRbRunner, :isolated_directory => true, :isolated_home => true, :type => :drb, :unless => RUBY_PLATFORM == 'java' do
-  let(:config) { RSpec::Core::Configuration.new }
+  let(:config) { RSpec::Core::ConfigurationOverlay.new }
   let(:out)    { StringIO.new }
   let(:err)    { StringIO.new }
 
@@ -66,7 +66,7 @@ RSpec.describe RSpec::Core::DRbRunner, :isolated_directory => true, :isolated_ho
     class SimpleDRbSpecServer
       def self.run(argv, err, out)
         options = RSpec::Core::ConfigurationOptions.new(argv)
-        config  = RSpec::Core::Configuration.new
+        config  = RSpec::Core::ConfigurationOverlay.new
         RSpec.configuration = config
         RSpec::Core::Runner.new(options, config).run(err, out)
       end
@@ -118,7 +118,7 @@ RSpec.describe RSpec::Core::DRbOptions, :isolated_directory => true, :isolated_h
     end
 
     def drb_filter_manager_for(args)
-      configuration = RSpec::Core::Configuration.new
+      configuration = RSpec::Core::ConfigurationOverlay.new
       RSpec::Core::DRbRunner.new(config_options_object(*args), configuration).drb_argv
       configuration.filter_manager
     end
@@ -201,13 +201,13 @@ RSpec.describe RSpec::Core::DRbOptions, :isolated_directory => true, :isolated_h
 
       it "leaves formatters intact" do
         coo = config_options_object("--format", "d")
-        RSpec::Core::DRbRunner.new(coo, RSpec::Core::Configuration.new).drb_argv
+        RSpec::Core::DRbRunner.new(coo, RSpec::Core::ConfigurationOverlay.new).drb_argv
         expect(coo.options[:formatters]).to eq([["d"]])
       end
 
       it "leaves output intact" do
         coo = config_options_object("--format", "p", "--out", "foo.txt", "--format", "d")
-        RSpec::Core::DRbRunner.new(coo, RSpec::Core::Configuration.new).drb_argv
+        RSpec::Core::DRbRunner.new(coo, RSpec::Core::ConfigurationOverlay.new).drb_argv
         expect(coo.options[:formatters]).to eq([["p","foo.txt"],["d"]])
       end
     end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -468,7 +468,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       end
 
       it 'releases references to the examples / their ivars', :if => reliable_gc do
-        config        = RSpec::Core::Configuration.new
+        config        = RSpec::Core::ConfigurationOverlay.new
         real_reporter = RSpec::Core::Reporter.new(config) # in case it is the cause of a leak
         garbage       = Struct.new :defined_in
 
@@ -560,10 +560,10 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
   end
 
   describe "reporting example_finished" do
-    let(:reporter) { RSpec::Core::Reporter.new(RSpec::Core::Configuration.new) }
+    let(:reporter) { RSpec::Core::Reporter.new(RSpec::Core::ConfigurationOverlay.new) }
 
     def capture_reported_execution_result_for_example(&block)
-      reporter = RSpec::Core::Reporter.new(RSpec::Core::Configuration.new)
+      reporter = RSpec::Core::Reporter.new(RSpec::Core::ConfigurationOverlay.new)
 
       reported_execution_result = nil
 

--- a/spec/rspec/core/formatters/syntax_highlighter_spec.rb
+++ b/spec/rspec/core/formatters/syntax_highlighter_spec.rb
@@ -2,7 +2,7 @@ require 'rspec/core/formatters/syntax_highlighter'
 
 module RSpec::Core::Formatters
   RSpec.describe SyntaxHighlighter do
-    let(:config)      { RSpec::Core::Configuration.new.tap { |config| config.color_mode = :on } }
+    let(:config)      { RSpec::Core::ConfigurationOverlay.new.tap { |config| config.color_mode = :on } }
     let(:highlighter) { SyntaxHighlighter.new(config)  }
 
     context "when CodeRay is available", :unless => RSpec::Support::OS.windows? do

--- a/spec/rspec/core/ordering_spec.rb
+++ b/spec/rspec/core/ordering_spec.rb
@@ -15,7 +15,7 @@ module RSpec
             instance_double(Example, :id => "./some_spec.rb[1:#{n}]")
           end
 
-          let(:configuration)  { RSpec::Core::Configuration.new }
+          let(:configuration)  { RSpec::Core::ConfigurationOverlay.new }
           let(:items)          { 10.times.map { |n| item(n) } }
           let(:shuffled_items) { subject.order items }
 

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe RSpec do
 
   describe ".configuration=" do
     it "sets the configuration object" do
-      configuration = RSpec::Core::Configuration.new
+      configuration = RSpec::Core::ConfigurationOverlay.new
 
       RSpec.configuration = configuration
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'rubygems' if RUBY_VERSION.to_f < 1.9
 
 require 'rspec/support/spec'
 
-$rspec_core_without_stderr_monkey_patch = RSpec::Core::Configuration.new
+$rspec_core_without_stderr_monkey_patch = RSpec::Core::ConfigurationOverlay.new
 
 class RSpec::Core::Configuration
   def self.new(*args, &block)

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -272,7 +272,7 @@ module FormatterSupport
   def config
     @configuration ||=
       begin
-        config = RSpec::Core::Configuration.new
+        config = RSpec::Core::ConfigurationOverlay.new
         config.output_stream = formatter_output
         config
       end


### PR DESCRIPTION
Currently rspec-retry doesn't work in before(:all) blocks; specs will simply fail after one attempt, eg if one passes retry=3 to a `bundle exec ...args` declaration.

Inherit from `RSpec::Core::Configuration` to create a new configuration object that overrides the previous functionality.

Add noredink/rspec-retry as a Gemspec dependency.

This should allow rspec-retry to retry in before(:all) blocks.