### PR TITLE
Avoid be_falsey and be_truthy 

### DIFF
--- a/features/clear_examples.feature
+++ b/features/clear_examples.feature
@@ -34,7 +34,7 @@ Feature: Running specs multiple times with different runner options in the same 
     RSpec.describe "truth" do
       describe true do
         it "is truthy" do
-          expect(true).to be_truthy
+          expect(true).to be(true)
         end
 
         it "is not falsy" do
@@ -48,7 +48,7 @@ Feature: Running specs multiple times with different runner options in the same 
         end
 
         it "is truthy" do
-          expect(false).not_to be_truthy
+          expect(false).not_to be(true)
         end
       end
     end

--- a/features/clear_examples.feature
+++ b/features/clear_examples.feature
@@ -34,7 +34,7 @@ Feature: Running specs multiple times with different runner options in the same 
     RSpec.describe "truth" do
       describe true do
         it "is truthy" do
-          expect(true).to be(true)
+          expect(true).to be_truthy
         end
 
         it "is not falsy" do
@@ -48,7 +48,7 @@ Feature: Running specs multiple times with different runner options in the same 
         end
 
         it "is truthy" do
-          expect(false).not_to be(true)
+          expect(false).not_to be_truthy
         end
       end
     end

--- a/features/configuration/custom_settings.feature
+++ b/features/configuration/custom_settings.feature
@@ -14,18 +14,14 @@ Feature: custom settings
           expect(RSpec.configuration.custom_setting).to be_nil
         end
 
-        it "acts false by default" do
-          expect(RSpec.configuration.custom_setting).to be_falsey
-        end
-
         it "is exposed as a predicate" do
-          expect(RSpec.configuration.custom_setting?).to be_falsey
+          expect(RSpec.configuration.custom_setting?).to be(false)
         end
 
         it "can be overridden" do
           RSpec.configuration.custom_setting = true
-          expect(RSpec.configuration.custom_setting).to be_truthy
-          expect(RSpec.configuration.custom_setting?).to be_truthy
+          expect(RSpec.configuration.custom_setting).to be(true)
+          expect(RSpec.configuration.custom_setting?).to be(true)
         end
       end
       """
@@ -41,17 +37,17 @@ Feature: custom settings
 
       RSpec.describe "custom setting" do
         it "is true by default" do
-          expect(RSpec.configuration.custom_setting).to be_truthy
+          expect(RSpec.configuration.custom_setting).to be(true)
         end
 
         it "is exposed as a predicate" do
-          expect(RSpec.configuration.custom_setting?).to be_truthy
+          expect(RSpec.configuration.custom_setting?).to be(true)
         end
 
         it "can be overridden" do
           RSpec.configuration.custom_setting = false
-          expect(RSpec.configuration.custom_setting).to be_falsey
-          expect(RSpec.configuration.custom_setting?).to be_falsey
+          expect(RSpec.configuration.custom_setting).to be(false)
+          expect(RSpec.configuration.custom_setting?).to be(false)
         end
       end
       """
@@ -71,11 +67,11 @@ Feature: custom settings
 
       RSpec.describe "custom setting" do
         it "returns the value set in the last cofigure block to get eval'd" do
-          expect(RSpec.configuration.custom_setting).to be_truthy
+          expect(RSpec.configuration.custom_setting).to be(true)
         end
 
         it "is exposed as a predicate" do
-          expect(RSpec.configuration.custom_setting?).to be_truthy
+          expect(RSpec.configuration.custom_setting?).to be(true)
         end
       end
       """

--- a/features/example_groups/shared_examples.feature
+++ b/features/example_groups/shared_examples.feature
@@ -106,13 +106,13 @@ Feature: shared examples
         describe "#include?" do
           context "with an item that is in the collection" do
             it "returns true" do
-              expect(collection.include?(7)).to be_truthy
+              expect(collection.include?(7)).to be(true)
             end
           end
 
           context "with an item that is not in the collection" do
             it "returns false" do
-              expect(collection.include?(9)).to be_falsey
+              expect(collection.include?(9)).to be(false)
             end
           end
         end

--- a/features/hooks/around_hooks.feature
+++ b/features/hooks/around_hooks.feature
@@ -219,7 +219,7 @@ Feature: `around` hooks
         end
 
         it "runs the example in the correct context" do
-          expect(included_in_configure_block).to be_truthy
+          expect(included_in_configure_block).to be(true)
         end
       end
       """

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -75,7 +75,13 @@ module RSpec
 
       # @private
       def self.define_predicate_for(*names)
