### PR TITLE
Prevent rspec-expectations from issuing a warning when combined with rspec-core

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -761,8 +761,9 @@ module RSpec
                 "on an example group (e.g. a `describe` or `context` block)."
         end
 
-        super
+        super(name, *args)
       end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
     end
     # rubocop:enable Metrics/ClassLength
 


### PR DESCRIPTION


This fixes the failing CI in rspec/rspec-expectations#1187