### PR TITLE
Explicitly support keyword arguments in shared context on 2.7.0

### DIFF
--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -33,8 +33,27 @@ module RSpec
         klass.update_inherited_metadata(@metadata) unless @metadata.empty?
 
         SharedExampleGroupInclusionStackFrame.with_frame(@description, inclusion_line) do
-          klass.class_exec(*args, &@definition)
+          klass_exec(klass, *args, &@definition)
           klass.class_exec(&customization_block) if customization_block
+        end
+      end
+
+    private
+
+      if RSpec::Support::RubyFeatures.kw_args_supported?
+        # Remove this in RSpec 4 in favour of explictly passed in kwargs down the entire
+        # stack, e.g. rspec/rspec-core#2711
+        def klass_exec(klass, *args, &definition)
+          if RSpec::Support::MethodSignature.new(definition).has_kw_args_in?(args)
+            kwargs = args.pop
+            klass.class_exec(*args, **kwargs, &definition)
+          else
+            klass.class_exec(*args, &definition)
+          end
+        end
+      else
+        def klass_exec(klass, *args, &definition)
+          klass.class_exec(*args, &definition)
         end
       end
     end

--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -43,6 +43,7 @@ module RSpec
       if RSpec::Support::RubyFeatures.kw_args_supported?
         # Remove this in RSpec 4 in favour of explictly passed in kwargs down the entire
         # stack, e.g. rspec/rspec-core#2711
+        binding.eval(<<-CODE, __FILE__, __LINE__)
         def klass_exec(klass, *args, &definition)
           if RSpec::Support::MethodSignature.new(definition).has_kw_args_in?(args)
             kwargs = args.pop
@@ -51,6 +52,7 @@ module RSpec
             klass.class_exec(*args, &definition)
           end
         end
+        CODE
       else
         def klass_exec(klass, *args, &definition)
           klass.class_exec(*args, &definition)

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -543,6 +543,16 @@ module RSpec
               expect(group).to have_example_descriptions("a different spec")
             end
           end
+
+          context "supporting kwargs" do
+            __send__ shared_method_name, "shared context" do |foo:|
+              it "has an expected value" do
+                expect(foo).to eq("bar")
+              end
+            end
+
+            it_behaves_like "shared context", foo: "bar"
+          end
         end
       end
     end

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -544,14 +544,18 @@ module RSpec
             end
           end
 
-          context "supporting kwargs" do
-            __send__ shared_method_name, "shared context" do |foo:|
-              it "has an expected value" do
-                expect(foo).to eq("bar")
+          if RSpec::Support::RubyFeatures.required_kw_args_supported?
+            binding.eval(<<-CODE, __FILE__, __LINE__)
+            context "supporting kwargs" do
+              __send__ shared_method_name, "shared context" do |foo:|
+                it "has an expected value" do
+                  expect(foo).to eq("bar")
+                end
               end
-            end
 
-            it_behaves_like "shared context", foo: "bar"
+              it_behaves_like "shared context", foo: "bar"
+            end
+            CODE
           end
         end
       end


### PR DESCRIPTION
This is an alternative #2711 that uses the method signature from rspec-support to conditionally apply keyword arguments on supporting rubies, it is 1.8.7 compatible.

This is a shorter change, but not a better one, it should be replaced by #2711 when we work on RSpec 4.