### PR TITLE
Memoize exception_lines in ExceptionPresenter

### DIFF
--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -175,12 +175,14 @@ module RSpec
         end
 
         def exception_lines
-          lines = []
-          lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
-          encoded_string(exception.message.to_s).split("\n").each do |line|
-            lines << (line.empty? ? line : "  #{line}")
+          @exception_lines ||= begin
+            lines = []
+            lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
+            encoded_string(exception.message.to_s).split("\n").each do |line|
+              lines << (line.empty? ? line : "  #{line}")
+            end
+            lines
           end
-          lines
         end
 
         def extra_failure_lines


### PR DESCRIPTION
When an exception occurs and is displayed, `ExceptionPresenter` is used. However, there is an obvious slow amplification doing in it. This PR fixes it.

The method `failure_lines` uses `exception_lines` 3 times, which uses `exception.message`. In some situation, `exception.message` can be slow (when inspect is called on a big object for example, such as during NoMethodError).
Without caching, this delay, which can become considerable, will be amplified by 3x.

Here is a simple example of an rspec that would be amplified

```
class A
  def inspect
    sleep(1)
  end
end

describe 'A' do
  it 'works' do
    A.new.no_such_method
  end
end
```
Instead of taking 1 second, the print of the failure message takes 3 seconds.

I did memoization (`@exception_lines ||= ...`), but the call result could have been saved and reused in the failure_lines method. Let me know if you prefer that i change it to just start `failure_lines` with `exception_lines = self.exception_lines`.

As a side note, I think it would be helpful if the `--profile` or a new flag would help debug slow failures messages (top 10 of slowest failures to display).