### PR TITLE
Add error-exit-code to differentiate from failures

### DIFF
--- a/features/configuration/error_exit_code.feature
+++ b/features/configuration/error_exit_code.feature
@@ -1,0 +1,52 @@
+Feature: error exit code
+
+  Use the `error_exit_code` option to set a custom exit code when RSpec fails outside an example.
+
+  ```ruby
+  RSpec.configure { |c| c.error_exit_code = 42 }
+  ```
+
+  Background:
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure { |c| c.error_exit_code = 42 }
+      """
+
+  Scenario: A erroring spec with the default exit code
+    Given a file named "spec/typo_spec.rb" with:
+      """ruby
+      RSpec.escribe "something" do # intentional typo
+        it "works" do
+          true
+        end
+      end
+      """
+    When I run `rspec spec/typo_spec.rb`
+    Then the exit status should be 1
+
+  Scenario: A erroring spec with a custom exit code
+    Given a file named "spec/typo_spec.rb" with:
+      """ruby
+      require 'spec_helper'
+      RSpec.escribe "something" do # intentional typo
+        it "works" do
+          true
+        end
+      end
+      """
+    When I run `rspec spec/typo_spec.rb`
+    And  the exit status should be 42
+
+
+  Scenario: Success running specs spec with a custom error exit code defined
+    Given a file named "spec/example_spec.rb" with:
+      """ruby
+      require 'spec_helper'
+      RSpec.describe "something" do
+        it "works" do
+          true
+        end
+      end
+      """
+    When I run `rspec spec/example_spec.rb`
+    Then the exit status should be 0

--- a/features/configuration/failure_exit_code.feature
+++ b/features/configuration/failure_exit_code.feature
@@ -37,6 +37,32 @@ Feature: failure exit code
     When I run `rspec spec/example_spec.rb`
     Then the exit status should be 42
 
+  Scenario: An error running specs spec with a custom exit code
+    Given a file named "spec/typo_spec.rb" with:
+      """ruby
+      require 'spec_helper'
+      RSpec.escribe "something" do # intentional typo
+        it "works" do
+          true
+        end
+      end
+      """
+    When I run `rspec spec/typo_spec.rb`
+    Then the exit status should be 42
+
+  Scenario: Success running specs spec with a custom exit code defined
+    Given a file named "spec/example_spec.rb" with:
+      """ruby
+      require 'spec_helper'
+      RSpec.describe "something" do
+        it "works" do
+          true
+        end
+      end
+      """
+    When I run `rspec spec/example_spec.rb`
+    Then the exit status should be 0
+
   Scenario: Exit with the default exit code when an `at_exit` hook is added upstream
     Given a file named "exit_at_spec.rb" with:
       """ruby

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -243,6 +243,11 @@ module RSpec
       add_setting :failure_exit_code
 
       # @macro add_setting
+      # The exit code to return if there are any errors outside examples (default: failure_exit_code)
+      # @return [Integer]
+      add_setting :error_exit_code
+
+      # @macro add_setting
       # Whether or not to fail when there are no RSpec examples (default: false).
       # @return [Boolean]
       add_setting :fail_if_no_examples
@@ -523,6 +528,7 @@ module RSpec
         @pattern = '**{,/*/**}/*_spec.rb'
         @exclude_pattern = ''
         @failure_exit_code = 1
+        @error_exit_code = nil # so it can be overridden by failure exit code
         @fail_if_no_examples = false
         @spec_files_loaded = false
 

--- a/lib/rspec/core/drb.rb
+++ b/lib/rspec/core/drb.rb
@@ -51,6 +51,7 @@ module RSpec
         argv << "--order"        << @submitted_options[:order]               if @submitted_options[:order]
 
         add_failure_exit_code(argv)
+        add_error_exit_code(argv)
         add_full_description(argv)
         add_filter(argv, :inclusion, @filter_manager.inclusions)
         add_filter(argv, :exclusion, @filter_manager.exclusions)
@@ -65,6 +66,12 @@ module RSpec
         return unless @submitted_options[:failure_exit_code]
 
         argv << "--failure-exit-code" << @submitted_options[:failure_exit_code].to_s
+      end
+
+      def add_error_exit_code(argv)
+        return unless @submitted_options[:error_exit_code]
+
+        argv << "--error-exit-code" << @submitted_options[:error_exit_code].to_s
       end
 
       def add_full_description(argv)

