### PR TITLE
Add a missing backtick in scenario title

### DIFF
--- a/features/hooks/before_and_after_hooks.feature
+++ b/features/hooks/before_and_after_hooks.feature
@@ -253,7 +253,7 @@ Feature: `before` and `after` hooks
       .after context
       """
 
-  Scenario: `before`/after` blocks defined in configuration are run in order
+  Scenario: `before`/`after` blocks defined in configuration are run in order
     Given a file named "configuration_spec.rb" with:
       """ruby
       require "rspec/expectations"


### PR DESCRIPTION
In the Cucumber-backed documentation, backticks were mismatched in one scenario.  This is a purely aesthetic change.