### PR TITLE
Fixes when given an array as `rspec_opt`

### DIFF
--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -122,7 +122,7 @@ module RSpec
         if ENV['SPEC']
           FileList[ENV['SPEC']].sort
         elsif String === pattern && !File.exist?(pattern)
-          return if rspec_opts =~ /--pattern/
+          return if [*rspec_opts].any? { |opt| opt =~ /--pattern/ }
           "--pattern #{escape pattern}"
         else
           # Before RSpec 3.1, we used `FileList` to get the list of matched

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -77,6 +77,13 @@ module RSpec::Core
           exclude(escape(RSpec::Core::RakeTask::DEFAULT_PATTERN))
         )
       end
+
+      it 'behaves properly if rspec_opts is an array' do
+        task.rspec_opts = %w[--pattern some_specs]
+        expect(spec_command).to include("--pattern some_specs").and(
+          exclude(escape(RSpec::Core::RakeTask::DEFAULT_PATTERN))
+        )
+      end
     end
 
     context "with pattern" do

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -62,15 +62,19 @@ module RSpec::Core
     end
 
     context "with rspec_opts" do
+      include RSpec::Core::ShellEscape
+
       it "adds the rspec_opts" do
         task.rspec_opts = "-Ifoo"
-        expect(spec_command).to match(/#{task.rspec_path}.*-Ifoo/)
+        expect(spec_command).to match(/#{task.rspec_path}.*-Ifoo/).and(
+          include(escape(RSpec::Core::RakeTask::DEFAULT_PATTERN)) # sanity check for following specs
+        )
       end
 
       it 'correctly excludes the default pattern if rspec_opts includes --pattern' do
         task.rspec_opts = "--pattern some_specs"
         expect(spec_command).to include("--pattern some_specs").and(
-          exclude(RSpec::Core::RakeTask::DEFAULT_PATTERN)
+          exclude(escape(RSpec::Core::RakeTask::DEFAULT_PATTERN))
         )
       end
     end


### PR DESCRIPTION
Rspec raketask's `rspec_opt` accepts a string or an array of strings.

In Ruby 2.7 a deprecation warning is generated for arrays. This led me to find and error that was undetected because there is no spec for the array case. Moreover I realized that the existing spec for string was erroneously written. This PR fixes both issues