### PR TITLE
Updated travis build scripts (from rspec-dev): Drop --client Java option

### DIFF
--- a/.rubocop_rspec_base.yml
+++ b/.rubocop_rspec_base.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-01-23T22:37:16+03:00 from the rspec-dev repo.
+# This file was generated on 2020-03-23T20:40:58+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # This file contains defaults for RSpec projects. Individual projects

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-01-23T22:37:16+03:00 from the rspec-dev repo.
+# This file was generated on 2020-03-23T20:40:58+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # In order to install old Rubies, we need to use old Ubuntu distibution.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# This file was generated on 2020-01-23T22:37:16+03:00 from the rspec-dev repo.
+# This file was generated on 2020-03-23T20:40:58+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 version: "{build}"

--- a/script/clone_all_rspec_repos
+++ b/script/clone_all_rspec_repos
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2020-01-23T22:37:16+03:00 from the rspec-dev repo.
+# This file was generated on 2020-03-23T20:40:58+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2020-01-23T22:37:16+03:00 from the rspec-dev repo.
+# This file was generated on 2020-03-23T20:40:58+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -38,12 +38,9 @@ function run_specs_and_record_done {
 
 function run_cukes {
   if [ -d features ]; then
-    # force jRuby to use client mode JVM or a compilation mode thats as close as possible,
-    # idea taken from https://github.com/jruby/jruby/wiki/Improving-startup-time
-    #
     # Note that we delay setting this until we run the cukes because we've seen
     # spec failures in our spec suite due to problems with this mode.
-    export JAVA_OPTS='-client -XX:+TieredCompilation -XX:TieredStopAtLevel=1'
+    export JAVA_OPTS='-XX:+TieredCompilation -XX:TieredStopAtLevel=1'
 
     echo "${PWD}/bin/cucumber"
 

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2020-01-23T22:37:16+03:00 from the rspec-dev repo.
+# This file was generated on 2020-03-23T20:40:58+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 function is_mri {

--- a/script/run_build
+++ b/script/run_build
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2020-01-23T22:37:16+03:00 from the rspec-dev repo.
+# This file was generated on 2020-03-23T20:40:58+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e

--- a/script/travis_functions.sh
+++ b/script/travis_functions.sh
@@ -1,4 +1,4 @@
-# This file was generated on 2020-01-23T22:37:16+03:00 from the rspec-dev repo.
+# This file was generated on 2020-03-23T20:40:58+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 # Taken from:

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This file was generated on 2020-01-23T22:37:16+03:00 from the rspec-dev repo.
+# This file was generated on 2020-03-23T20:40:58+03:00 from the rspec-dev repo.
 # DO NOT modify it by hand as your changes will get lost the next time it is generated.
 
 set -e


### PR DESCRIPTION
This option fails `rspec-rails` build with the latest JVM by emitting a warning that it's deprecated. It's better to be slower than fail.