### PR TITLE
Implement reset for memoized

### DIFF
--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -158,6 +158,12 @@ module RSpec
             end
           end
         end
+
+        def reset
+          @mutex.synchronize do
+            @memoized.clear
+          end
+        end
       end
 
       # @private
@@ -168,6 +174,10 @@ module RSpec
 
         def fetch_or_store(key)
           @memoized.fetch(key) { @memoized[key] = yield }
+        end
+
+        def reset
+          @memoized.clear
         end
       end
 


### PR DESCRIPTION
It would be nice to have a method to reset the memoized store. The store resetting would allow to run example several times in the around block. That in turn, could allow to define options on contexts that specify when the example should be run multiple times in different environment.

Specifically, the next option on contexts can be defined:

```ruby
config.around(:each, within_time_zones: ->(value) { value.present? }) do |example|
  example.metadata[:within_time_zones].each do |zone|
    __memoized.reset
    Time.use_zone(zone) { example.run }
  end
end
```

With it help it would be easy to run context in different timezones:

```ruby
context 'some test', within_time_zones: ['Madrid', 'Minsk'] do
   ...
end
```

Unfortunately, without a reset method there is the only way to implement that option for context using `instance_variable_set` that's not very elegant: `__memoized.instance_variable_set(:@memoized, {})`.