### PR TITLE
Remove Ruby version constraint workarounds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,11 @@ if RUBY_VERSION < '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|min
   gem "childprocess", "< 1.0.0"
 end
 
+platforms :jruby do
+  # Pin child-process on older JRuby
+  gem "childprocess", "< 1.0.0" if RUBY_VERSION < '1.9.0'
+end
+
 gem 'simplecov', '~> 0.8'
 
 # No need to run rubocop on earlier versions

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ group :documentation do
   gem 'github-markup', :platform => :mri
 end
 
+if RUBY_VERSION < '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
+  gem "childprocess", "< 1.0.0"
+end
+
 gem 'simplecov', '~> 0.8'
 
 # No need to run rubocop on earlier versions

--- a/Gemfile
+++ b/Gemfile
@@ -12,13 +12,7 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
   end
 end
 
-if RUBY_VERSION < '1.9.3'
-  gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later
-elsif RUBY_VERSION < '2.0.0'
-  gem 'rake', '< 12.0.0' # rake 12 requires Ruby 2.0.0 or later
-else
-  gem 'rake', '> 12.3.2'
-end
+gem 'rake'
 
 if ENV['DIFF_LCS_VERSION']
   gem 'diff-lcs', ENV['DIFF_LCS_VERSION']
@@ -34,35 +28,6 @@ group :documentation do
   gem 'github-markup', :platform => :mri
 end
 
-if RUBY_VERSION < '2.0.0' || RUBY_ENGINE == 'java'
-  gem 'json', '< 2.0.0'
-else
-  gem 'json', '> 2.3.0'
-end
-
-if RUBY_VERSION < '2.2.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
-  gem 'ffi', '< 1.10'
-elsif RUBY_VERSION < '2.0'
-  gem 'ffi', '< 1.9.19' # ffi dropped Ruby 1.8 support in 1.9.19
-else
-  gem 'ffi', '~> 1.11.0'
-end
-
-if RUBY_VERSION < '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
-  gem "childprocess", "< 1.0.0"
-end
-
-platforms :jruby do
-  if RUBY_VERSION < '1.9.0'
-    # Pin jruby-openssl on older J Ruby
-    gem "jruby-openssl", "< 0.10.0"
-    # Pin child-process on older J Ruby
-    gem "childprocess", "< 1.0.0"
-  else
-    gem "jruby-openssl"
-  end
-end
-
 gem 'simplecov', '~> 0.8'
 
 # No need to run rubocop on earlier versions
@@ -70,14 +35,7 @@ if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
   gem "rubocop", "~> 0.52.1"
 end
 
-gem 'test-unit', '~> 3.0' if RUBY_VERSION.to_f >= 2.2
-
-# Version 5.12 of minitest requires Ruby 2.4
-if RUBY_VERSION < '2.4.0'
-  gem 'minitest', '< 5.12.0'
-end
-
-
-gem 'contracts', '< 0.16' if RUBY_VERSION < '1.9.0'
+# Minitest version 5.12.0 relies on Ruby 2.4, but denies it
+gem 'minitest', '!= 5.12.0'
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/Gemfile
+++ b/Gemfile
@@ -28,8 +28,6 @@ group :documentation do
   gem 'github-markup', :platform => :mri
 end
 
-gem 'ffi'
-
 if RUBY_VERSION < '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
   gem "childprocess", "< 1.0.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ group :documentation do
   gem 'github-markup', :platform => :mri
 end
 
+gem 'ffi'
+
 if RUBY_VERSION < '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
   gem "childprocess", "< 1.0.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
   gem "rubocop", "~> 0.52.1"
 end
 
+# Contracts gem denies that it uses Ruby 2.0 syntax
+gem 'contracts', '< 0.16' if RUBY_VERSION < '1.9.0'
+
 # Minitest version 5.12.0 relies on Ruby 2.4, but denies it
 gem 'minitest', '!= 5.12.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,12 @@ end
 # Contracts gem denies that it uses Ruby 2.0 syntax
 gem 'contracts', '< 0.16' if RUBY_VERSION < '1.9.0'
 
+# json 2.2.0 denies that it needs Ruby 2.0
+gem 'json', '< 2.0.0' if RUBY_VERSION < '2.0.0' || RUBY_ENGINE == 'java'
+
+# Test::Unit was removed from stdlib in Ruby 2.2
+gem 'test-unit', '~> 3.0' if RUBY_VERSION.to_f >= 2.2
+
 # Minitest version 5.12.0 relies on Ruby 2.4, but denies it
 gem 'minitest', '!= 5.12.0'
 

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -1,6 +1,8 @@
 module ArubaLoader
   extend RSpec::Support::WithIsolatedStdErr
   with_isolated_stderr do
+    # Aruba depends on FFI, but under JRuby it's not loaded for some reason
+    require 'ffi'
     require 'aruba/api'
   end
 end


### PR DESCRIPTION
The point of this PR is to remove workaround previously needed to work around Rubygems API not providing necessary gem Ruby constraints under certain conditions.

The problem was presumably fixed in Rubygems.
A couple of passed builds have no odd gem version resolutions resulting in Ruby version incompatibility.

Siblings: https://github.com/rspec/rspec-rails/pull/2380 https://github.com/rspec/rspec-rails/pull/2386

Related to https://github.com/rubygems/rubygems/issues/3463