### PR TITLE
Only set $SAFE for MRI in spec helper

### DIFF
--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -15,8 +15,9 @@ module RSpecHelpers
   end
 
   # In Ruby 2.7 taint was removed and has no effect, whilst SAFE warns that it
-  # has no effect and will become a normal varible in 3.0.
-  if RUBY_VERSION >= '2.7'
+  # has no effect and will become a normal varible in 3.0. Other engines do not
+  # implement SAFE.
+  if RUBY_VERSION >= '2.7' || (defined?(RUBY_ENGINE) && RUBY_ENGINE != "ruby")
     def with_safe_set_to_level_that_triggers_security_errors
       yield
     end


### PR DESCRIPTION
This PR is to set`$SAFE` only for MRI as I think other engines do not support `$SAFE`.