-        names.each { |name| alias_method "#{name}?", name }
+        names.each do |name|
+          class_eval <<-PREDICATE, __FILE__ , __LINE__ + 1
+            def #{name}?
+              !!#{name}
+            end
+          PREDICATE
+        end
       end
 
       # @private
@@ -1038,6 +1044,7 @@ module RSpec
       #
       # Defaults `profile_examples` to 10 examples when `@profile_examples` is
       # `true`.
+      remove_method :profile_examples
       def profile_examples
         profile = value_for(:profile_examples) { @profile_examples }
         if profile && !profile.is_a?(Integer)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -75,11 +75,9 @@ module RSpec
 
       # @private
       def self.define_predicate(name)
-        class_eval <<-PREDICATE, __FILE__ , __LINE__ + 1
-          def #{name}?
-            !!#{name}
-          end
-        PREDICATE
+        define_method "#{name}?" do
+          !!send(name)
+        end
       end
 
       # @private

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -318,7 +318,8 @@ module RSpec
       # Report the times for the slowest examples (default: `false`).
       # Use this to specify the number of examples to include in the profile.
       # @return [Boolean]
-      add_setting :profile_examples
+      attr_writer :profile_examples
+      define_predicate :profile_examples
 
       # @macro add_setting
       # Run all examples if none match the configured filters
@@ -1044,7 +1045,6 @@ module RSpec
       #
       # Defaults `profile_examples` to 10 examples when `@profile_examples` is
       # `true`.
-      remove_method :profile_examples
       def profile_examples
         profile = value_for(:profile_examples) { @profile_examples }
         if profile && !profile.is_a?(Integer)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -67,21 +67,19 @@ module RSpec
       end
 
       # @private
-      def self.define_aliases(name, alias_name)
+      def self.define_alias(name, alias_name)
         alias_method alias_name, name
         alias_method "#{alias_name}=", "#{name}="
-        define_predicate_for alias_name
+        define_predicate alias_name
       end
 
       # @private
-      def self.define_predicate_for(*names)
-        names.each do |name|
-          class_eval <<-PREDICATE, __FILE__ , __LINE__ + 1
-            def #{name}?
-              !!#{name}
-            end
-          PREDICATE
-        end
+      def self.define_predicate(name)
+        class_eval <<-PREDICATE, __FILE__ , __LINE__ + 1
+          def #{name}?
+            !!#{name}
+          end
+        PREDICATE
       end
 
       # @private
@@ -94,7 +92,7 @@ module RSpec
         add_read_only_setting name
 
         Array(opts[:alias_with]).each do |alias_name|
-          define_aliases(name, alias_name)
+          define_alias(name, alias_name)
         end
       end
 
@@ -104,7 +102,7 @@ module RSpec
       def self.add_read_only_setting(name, opts={})
         raise "Use the instance add_setting method if you want to set a default" if opts.key?(:default)
         define_reader name
-        define_predicate_for name
+        define_predicate name
       end
 
       # @macro [attach] add_setting

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -17,6 +17,7 @@ module RSpec
       attr_accessor :non_example_failure
 
       def initialize(configuration=RSpec.configuration)
+        @wants_to_quit = false
         @configuration = configuration
         configuration.world = self
         @example_groups = []

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -296,16 +296,16 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
   end
 
   describe "--fail-fast" do
-    it "defaults to false" do
-      expect(parse_options[:fail_fast]).to be_falsey
+    it "defaults to nil" do
+      expect(parse_options[:fail_fast]).to be(nil)
     end
 
-    it "sets fail_fast on config" do
-      expect(parse_options("--fail-fast")[:fail_fast]).to be_truthy
+    it "sets fail_fast to 1 on config" do
+      expect(parse_options("--fail-fast")[:fail_fast]).to be(1)
     end
 
-    it "sets fail_fast on config" do
-      expect(parse_options("--no-fail-fast")[:fail_fast]).to be_falsey
+    it "sets fail_fast to false on config" do
+      expect(parse_options("--no-fail-fast")[:fail_fast]).to be(false)
     end
   end
 
