### PR TITLE
Fix predicates to return actual true/false values

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -232,7 +232,10 @@ module RSpec
       end
 
       alias_method :pending?, :pending
-      alias_method :skipped?, :skip
+
+      def skipped?
+        !!skip
+      end
 
       # @api private
       # instance_execs the block passed to the constructor in the context of
@@ -578,6 +581,10 @@ module RSpec
         attr_accessor :pending_fixed
 
         alias pending_fixed? pending_fixed
+
+        def initialize
+          @pending_fixed = false
+        end
 
         # @return [Boolean] Indicates if the example was completely skipped
         #   (typically done via `:skip` metadata or the `skip` method). Skipped examples

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,6 +87,9 @@ RSpec.configure do |c|
   c.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
     expectations.max_formatted_output_length = 1000
+    if expectations.respond_to? :strict_predicate_matchers=
+      expectations.strict_predicate_matchers = true
+    end
   end
 
   c.mock_with :rspec do |mocks|


### PR DESCRIPTION
This PR fixes `pending?`, `skipped?` and `pending_fixed?` so they return `true` / `false` values.

It also turns on `expectations.strict_predicate_matchers` config; with this new config, some specs were failing because these predicates were not returning the right values.

```
rspec ./spec/rspec/core/metadata_spec.rb:104 # RSpec::Core::Metadata for an example creates an empty execution result
rspec ./spec/rspec/core/example_group_spec.rb:1126 # RSpec::Core::ExampleGroup skip with message in metadata generates a skipped example
rspec ./spec/rspec/core/example_group_spec.rb[1:36:1] # RSpec::Core::ExampleGroup.xit generates a skipped example
rspec ./spec/rspec/core/example_group_spec.rb[1:38:1] # RSpec::Core::ExampleGroup.xexample generates a skipped example
rspec ./spec/rspec/core/example_group_spec.rb[1:37:1] # RSpec::Core::ExampleGroup.xspecify generates a skipped example
```

Precursor to rspec/rspec-expectations#1196