### PR TITLE
Detach bisect subprocesses to avoid making zombie processes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ Bug Fixes:
 * Ensure custom error codes are returned from bisect runs. (Jon Rowe, #2732)
 * Ensure `RSpec::Core::Configuration` predicate config methods return booleans.
   (Marc-André Lafortune, #2736)
+* Prevent `rspec --bisect` from generating zombie processes while executing
+  (Benoit Tigeot, Jon Rowe, #2739)
 
 ### 3.9.2 / 2020-05-02
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.9.1...v3.9.2)

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,7 @@ Bug Fixes:
 * Ensure `RSpec::Core::Configuration` predicate config methods return booleans.
   (Marc-André Lafortune, #2736)
 * Prevent `rspec --bisect` from generating zombie processes while executing
-  (Benoit Tigeot, Jon Rowe, #2739)
+  bisect runs. (Benoit Tigeot, Jon Rowe, #2739)
 
 ### 3.9.2 / 2020-05-02
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.9.1...v3.9.2)

--- a/lib/rspec/core/bisect/fork_runner.rb
+++ b/lib/rspec/core/bisect/fork_runner.rb
@@ -91,9 +91,12 @@ module RSpec
           end
 
           def dispatch_specs(run_descriptor)
-            fork { run_specs(run_descriptor) }
+            pid = fork { run_specs(run_descriptor) }
             # We don't use Process.waitpid here as it was causing bisects to
-            # block due to the file descriptor limit on OSX / Linux.
+            # block due to the file descriptor limit on OSX / Linux. We need
+            # to detach the process to avoid having zombie process and consume
+            # slot in the kernel process table.
+            Process.detach(pid)
           end
 
         private

--- a/lib/rspec/core/bisect/fork_runner.rb
+++ b/lib/rspec/core/bisect/fork_runner.rb
@@ -94,8 +94,8 @@ module RSpec
             pid = fork { run_specs(run_descriptor) }
             # We don't use Process.waitpid here as it was causing bisects to
             # block due to the file descriptor limit on OSX / Linux. We need
-            # to detach the process to avoid having zombie process and consume
-            # slot in the kernel process table.
+            # to detach the process to avoid having zombie processes
+            # consuming slots in the kernel process table during bisect runs.
             Process.detach(pid)
           end
 

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -33,13 +33,18 @@ module RSpec::Core
       end
     end
 
-    context "when the bisect commasaturingnd is long" do
+    context "when the bisect command saturates the pipe" do
       # On OSX and Linux a file descriptor limit meant that the bisect process got stuck at a certain limit.
       # This test demonstrates that we can run large bisects above this limit (found to be at time of commit).
       # See: https://github.com/rspec/rspec-core/pull/2669
       it 'does not hit pipe size limit and does not get stuck' do
         output = bisect(%W[spec/rspec/core/resources/blocking_pipe_bisect_spec.rb_], 1)
         expect(output).to include("No failures found.")
+      end
+
+      it 'does not leave zombie processes', :unless => RSpec::Support::OS.windows? do
+        bisect(%W[spec/rspec/core/resources/blocking_pipe_bisect_spec.rb_], 1)
+        expect(%x[ps -ho pid,state]).to_not include("Z")
       end
     end
   end

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -43,9 +43,15 @@ module RSpec::Core
       end
 
       it 'does not leave zombie processes', :unless => RSpec::Support::OS.windows? do
+        original_pids = pids()
         bisect(%W[spec/rspec/core/resources/blocking_pipe_bisect_spec.rb_], 1)
-        expect(%x[ps -ho pid,state]).to_not include("Z")
+        sleep 0.1 while (extra_pids = pids() - original_pids).join.match?(/[RE]/i)
+        expect(extra_pids.join).to_not include "Z"
       end
+    end
+
+    def pids
+      %x[ps -ho pid,state].split("\n").map { |line| line.split(/\s+/).compact.join(' ') }
     end
   end
 end

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -45,7 +45,10 @@ module RSpec::Core
       it 'does not leave zombie processes', :unless => RSpec::Support::OS.windows? do
         original_pids = pids()
         bisect(%W[spec/rspec/core/resources/blocking_pipe_bisect_spec.rb_], 1)
+        cursor = 0
         while ((extra_pids = pids() - original_pids).join =~ /[RE]/i)
+          raise "Extra process detected" if cursor > 10
+          cursor += 1
           sleep 0.1
         end
         expect(extra_pids.join).to_not include "Z"

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -45,13 +45,17 @@ module RSpec::Core
       it 'does not leave zombie processes', :unless => RSpec::Support::OS.windows? do
         original_pids = pids()
         bisect(%W[spec/rspec/core/resources/blocking_pipe_bisect_spec.rb_], 1)
-        sleep 0.1 while ((extra_pids = pids() - original_pids).join =~ /[RE]/i)
+        while ((extra_pids = pids() - original_pids).join =~ /[RE]/i)
+          sleep 0.1
+        end
         expect(extra_pids.join).to_not include "Z"
       end
     end
 
     def pids
-      %x[ps -ho pid,state].split("\n").map { |line| line.split(/\s+/).compact.join(' ') }
+      %x[ps -ho pid,state,cmd | grep "[r]uby"].split("\n").map do |line|
+        line.split(/\s+/).compact.join(' ')
+      end
     end
   end
 end

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -45,7 +45,7 @@ module RSpec::Core
       it 'does not leave zombie processes', :unless => RSpec::Support::OS.windows? do
         original_pids = pids()
         bisect(%W[spec/rspec/core/resources/blocking_pipe_bisect_spec.rb_], 1)
-        sleep 0.1 while (extra_pids = pids() - original_pids).join.match?(/[RE]/i)
+        sleep 0.1 while (extra_pids = pids() - original_pids).join =~ /[RE]/i
         expect(extra_pids.join).to_not include "Z"
       end
     end

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -45,7 +45,7 @@ module RSpec::Core
       it 'does not leave zombie processes', :unless => RSpec::Support::OS.windows? do
         original_pids = pids()
         bisect(%W[spec/rspec/core/resources/blocking_pipe_bisect_spec.rb_], 1)
-        sleep 0.1 while (extra_pids = pids() - original_pids).join =~ /[RE]/i
+        sleep 0.1 while ((extra_pids = pids() - original_pids).join =~ /[RE]/i)
         expect(extra_pids.join).to_not include "Z"
       end
     end


### PR DESCRIPTION
If we do not `waitpid` or `detach` the bisect process become a zombie process.

As mentioned in waitpid doc:
> As long as a zombie is not removed from the system via a wait, it will consume a slot in the kernel process table, and if this table fills, it will not be possible to create further processes.

`detach` is a good idea. Thanks @pirj. From the Ruby doc:
> Some operating systems retain the status of terminated child processes until the parent collects that status (normally using some variant of wait()). If the parent never collects this status, the child stays around as a zombie process. Process::detach prevents this by setting up a separate Ruby thread whose sole job is to reap the status of the process pid when it terminates. Use detach only when you do not intend to explicitly wait for the child to terminate.

Related:
- https://github.com/rspec/rspec-core/pull/2669
- https://andrykonchin.github.io/rails/2019/12/25/deadlock-in-rspec.html

Thanks @pirj and @andrykonchin