@@ -322,12 +322,12 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
   end
 
   describe "--dry-run" do
-    it "defaults to false" do
-      expect(parse_options[:dry_run]).to be_falsey
+    it "defaults to nil" do
+      expect(parse_options[:dry_run]).to be(nil)
     end
 
     it "sets dry_run on config" do
-      expect(parse_options("--dry-run")[:dry_run]).to be_truthy
+      expect(parse_options("--dry-run")[:dry_run]).to be(true)
     end
   end
 
@@ -464,7 +464,7 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
 
         expect(options[:requires]).to eq(["some_file"])
         expect(options[:full_description]).to eq([/foo\ bar/])
-        expect(options[:drb]).to be_truthy
+        expect(options[:drb]).to be(true)
         expect(options[:formatters]).to eq([['global']])
       end
     end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1301,7 +1301,7 @@ module RSpec::Core
 
     describe "#run_all_when_everything_filtered?" do
 
-      it "defaults to nil" do
+      it "defaults to false" do
         expect(config.run_all_when_everything_filtered?).to be(false)
       end
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -293,7 +293,7 @@ module RSpec::Core
           mod_config.custom_setting = true
         end
 
-        expect(mod.configuration.custom_setting).to be_truthy
+        expect(mod.configuration.custom_setting).to be(true)
       end
 
       it "raises if framework module doesn't support configuration" do
@@ -1301,13 +1301,13 @@ module RSpec::Core
 
     describe "#run_all_when_everything_filtered?" do
 
-      it "defaults to false" do
-        expect(config.run_all_when_everything_filtered?).to be_falsey
+      it "defaults to nil" do
+        expect(config.run_all_when_everything_filtered?).to be(false)
       end
 
       it "can be queried with question method" do
         config.run_all_when_everything_filtered = true
-        expect(config.run_all_when_everything_filtered?).to be_truthy
+        expect(config.run_all_when_everything_filtered?).to be(true)
       end
     end
 
@@ -1779,14 +1779,14 @@ module RSpec::Core
         config_2 = Configuration.new
 
         config_1.full_backtrace = true
-        expect(config_2.full_backtrace?).to be_falsey
+        expect(config_2.full_backtrace?).to be(false)
       end
     end
 
     describe "#backtrace_exclusion_patterns=" do
       it "actually receives the new filter values" do
         config.backtrace_exclusion_patterns = [/.*/]
-        expect(config.backtrace_formatter.exclude? "this").to be_truthy
+        expect(config.backtrace_formatter.exclude? "this").to be(true)
       end
     end
 
@@ -1805,7 +1805,7 @@ module RSpec::Core
     describe "#backtrace_exclusion_patterns" do
       it "can be appended to" do
         config.backtrace_exclusion_patterns << /.*/
-        expect(config.backtrace_formatter.exclude? "this").to be_truthy
+        expect(config.backtrace_formatter.exclude? "this").to be(true)
       end
     end
 
@@ -2213,7 +2213,7 @@ module RSpec::Core
           end
 
           it "adds a predicate" do
-            expect(config.custom_option?).to be_falsey
+            expect(config.custom_option?).to be(false)
           end
 
           it "can be overridden" do
@@ -2232,7 +2232,7 @@ module RSpec::Core
           end
 
           it "returns true for the predicate" do
-            expect(config.custom_option?).to be_truthy
+            expect(config.custom_option?).to be(true)
           end
 
           it "can be overridden with a truthy value" do
@@ -2269,7 +2269,7 @@ module RSpec::Core
 
         it "delegates the predicate to the other option" do
           config.custom_option = true
-          expect(config.another_custom_option?).to be_truthy
+          expect(config.another_custom_option?).to be(true)
         end
       end
     end
@@ -2526,11 +2526,11 @@ module RSpec::Core
       it "forces 'false' value" do
         config.add_setting :custom_option
         config.custom_option = true
-        expect(config.custom_option?).to be_truthy
+        expect(config.custom_option?).to be(true)
         config.force :custom_option => false
-        expect(config.custom_option?).to be_falsey
+        expect(config.custom_option?).to be(false)
         config.custom_option = true
-        expect(config.custom_option?).to be_falsey
+        expect(config.custom_option?).to be(false)
       end
     end
 

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -180,7 +180,7 @@ module RSpec::Core
 
       it 'does not have problems with example groups named "Core"', :unless => RUBY_VERSION == '1.9.2' do
         RSpec.describe("Core")
