### PR TITLE
Improve MemoizedHelpers#subject to work with Singleton

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -1,3 +1,4 @@
+require 'singleton'
 RSpec::Support.require_rspec_support 'reentrant_mutex'
 
 module RSpec
@@ -57,7 +58,16 @@ module RSpec
       def subject
         __memoized.fetch_or_store(:subject) do
           described = described_class || self.class.metadata.fetch(:description_args).first
-          Class === described ? described.new : described
+
+          if described.is_a?(Class)
+            if described.included_modules.include?(::Singleton)
+              described.instance
+            else
+              described.new
+            end
+          else
+            described
+          end
         end
       end
 


### PR DESCRIPTION
I faced some troubles while testing my class with included Singleton method. I passed `MyClass` that includes Singleton to `RSpec#describe`, so I got `NoMethodError: private method 'new' called for MyClass:Class` when I tried to call `subject` inside my spec. So I decided to improve `subject` method to work with Singleton.