--- a/lib/rspec/core/invocations.rb
+++ b/lib/rspec/core/invocations.rb
@@ -37,7 +37,7 @@ module RSpec
             runner, options.args, formatter
           )
 
-          success ? 0 : runner.configuration.failure_exit_code
+          runner.exit_code(success)
         end
 
       private

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -95,6 +95,11 @@ module RSpec::Core
           options[:failure_exit_code] = code
         end
 
+        parser.on('--error-exit-code CODE', Integer,
+                  'Override the exit code used when there are errors loading or running specs outside of examples.') do |code|
+          options[:error_exit_code] = code
+        end
+
         parser.on('-X', '--[no-]drb', 'Run examples via DRb.') do |use_drb|
           options[:drb] = use_drb
           options[:runner] = RSpec::Core::Invocations::DRbWithFallback.new if use_drb

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Spec file load errors' do
   include FormatterSupport
 
   let(:failure_exit_code) { rand(97) + 2 } # 2..99
+  let(:error_exit_code) { failure_exit_code + 1 } # 3..100
 
   if RSpec::Support::Ruby.jruby_9000?
     let(:spec_line_suffix) { ":in `<main>'" }
@@ -24,6 +25,7 @@ RSpec.describe 'Spec file load errors' do
       c.filter_gems_from_backtrace "gems/aruba"
       c.backtrace_exclusion_patterns << %r{/rspec-core/spec/} << %r{rspec_with_simplecov}
       c.failure_exit_code = failure_exit_code
+      c.error_exit_code = error_exit_code
     end
   end
 
@@ -31,7 +33,7 @@ RSpec.describe 'Spec file load errors' do
     write_file_formatted "helper_with_error.rb", "raise 'boom'"
 
     run_command "--require ./helper_with_error"
-    expect(last_cmd_exit_status).to eq(failure_exit_code)
+    expect(last_cmd_exit_status).to eq(error_exit_code)
     output = normalize_durations(last_cmd_stdout)
     expect(output).to eq unindent(<<-EOS)
 
@@ -60,7 +62,7 @@ RSpec.describe 'Spec file load errors' do
     "
 
     run_command "--require ./helper_with_error 1_spec.rb"
-    expect(last_cmd_exit_status).to eq(failure_exit_code)
+    expect(last_cmd_exit_status).to eq(error_exit_code)
     output = normalize_durations(last_cmd_stdout)
     expect(output).to eq unindent(<<-EOS)
 
@@ -109,7 +111,7 @@ RSpec.describe 'Spec file load errors' do
     "
 
     run_command "1_spec.rb 2_spec.rb 3_spec.rb"
-    expect(last_cmd_exit_status).to eq(failure_exit_code)
+    expect(last_cmd_exit_status).to eq(error_exit_code)
     output = normalize_durations(last_cmd_stdout)
     expect(output).to eq unindent(<<-EOS)
 

--- a/spec/integration/suite_hooks_errors_spec.rb
+++ b/spec/integration/suite_hooks_errors_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Suite hook errors' do
   include FormatterSupport
 
   let(:failure_exit_code) { rand(97) + 2 } # 2..99
+  let(:error_exit_code) { failure_exit_code + 2 } # 4..101
 
   if RSpec::Support::Ruby.jruby_9000?
     let(:spec_line_suffix) { ":in `block in (root)'" }
@@ -24,6 +25,7 @@ RSpec.describe 'Suite hook errors' do
       c.filter_gems_from_backtrace "gems/aruba"
       c.backtrace_exclusion_patterns << %r{/rspec-core/spec/} << %r{rspec_with_simplecov}
       c.failure_exit_code = failure_exit_code
+      c.error_exit_code = error_exit_code
     end
   end
 
@@ -41,7 +43,7 @@ RSpec.describe 'Suite hook errors' do
     "
 
     run_command "the_spec.rb"
-    expect(last_cmd_exit_status).to eq(failure_exit_code)
+    expect(last_cmd_exit_status).to eq(error_exit_code)
     normalize_durations(last_cmd_stdout)
   end
 
@@ -96,7 +98,7 @@ RSpec.describe 'Suite hook errors' do
     "
 
     run_command "the_spec.rb"
-    expect(last_cmd_exit_status).to eq(failure_exit_code)
+    expect(last_cmd_exit_status).to eq(error_exit_code)
     output = normalize_durations(last_cmd_stdout)
 
     expect(output).to eq unindent(<<-EOS)

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -321,6 +321,18 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
     end
   end
 
