### PR TITLE
Allow `pluralize` to handle words that end with s.

### DIFF
--- a/lib/rspec/core/formatters/helpers.rb
+++ b/lib/rspec/core/formatters/helpers.rb
@@ -86,7 +86,15 @@ module RSpec
         # @param string [String] word to be pluralized
         # @return [String] pluralized word
         def self.pluralize(count, string)
-          "#{count} #{string}#{'s' unless count.to_f == 1}"
+          pluralized_string = if count.to_f == 1
+                                string
+                              elsif string.end_with?('s') # e.g. "process"
+                                "#{string}es" # e.g. "processes"
+                              else
+                                "#{string}s"
+                              end
+
+          "#{count} #{pluralized_string}"
         end
 
         # @api private

--- a/spec/rspec/core/formatters/helpers_spec.rb
+++ b/spec/rspec/core/formatters/helpers_spec.rb
@@ -117,5 +117,38 @@ RSpec.describe RSpec::Core::Formatters::Helpers do
     end
   end
 
+  describe "pluralize" do
+    context "when word does not end in s" do
+      let(:word){ "second" }
+
+      it "pluralizes with 0" do
+        expect(helper.pluralize(0, "second")).to eq("0 seconds")
+      end
+
+      it "does not pluralizes with 1" do
+        expect(helper.pluralize(1, "second")).to eq("1 second")
+      end
+
+      it "pluralizes with 2" do
+        expect(helper.pluralize(2, "second")).to eq("2 seconds")
+      end
+    end
+
+    context "when word ends in s" do
+      let(:word){ "process" }
+
+      it "pluralizes with 0" do
+        expect(helper.pluralize(0, "process")).to eq("0 processes")
+      end
+
+      it "does not pluralizes with 1" do
+        expect(helper.pluralize(1, "process")).to eq("1 process")
+      end
+
+      it "pluralizes with 2" do
+        expect(helper.pluralize(2, "process")).to eq("2 processes")
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
Use Case:

We have a custom formatter that we use with `parallel_tests` to get a cleaner output from the various test processes.

We make use of `RSpec::Core::Formatters::Helpers.pluralize` in there to display the number of remaining processes left.

However, instead of getting "processes", we get "processs".

Looking into the `pluralize` method definition, it simple adds an "s" to the end of the provided String, unless the count is equal to 1.

Without accounting for all the different words that are possible, which something like Rails would do, we just extended this to add "es" if the provided String ends in "s" already.

We also added tests for words that end in "s" and words that do not end in "s".