### PR TITLE
Force --no-profile for output dependant specs

### DIFF
--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -20,7 +20,7 @@ RSpec.shared_context "aruba support" do
 
     # So that `RSpec.warning` will go to temp_stderr.
     allow(::Kernel).to receive(:warn) { |msg| temp_stderr.puts(msg) }
-    cmd_parts = Shellwords.split(cmd)
+    cmd_parts = ["--no-profile"] + Shellwords.split(cmd)
 
     handle_current_dir_change do
       cd '.' do

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -25,7 +25,7 @@ module FormatterSupport
     spec_order = options[:seed] ? ["--seed", options[:seed].to_s] : ["--order", "defined"]
 
     options = RSpec::Core::ConfigurationOptions.new([
-      "--format", formatter, *(spec_order + extra_options)
+      "--no-profile", "--format", formatter, *(spec_order + extra_options)
     ])
 
     err, out = StringIO.new, StringIO.new


### PR DESCRIPTION
Fixes an issue highlighted in #2602