### PR TITLE
Prevent malformed exception messages from exiting RSpec

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,8 @@ Bug Fixes:
 * Predicates for pending examples, (in `RSpec::Core::Example`, `#pending?`, `#skipped?` and
   `#pending_fixed?`) now return boolean values rather than truthy values.
   (Marc-André Lafortune, #2756, #2758)
+* Exceptions which have a message which cannot be cast to a string will no longer
+  cause a crash. (Jon Rowe, #2761)
 
 ### 3.9.2 / 2020-05-02
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.9.1...v3.9.2)

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -51,7 +51,7 @@ module RSpec
               cause << '--- Caused by: ---'
               cause << "#{exception_class_name(last_cause)}:" unless exception_class_name(last_cause) =~ /RSpec/
 
-              encoded_string(last_cause.message.to_s).split("\n").each do |line|
+              encoded_string(exception_message_string(last_cause)).split("\n").each do |line|
                 cause << "  #{line}"
               end
 
@@ -174,11 +174,19 @@ module RSpec
           lines
         end
 
+        # rubocop:disable Lint/RescueException
+        def exception_message_string(exception)
+          exception.message.to_s
+        rescue Exception => other
+          "A #{exception.class} for which `exception.message.to_s` raises #{other.class}."
+        end
+        # rubocop:enable Lint/RescueException
+
         def exception_lines
           @exception_lines ||= begin
             lines = []
             lines << "#{exception_class_name}:" unless exception_class_name =~ /RSpec/
-            encoded_string(exception.message.to_s).split("\n").each do |line|
+            encoded_string(exception_message_string(exception)).split("\n").each do |line|
               lines << (line.empty? ? line : "  #{line}")
             end
             lines


### PR DESCRIPTION
When an exception message raises when to_s is called, particularly the loop style presented by #2753, RSpec will hard loop as it tries and fails to produce a valid string for the exception, this detects and prevent this from happening and produces a reasonable stand in explanation, but its not advisable (or possible in the case of the spec example) to introspect the error itself.

Fixes #2753.