+  describe "--error-exit-code" do
+    it "sets :error_exit_code" do
+      expect(parse_options('--error-exit-code', '0')).to include(:error_exit_code => 0)
+      expect(parse_options('--error-exit-code', '1')).to include(:error_exit_code => 1)
+      expect(parse_options('--error-exit-code', '2')).to include(:error_exit_code => 2)
+    end
+
+    it "overrides previous :error_exit_code" do
+      expect(parse_options('--error-exit-code', '2', '--error-exit-code', '3')).to include(:error_exit_code => 3)
+    end
+  end
+
   describe "--dry-run" do
     it "defaults to nil" do
       expect(parse_options[:dry_run]).to be(nil)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -2862,6 +2862,28 @@ module RSpec::Core
       end
     end
 
+    describe '#failure_exit_code' do
+      it 'defaults to 1' do
+        expect(config.failure_exit_code).to eq 1
+      end
+
+      it 'is configurable' do
+        config.failure_exit_code = 2
+        expect(config.failure_exit_code).to eq 2
+      end
+    end
+
+    describe '#error_exit_code' do
+      it 'defaults to nil' do
+        expect(config.error_exit_code).to eq nil
+      end
+
+      it 'is configurable' do
+        config.error_exit_code = 2
+        expect(config.error_exit_code).to eq 2
+      end
+    end
+
     describe "#shared_context_metadata_behavior" do
       it "defaults to :trigger_inclusion for backwards compatibility" do
         expect(config.shared_context_metadata_behavior).to eq :trigger_inclusion

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -232,6 +232,51 @@ module RSpec::Core
       end
     end
 
+    describe '#exit_code' do
+      let(:world) { World.new }
+      let(:config) { Configuration.new }
+      let(:runner) { Runner.new({}, config, world) }
+
+      it 'defaults to 1' do
+        expect(runner.exit_code).to eq 1
+      end
+
+      it 'is failure_exit_code by default' do
+        config.failure_exit_code = 2
+        expect(runner.exit_code).to eq 2
+      end
+
+      it 'is failure_exit_code when world is errored by default' do
+        world.non_example_failure = true
+        config.failure_exit_code = 2
+        expect(runner.exit_code).to eq 2
+      end
+
+      it 'is error_exit_code when world is errored by and both are defined' do
+        world.non_example_failure = true
+        config.failure_exit_code = 2
+        config.error_exit_code = 3
+        expect(runner.exit_code).to eq 3
+      end
+
+      it 'is error_exit_code when world is errored by and failure exit code is not defined' do
+        world.non_example_failure = true
+        config.error_exit_code = 3
+        expect(runner.exit_code).to eq 3
+      end
+
+      it 'can be given success' do
+        config.error_exit_code = 3
+        expect(runner.exit_code(true)).to eq 0
+      end
+
+      it 'can be given success, but non_example_failure=true will still cause an error code' do
+        world.non_example_failure = true
+        config.error_exit_code = 3
+        expect(runner.exit_code(true)).to eq 3
+      end
+    end
+
     describe ".invoke" do
       let(:runner) { RSpec::Core::Runner }
 
@@ -287,7 +332,6 @@ module RSpec::Core
           expect(process_proxy).to have_received(:run).with(err, out)
         end
       end
-
     end
 
     context "when run" do


### PR DESCRIPTION
it can be helpful to know if RSpec fails because of an example or if it
errors out because it couldn't load a spec file, or there was an issue
in the a before(:suite) hook or etc

i've named the setting error-exit-code, and tried to add it to all the
relevant places, but i don't know rspec codebase well so there was some
guessing. in particular i'm not sure what bisect should do.

i have it fall back to the failure-exit-code before defaulting to 1 so
there's no changes if people don't opt in to the setting.

the specific usecase  of this is our CI automatically retries failures using
the persistence file, and assumes if they pass on that retry they were
flaky. however, the persistence file isn't written to when there's an
error outside of examples, so this could mean falsely passing builds.

by checking for a different exit code, and then not running the retry we
can avoid this issue.

---

This PR also includes me trying to make travis builds work. there were gem/ruby version issues with simplecov-html, childprocecss, & rake (these issues were also present in other RSpec projects, so when it tries to build e.g. rspec-expectations it still fails. that's when i gave up trying to make travis work)