-        expect(defined?(::RSpec::ExampleGroups::Core)).to be_truthy
+        expect(defined?(::RSpec::ExampleGroups::Core)).to eq('constant')
 
         # The original bug was triggered when a group was defined AFTER one named `Core`,
         # due to it not using the fully qualified `::RSpec::Core::ExampleGroup` constant.
@@ -190,7 +190,7 @@ module RSpec::Core
 
       it 'does not have problems with example groups named "RSpec"', :unless => RUBY_VERSION == '1.9.2' do
         RSpec.describe("RSpec")
-        expect(defined?(::RSpec::ExampleGroups::RSpec)).to be_truthy
+        expect(defined?(::RSpec::ExampleGroups::RSpec)).to eq('constant')
 
         # The original bug was triggered when a group was defined AFTER one named `RSpec`,
         # due to it not using the fully qualified `::RSpec::Core::ExampleGroup` constant.
@@ -535,7 +535,7 @@ module RSpec::Core
               end
             end
 
-            expect(group.run).to be_truthy
+            expect(group.run).to be(true)
           end
         end
 
@@ -551,7 +551,7 @@ module RSpec::Core
               end
             end
 
-            expect(group.run).to be_truthy
+            expect(group.run).to be(true)
           end
         end
       end
@@ -566,7 +566,7 @@ module RSpec::Core
             end
           end
 
-          expect(group.run).to be_truthy, "expected examples in group to pass"
+          expect(group.run).to be(true), "expected examples in group to pass"
         end
 
         context "when a class is passed" do
@@ -662,7 +662,7 @@ module RSpec::Core
         let(:focused_example) { RSpec.describe.send example_alias, "a focused example" }
 
         it 'defines an example that can be filtered with :focus => true' do
-          expect(focused_example.metadata[:focus]).to be_truthy
+          expect(focused_example.metadata[:focus]).to be(true)
         end
       end
     end
@@ -778,7 +778,7 @@ module RSpec::Core
         group.example("example") {}
 
         group.run
-        expect(RSpec.world.wants_to_quit).to be_falsey
+        expect(RSpec.world.wants_to_quit).to be(false)
       end
 
       it "runs the before eachs in order" do
@@ -941,7 +941,7 @@ module RSpec::Core
         group = RSpec.describe
         group.before(:all) { raise "error in before all" }
         example = group.example("equality") { expect(1).to eq(2) }
-        expect(group.run).to be_falsey
+        expect(group.run).to be(false)
 
         expect(example.metadata).not_to be_nil
         expect(example.execution_result.exception).not_to be_nil
@@ -1291,7 +1291,7 @@ module RSpec::Core
           example('ex 2') { expect(1).to eq(1) }
         end
         allow(group).to receive(:filtered_examples) { group.examples }
-        expect(group.run(reporter)).to be_truthy
+        expect(group.run(reporter)).to be(true)
       end
 
       it "returns false if any of the examples fail" do
@@ -1300,7 +1300,7 @@ module RSpec::Core
           example('ex 2') { expect(1).to eq(2) }
         end
         allow(group).to receive(:filtered_examples) { group.examples }
-        expect(group.run(reporter)).to be_falsey
+        expect(group.run(reporter)).to be(false)
       end
 
       it "runs all examples, regardless of any of them failing" do
@@ -1312,7 +1312,7 @@ module RSpec::Core
         group.filtered_examples.each do |example|
           expect(example).to receive(:run)
         end
-        expect(group.run(reporter)).to be_falsey
+        expect(group.run(reporter)).to be(false)
       end
     end
 
@@ -1366,12 +1366,12 @@ module RSpec::Core
     describe "ivars are not shared across examples" do
       it "(first example)" do
         @a = 1
-        expect(defined?(@b)).to be_falsey
+        expect(defined?(@b)).to be(nil)
       end
 
       it "(second example)" do
         @b = 2
-        expect(defined?(@a)).to be_falsey
+        expect(defined?(@a)).to be(nil)
       end
     end
 
@@ -1427,8 +1427,8 @@ module RSpec::Core
         it "sets RSpec.world.wants_to_quit flag if encountering an exception in before(:all)" do
           group().before(:all) { raise "error in before all" }
           group().example("equality") { expect(1).to eq(2) }
