### PR TITLE
Fix bug with bisect and custom error codes

### DIFF
--- a/lib/rspec/core/invocations.rb
+++ b/lib/rspec/core/invocations.rb
@@ -37,7 +37,7 @@ module RSpec
             runner, options.args, formatter
           )
 
-          success ? 0 : 1
+          success ? 0 : runner.configuration.failure_exit_code
         end
 
       private

--- a/spec/rspec/core/invocations_spec.rb
+++ b/spec/rspec/core/invocations_spec.rb
@@ -111,6 +111,16 @@ module RSpec::Core
 
           expect(exit_code).to eq(1)
         end
+
+        context "with a custom failure code set" do
+          it "returns the custom failure code" do
+            in_sub_process do
+              RSpec.configuration.failure_exit_code = 42
+              exit_code = run_invocation
+              expect(exit_code).to eq(42)
+            end
+          end
+        end
       end
 
       context "and the verbose option is specified" do


### PR DESCRIPTION
The bisector was hardcoded to return 1 for failure rather than a custom error code if configured.