### PR TITLE
Update the --seed description

### DIFF
--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -65,7 +65,8 @@ module RSpec::Core
           options[:order] = o
         end
 
-        parser.on('--seed SEED', Integer, 'Equivalent of --order rand:SEED.') do |seed|
+        parser.on('--seed SEED', Integer,
+                  'Makes randomness deterministic, including examples ordering, as well as the Random class.') do |seed|
           options[:order] = "rand:#{seed}"
         end
 


### PR DESCRIPTION
In addition to making the test examples order deterministic, --seed also seeds the Random class, making various random generators deterministic.

I tried to find where exactly this change is applies so I could make the description as accurate as possible. I _think_ it happens [here](https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/ordering.rb#L28), but I'm not 100% sure. In any case though, I think the CLI options should indicate that it makes more things deterministic than just the examples ordering.