-          expect(group().run(reporter)).to be_falsey
-          expect(RSpec.world.wants_to_quit).to be_truthy
+          expect(group().run(reporter)).to be(false)
+          expect(RSpec.world.wants_to_quit).to be(true)
         end
       end
 
@@ -1457,7 +1457,7 @@ module RSpec::Core
 
           expect(group().run(reporter)).to be false
 
-          expect(RSpec.world.wants_to_quit).to be_falsey
+          expect(RSpec.world.wants_to_quit).to be(false)
         end
 
         it "sets RSpec.world.wants_to_quit flag if encountering an exception in before(:all) causing at least 3 failures" do
@@ -1500,7 +1500,7 @@ module RSpec::Core
             end
           end
 
-          expect(group.run(reporter)).to be_truthy
+          expect(group.run(reporter)).to be(true)
         end
       end
 
@@ -1517,7 +1517,7 @@ module RSpec::Core
             end
           end
 
-          expect(group.run(reporter)).to be_falsey
+          expect(group.run(reporter)).to be(false)
         end
       end
 
@@ -1534,7 +1534,7 @@ module RSpec::Core
             end
           end
 
-          expect(group.run(reporter)).to be_falsey
+          expect(group.run(reporter)).to be(false)
         end
       end
     end
@@ -1751,7 +1751,7 @@ module RSpec::Core
               def foo; "bar"; end
             end
           end
-          expect(group.run).to be_truthy
+          expect(group.run).to be(true)
         end
       end
     end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -180,7 +180,7 @@ module RSpec::Core
 
       it 'does not have problems with example groups named "Core"', :unless => RUBY_VERSION == '1.9.2' do
         RSpec.describe("Core")
-        expect(defined?(::RSpec::ExampleGroups::Core)).to eq('constant')
+        expect(defined?(::RSpec::ExampleGroups::Core)).to be
 
         # The original bug was triggered when a group was defined AFTER one named `Core`,
         # due to it not using the fully qualified `::RSpec::Core::ExampleGroup` constant.
@@ -190,7 +190,7 @@ module RSpec::Core
 
       it 'does not have problems with example groups named "RSpec"', :unless => RUBY_VERSION == '1.9.2' do
         RSpec.describe("RSpec")
-        expect(defined?(::RSpec::ExampleGroups::RSpec)).to eq('constant')
+        expect(defined?(::RSpec::ExampleGroups::RSpec)).to be
 
         # The original bug was triggered when a group was defined AFTER one named `RSpec`,
         # due to it not using the fully qualified `::RSpec::Core::ExampleGroup` constant.

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
         example('example') { expect(1).to eq(1) }
       end
       group.run
-      expect(after_run).to be_truthy, "expected after(:each) to be run"
+      expect(after_run).to be(true), "expected after(:each) to be run"
     end
 
     it "runs after(:each) when the example fails" do
@@ -381,7 +381,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
         example('example') { expect(1).to eq(2) }
       end
       group.run
-      expect(after_run).to be_truthy, "expected after(:each) to be run"
+      expect(after_run).to be(true), "expected after(:each) to be run"
     end
 
     it "runs after(:each) when the example raises an Exception" do
@@ -391,7 +391,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
         example('example') { raise "this error" }
       end
       group.run
-      expect(after_run).to be_truthy, "expected after(:each) to be run"
+      expect(after_run).to be(true), "expected after(:each) to be run"
     end
 
     context "with an after(:each) that raises" do
@@ -403,7 +403,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
           example('example') { expect(1).to eq(1) }
         end
         group.run
-        expect(after_run).to be_truthy, "expected after(:each) to be run"
+        expect(after_run).to be(true), "expected after(:each) to be run"
       end
 
       it "stores the exception" do

--- a/spec/rspec/core/filter_manager_spec.rb
+++ b/spec/rspec/core/filter_manager_spec.rb
@@ -443,46 +443,46 @@ module RSpec::Core
       describe "the default :if filter" do
         it "does not exclude a spec with  { :if => true } metadata" do
           example = example_with_metadata(:if => true)
-          expect(exclude?(example)).to be_falsey
+          expect(exclude?(example)).to be(false)
         end
 
         it "excludes a spec with  { :if => false } metadata" do
           example = example_with_metadata(:if => false)
