### PR TITLE
Indent messages correctly in DocumentationFormatter.

### DIFF
--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -13,12 +13,12 @@ module RSpec
           super
           @group_level = 0
 
-          @example_started = false
+          @example_running = false
           @messages = []
         end
 
         def example_started(_notification)
-          @example_started = true
+          @example_running = true
         end
 
         def example_group_started(notification)
@@ -36,7 +36,7 @@ module RSpec
           output.puts passed_output(passed.example)
 
           flush_messages
-          @example_started = false
+          @example_running = false
         end
 
         def example_pending(pending)
@@ -44,18 +44,18 @@ module RSpec
                                      pending.example.execution_result.pending_message)
 
           flush_messages
-          @example_started = false
+          @example_running = false
         end
 
         def example_failed(failure)
           output.puts failure_output(failure.example)
 
           flush_messages
-          @example_started = false
+          @example_running = false
         end
 
         def message(notification)
-          if @example_started
+          if @example_running
             @messages << notification.message
           else
             output.puts "#{current_indentation}#{notification.message}"

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -38,6 +38,10 @@ module RSpec
           output.puts failure_output(failure.example)
         end
 
+        def message(notification)
+          output.puts "#{current_indentation}#{notification.message}"
+        end
+
       private
 
         def passed_output(example)

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -12,9 +12,12 @@ module RSpec
         def initialize(output)
           super
           @group_level = 0
+          @messages = []
         end
 
         def example_group_started(notification)
+          flush_messages
+
           output.puts if @group_level == 0
           output.puts "#{current_indentation}#{notification.group.description.strip}"
 
@@ -23,26 +26,42 @@ module RSpec
 
         def example_group_finished(_notification)
           @group_level -= 1 if @group_level > 0
+          flush_messages
         end
 
         def example_passed(passed)
           output.puts passed_output(passed.example)
+          flush_messages
         end
 
         def example_pending(pending)
           output.puts pending_output(pending.example,
                                      pending.example.execution_result.pending_message)
+          flush_messages
         end
 
         def example_failed(failure)
           output.puts failure_output(failure.example)
+          flush_messages
         end
 
         def message(notification)
-          output.puts "#{current_indentation}#{notification.message}"
+          if @group_level.zero?
+            output.puts notification.message
+          else
+            @messages << notification.message
+          end
         end
 
       private
+
+        def flush_messages
+          @messages.each do |message|
+            output.puts "#{current_indentation(1)}#{message}"
+          end
+
+          @messages.clear
+        end
 
         def passed_output(example)
           ConsoleCodes.wrap("#{current_indentation}#{example.description.strip}", :success)
@@ -65,8 +84,8 @@ module RSpec
           @next_failure_index += 1
         end
 
-        def current_indentation
-          '  ' * @group_level
+        def current_indentation(offset=0)
+          '  ' * (@group_level + offset)
         end
       end
     end

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -50,7 +50,7 @@ module RSpec
           if @messages
             @messages << notification.message
           else
-            output.puts notification.message
+            output.puts "#{current_indentation(1)}#{notification.message}"
           end
         end
 

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -15,7 +15,7 @@ module RSpec
           @messages = nil
         end
 
-        def example_started(notification)
+        def example_started(_notification)
           @messages = []
         end
 

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -12,11 +12,13 @@ module RSpec
         def initialize(output)
           super
           @group_level = 0
-          @messages = nil
+
+          @example_started = false
+          @messages = []
         end
 
         def example_started(_notification)
-          @messages = []
+          @example_started = true
         end
 
         def example_group_started(notification)
@@ -32,22 +34,28 @@ module RSpec
 
         def example_passed(passed)
           output.puts passed_output(passed.example)
+
           flush_messages
+          @example_started = false
         end
 
         def example_pending(pending)
           output.puts pending_output(pending.example,
                                      pending.example.execution_result.pending_message)
+
           flush_messages
+          @example_started = false
         end
 
         def example_failed(failure)
           output.puts failure_output(failure.example)
+
           flush_messages
+          @example_started = false
         end
 
         def message(notification)
-          if @messages
+          if @example_started
             @messages << notification.message
           else
             output.puts "#{current_indentation}#{notification.message}"
@@ -57,12 +65,12 @@ module RSpec
       private
 
         def flush_messages
-          if @messages
+          if @messages.any?
             @messages.each do |message|
               output.puts "#{current_indentation(1)}#{message}"
             end
 
-            @messages = nil
+            @messages.clear
           end
         end
 

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -50,7 +50,7 @@ module RSpec
           if @messages
             @messages << notification.message
           else
-            output.puts "#{current_indentation(1)}#{notification.message}"
+            output.puts "#{current_indentation}#{notification.message}"
           end
         end
 

--- a/lib/rspec/core/formatters/documentation_formatter.rb
+++ b/lib/rspec/core/formatters/documentation_formatter.rb
@@ -65,13 +65,11 @@ module RSpec
       private
 
         def flush_messages
-          if @messages.any?
-            @messages.each do |message|
-              output.puts "#{current_indentation(1)}#{message}"
-            end
-
-            @messages.clear
+          @messages.each do |message|
+            output.puts "#{current_indentation(1)}#{message}"
           end
+
+          @messages.clear
         end
 
         def passed_output(example)

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -81,7 +81,7 @@ root
 ")
     end
 
-    it "can output indented messages" do
+    it "can output indented messages from within example group" do
       root = RSpec.describe("root")
       root.example("example") {|example| example.reporter.message("message")}
 
@@ -91,6 +91,23 @@ root
 root
   example
     message
+")
+    end
+
+    it "can output indented messages" do
+      root = RSpec.describe("root")
+      context = root.describe("nested")
+      context.example("example") {}
+
+      root.run(reporter)
+
+      reporter.message("message")
+
+      expect(formatter_output.string).to eql("
+root
+  nested
+    example
+  message
 ")
     end
 

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -89,8 +89,8 @@ root
 
       expect(formatter_output.string).to eql("
 root
-  message
   example
+    message
 ")
     end
 

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -81,6 +81,19 @@ root
 ")
     end
 
+    it "can output indented messages" do
+      root = RSpec.describe("root")
+      root.example("example") {|example| example.reporter.message("message")}
+
+      root.run(reporter)
+
+      expect(formatter_output.string).to eql("
+root
+  message
+  example
+")
+    end
+
     it "strips whitespace for each row" do
       group = RSpec.describe(" root ")
       context1 = group.describe(" nested ")

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -107,7 +107,7 @@ root
 root
   nested
     example
-  message
+message
 ")
     end
 


### PR DESCRIPTION
When using `example.reporter.message`, it would be nice if the messages were indented correctly, so that it's clear it relates to the current spec being executed.