### PR TITLE
Allow optional trapping of interrupts, and restore previous interrupt…

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -230,6 +230,10 @@ module RSpec
         end
       end
 
+      # @macro trap_interrupt
+      # Default: `true`.
+      add_setting :trap_interrupt
+
       # @macro add_setting
       # Prints the formatter output of your suite without running any
       # examples or hooks.
@@ -522,6 +526,7 @@ module RSpec
         @failure_exit_code = 1
         @fail_if_no_examples = false
         @spec_files_loaded = false
+        @trap_interrupt = true
 
         @backtrace_formatter = BacktraceFormatter.new
 


### PR DESCRIPTION
… handler after running tests.

My suggestion is to make this the default for RSpec 4.0 because I think it's best for RSpec to be minimally intrusive on tests. What I mean by that is some code may wish to test the behaviour of SIGINT or depend on it's behaviour. The less global state RSpec is changing/manipulating, the better IMHO.