-          expect(exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be(true)
         end
 
         it "excludes a spec with  { :if => nil } metadata" do
           example = example_with_metadata(:if => nil)
-          expect(exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be(true)
         end
 
         it "continues to be an exclusion even if exclusions are cleared" do
           example = example_with_metadata(:if => false)
           filter_manager.exclusions.clear
-          expect(exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be(true)
         end
       end
 
       describe "the default :unless filter" do
         it "excludes a spec with  { :unless => true } metadata" do
           example = example_with_metadata(:unless => true)
-          expect(exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be(true)
         end
 
         it "does not exclude a spec with { :unless => false } metadata" do
           example = example_with_metadata(:unless => false)
-          expect(exclude?(example)).to be_falsey
+          expect(exclude?(example)).to be(false)
         end
 
         it "does not exclude a spec with { :unless => nil } metadata" do
           example = example_with_metadata(:unless => nil)
-          expect(exclude?(example)).to be_falsey
+          expect(exclude?(example)).to be(false)
         end
 
         it "continues to be an exclusion even if exclusions are cleared" do
           example = example_with_metadata(:unless => true)
           filter_manager.exclusions.clear
-          expect(exclude?(example)).to be_truthy
+          expect(exclude?(example)).to be(true)
         end
       end
     end

--- a/spec/rspec/core/metadata_filter_spec.rb
+++ b/spec/rspec/core/metadata_filter_spec.rb
@@ -60,45 +60,45 @@ module RSpec
           it "matches the group when the line_number is the example group line number" do
             # this call doesn't really make sense since filter_applies? is only called
             # for example metadata not group metadata
-            expect(filter_applies?(condition_key, group_condition, group_metadata)).to be_truthy
+            expect(filter_applies?(condition_key, group_condition, group_metadata)).to be(true)
           end
 
           it "matches the example when the line_number is the grandparent example group line number" do
-            expect(filter_applies?(condition_key, parent_group_condition, example_metadata)).to be_truthy
+            expect(filter_applies?(condition_key, parent_group_condition, example_metadata)).to be(true)
           end
 
           it "matches the example when the line_number is the parent example group line number" do
-            expect(filter_applies?(condition_key, group_condition, example_metadata)).to be_truthy
+            expect(filter_applies?(condition_key, group_condition, example_metadata)).to be(true)
           end
 
           it "matches the example when the line_number is the example line number" do
-            expect(filter_applies?(condition_key, example_condition, example_metadata)).to be_truthy
+            expect(filter_applies?(condition_key, example_condition, example_metadata)).to be(true)
           end
 
           it "matches when the line number is between this example and the next" do
-            expect(filter_applies?(condition_key, between_examples_condition, example_metadata)).to be_truthy
+            expect(filter_applies?(condition_key, between_examples_condition, example_metadata)).to be(true)
           end
 
           it "does not match when the line number matches the next example" do
-            expect(filter_applies?(condition_key, next_example_condition, example_metadata)).to be_falsey
+            expect(filter_applies?(condition_key, next_example_condition, example_metadata)).to be(false)
           end
         end
 
         it "matches a proc with no arguments that evaluates to true" do
-          expect(filter_applies?(:if, lambda { true }, example_metadata)).to be_truthy
+          expect(filter_applies?(:if, lambda { true }, example_metadata)).to be(true)
         end
 
         it "matches a proc that evaluates to true" do
-          expect(filter_applies?(:if, lambda { |v| v }, example_metadata)).to be_truthy
+          expect(filter_applies?(:if, lambda { |v| v }, example_metadata)).to be(true)
         end
 
         it "does not match a proc that evaluates to false" do
-          expect(filter_applies?(:if, lambda { |v| !v }, example_metadata)).to be_falsey
+          expect(filter_applies?(:if, lambda { |v| !v }, example_metadata)).to be(false)
         end
 
         it "matches a proc with an arity of 2" do
           example_metadata[:foo] = nil
-          expect(filter_applies?(:foo, lambda { |v, m| m == example_metadata }, example_metadata)).to be_truthy
+          expect(filter_applies?(:foo, lambda { |v, m| m == example_metadata }, example_metadata)).to be(true)
         end
 
         it "raises an error when the proc has an incorrect arity" do
@@ -151,26 +151,26 @@ module RSpec
         context "with a nested hash" do
           it 'matches when the nested entry matches' do
             metadata = { :foo => { :bar => "words" } }
-            expect(filter_applies?(:foo, { :bar => /wor/ }, metadata)).to be_truthy
+            expect(filter_applies?(:foo, { :bar => /wor/ }, metadata)).to be(true)
           end
 
           it 'does not match when the nested entry does not match' do
             metadata = { :foo => { :bar => "words" } }
-            expect(filter_applies?(:foo, { :bar => /sword/ }, metadata)).to be_falsey
+            expect(filter_applies?(:foo, { :bar => /sword/ }, metadata)).to be(false)
           end
 
           it 'does not match when the metadata lacks the key' do
-            expect(filter_applies?(:foo, { :bar => /sword/ }, {})).to be_falsey
+            expect(filter_applies?(:foo, { :bar => /sword/ }, {})).to be(false)
           end
 
           it 'does not match when the metadata does not have a hash entry for the key' do
             metadata = { :foo => "words" }
-            expect(filter_applies?(:foo, { :bar => /word/ }, metadata)).to be_falsey
+            expect(filter_applies?(:foo, { :bar => /word/ }, metadata)).to be(false)
           end
 
           it 'matches when a metadata key is specified without a value and exists in the metadata hash' do
             metadata = { :foo => "words" }
-            expect(filter_applies?(:foo, true, metadata)).to be_truthy
+            expect(filter_applies?(:foo, true, metadata)).to be(true)
           end
         end
 
@@ -184,39 +184,39 @@ module RSpec
           end
 
           it "matches a symbol" do
-            expect(filter_applies?(:tag, 'one', metadata_with_array)).to be_truthy
-            expect(filter_applies?(:tag, :one, metadata_with_array)).to be_truthy
-            expect(filter_applies?(:tag, 'two', metadata_with_array)).to be_falsey
+            expect(filter_applies?(:tag, 'one', metadata_with_array)).to be(true)
+            expect(filter_applies?(:tag, :one, metadata_with_array)).to be(true)
+            expect(filter_applies?(:tag, 'two', metadata_with_array)).to be(false)
           end
 
           it "matches a string" do
-            expect(filter_applies?(:tag, 'three', metadata_with_array)).to be_truthy
-            expect(filter_applies?(:tag, :three, metadata_with_array)).to be_truthy
-            expect(filter_applies?(:tag, 'tree', metadata_with_array)).to be_falsey
+            expect(filter_applies?(:tag, 'three', metadata_with_array)).to be(true)
+            expect(filter_applies?(:tag, :three, metadata_with_array)).to be(true)
+            expect(filter_applies?(:tag, 'tree', metadata_with_array)).to be(false)
           end
 
           it "matches an integer" do
-            expect(filter_applies?(:tag, '2', metadata_with_array)).to be_truthy
-            expect(filter_applies?(:tag, 2, metadata_with_array)).to be_truthy
-            expect(filter_applies?(:tag, 3, metadata_with_array)).to be_falsey
+            expect(filter_applies?(:tag, '2', metadata_with_array)).to be(true)
+            expect(filter_applies?(:tag, 2, metadata_with_array)).to be(true)
+            expect(filter_applies?(:tag, 3, metadata_with_array)).to be(false)
           end
 
           it "matches a regexp" do
-            expect(filter_applies?(:tag, 'four', metadata_with_array)).to be_truthy
-            expect(filter_applies?(:tag, 'fourtune', metadata_with_array)).to be_truthy
-            expect(filter_applies?(:tag, 'fortune', metadata_with_array)).to be_falsey
+            expect(filter_applies?(:tag, 'four', metadata_with_array)).to be(true)
+            expect(filter_applies?(:tag, 'fourtune', metadata_with_array)).to be(true)
+            expect(filter_applies?(:tag, 'fortune', metadata_with_array)).to be(false)
           end
 
           it "matches a proc that evaluates to true" do
-            expect(filter_applies?(:tag, lambda { |values| values.include? 'three' }, metadata_with_array)).to be_truthy
+            expect(filter_applies?(:tag, lambda { |values| values.include? 'three' }, metadata_with_array)).to be(true)
           end
 
           it "does not match a proc that evaluates to false" do
-            expect(filter_applies?(:tag, lambda { |values| values.include? 'nothing' }, metadata_with_array)).to be_falsey
+            expect(filter_applies?(:tag, lambda { |values| values.include? 'nothing' }, metadata_with_array)).to be(false)
           end
 
           it 'matches when a metadata key is specified without a value and exists in the metadata hash' do
-            expect(filter_applies?(:tag, true, metadata_with_array)).to be_truthy
+            expect(filter_applies?(:tag, true, metadata_with_array)).to be(true)
           end
         end
       end

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -89,7 +89,7 @@ module RSpec::Core
         it 'sets the `:drb` option to true' do
           options = parser.parse
 
-          expect(options[:drb]).to be_truthy
+          expect(options[:drb]).to be(true)
         end
 
         it 'sets the `:runner` option with the `DrbWithFallback` invocation' do
@@ -339,7 +339,7 @@ module RSpec::Core
       it "sets the `:bisect` option" do
         options = Parser.parse(%w[ --bisect ])
 
-        expect(options[:bisect]).to be_truthy
+        expect(options[:bisect]).to be(true)
       end
 
       it "sets the `:runner` option with the `Bisect` invocation" do

--- a/spec/rspec/core/pending_example_spec.rb
+++ b/spec/rspec/core/pending_example_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "an example" do
 
       group.run
       example = group.examples.first
-      expect(example.metadata[:pending]).to be_truthy
+      expect(example.metadata[:pending]).to be(true)
     end
   end
 

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -28,7 +28,7 @@ module RSpec::Core
         end
 
         expect(the_task).to receive(:run_task) { true }
-        expect(Rake.application.invoke_task("rake_task_args[first_spec.rb]")).to be_truthy
+        Rake.application.invoke_task("rake_task_args[first_spec.rb]")
       end
     end
 

--- a/spec/rspec/core/shared_context_spec.rb
+++ b/spec/rspec/core/shared_context_spec.rb
@@ -26,10 +26,10 @@ RSpec.describe RSpec::SharedContext do
 
     group.run
 
-    expect(before_all_hook).to be_truthy
-    expect(before_each_hook).to be_truthy
-    expect(after_each_hook).to be_truthy
-    expect(after_all_hook).to be_truthy
+    expect(before_all_hook).to be(true)
+    expect(before_each_hook).to be(true)
+    expect(after_each_hook).to be(true)
+    expect(after_all_hook).to be(true)
   end
 
   include RSpec::Core::SharedExampleGroup::TopLevelDSL

--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -289,9 +289,9 @@ RSpec.describe RSpec do
 
   describe "::Core.path_to_executable" do
     it 'returns the absolute location of the exe/rspec file' do
-      expect(File.exist? RSpec::Core.path_to_executable).to be_truthy
+      expect(File.exist? RSpec::Core.path_to_executable).to be(true)
       expect(File.read(RSpec::Core.path_to_executable)).to include("RSpec::Core::Runner.invoke")
-      expect(File.executable? RSpec::Core.path_to_executable).to be_truthy unless RSpec::Support::OS.windows?
+      expect(File.executable? RSpec::Core.path_to_executable).to be(true) unless RSpec::Support::OS.windows?
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,6 +86,7 @@ RSpec.configure do |c|
 
   c.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.max_formatted_output_length = 1000
   end
 
   c.mock_with :rspec do |mocks|


### PR DESCRIPTION
This PR first fixes `Configuration#any_predicate?` to return `true`/`false` instead of `any_predicate`.

No spec fail for this change, because all specs on those predicates use `be_truthy`, like [this one](https://github.com/marcandre/rspec-core/blob/4e81d92f0e8cc41960e7097a3f3df2dea914aa84/spec/rspec/core/configuration_spec.rb#L2234-L2236) which passed even though `config.custom_option?` used to be a simple alias for `config.custom_option` and return `'a value'`.

Second commit removes all uses of `be_truthy` and `be_falsey` except the two for testing the matchers themselves. I believe most of these date from before [they were renamed to avoid confusion](https://github.com/rspec/rspec-core/commit/eb5bb45a09)

Most of these changes are trivial `be_truthy => be(true)`. A non-trivial example is [this spec](https://github.com/marcandre/rspec-core/blob/4e81d92f0e8cc41960e7097a3f3df2dea914aa84/spec/rspec/core/configuration_options_spec.rb#L303-L305) that was not updated now that `fail-fast` defaults to `1` instead of `true`.
