### PR TITLE
Make World.reset also reset example group counts

### DIFF
--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -5,7 +5,7 @@ module RSpec
     # Internal container for global non-configuration data.
     class World
       # @private
-      attr_reader :example_groups, :filtered_examples
+      attr_reader :example_groups, :filtered_examples, :example_group_counts_by_spec_file
 
       # Used internally to determine what to do when a SIGINT is received.
       attr_accessor :wants_to_quit
@@ -53,6 +53,7 @@ module RSpec
         example_groups.clear
         @sources_by_path.clear if defined?(@sources_by_path)
         @syntax_highlighter = nil
+        @example_group_counts_by_spec_file = Hash.new(0)
       end
 
       # @private

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -36,6 +36,14 @@ module RSpec::Core
           RSpec.world.reset
         }.to change(RSpec::ExampleGroups, :constants).to([])
       end
+
+      it 'clears #example_group_counts_by_spec_file' do
+        RSpec.describe "group"
+
+        expect {
+          RSpec.world.reset
+        }.to change { world.example_group_counts_by_spec_file }.to be_empty
+      end
     end
 
     describe "#example_groups" do


### PR DESCRIPTION
If we don't reset example group counts in custom runners that run from
the same process, example metadata end up being published with incorrect
scoped IDs.

`World#example_group_counts_by_spec_file` is merely added for testability.

Fixes #2721