### PR TITLE
Gem::Version allows proper comparison of version strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,11 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
   end
 end
 
-if RUBY_VERSION < '1.9.3'
+ruby_version = Gem::Version.new(RUBY_VERSION)
+
+if ruby_version < Gem::Version.new('1.9.3')
   gem 'rake', '< 11.0.0' # rake 11 requires Ruby 1.9.3 or later
-elsif RUBY_VERSION < '2.0.0'
+elsif ruby_version < Gem::Version.new('2.0.0')
   gem 'rake', '< 12.0.0' # rake 12 requires Ruby 2.0.0 or later
 else
   gem 'rake', '> 12.3.2'
@@ -34,29 +36,29 @@ group :documentation do
   gem 'github-markup', :platform => :mri
 end
 
-if RUBY_VERSION < '2.0.0' || RUBY_ENGINE == 'java'
+if ruby_version < Gem::Version.new('2.0.0') || RUBY_ENGINE == 'java'
   gem 'json', '< 2.0.0'
 else
   gem 'json', '> 2.3.0'
 end
 
-if RUBY_VERSION < '2.2.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
+if ruby_version < Gem::Version.new('2.2.0') && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
   gem 'ffi', '< 1.10'
-elsif RUBY_VERSION < '2.0'
+elsif ruby_version < Gem::Version.new('2.0')
   gem 'ffi', '< 1.9.19' # ffi dropped Ruby 1.8 support in 1.9.19
-elsif RUBY_VERSION < '2.3.0'
+elsif ruby_version < Gem::Version.new('2.3.0')
   gem 'ffi', '~> 1.12.0'
 else
   # Until 1.13.2 is released due to Rubygems usage
   gem 'ffi', '~> 1.12.0'
 end
 
-if RUBY_VERSION < '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
+if ruby_version < Gem::Version.new('2.3.0') && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)
   gem "childprocess", "< 1.0.0"
 end
 
 platforms :jruby do
-  if RUBY_VERSION < '1.9.0'
+  if ruby_version < Gem::Version.new('1.9.0')
     # Pin jruby-openssl on older J Ruby
     gem "jruby-openssl", "< 0.10.0"
     # Pin child-process on older J Ruby
@@ -69,18 +71,18 @@ end
 gem 'simplecov', '~> 0.8'
 
 # No need to run rubocop on earlier versions
-if RUBY_VERSION >= '2.4' && RUBY_ENGINE == 'ruby'
+if ruby_version >= Gem::Version.new('2.4') && RUBY_ENGINE == 'ruby'
   gem "rubocop", "~> 0.52.1"
 end
 
-gem 'test-unit', '~> 3.0' if RUBY_VERSION.to_f >= 2.2
+gem 'test-unit', '~> 3.0' if ruby_version >= Gem::Version.new('2.2')
 
 # Version 5.12 of minitest requires Ruby 2.4
-if RUBY_VERSION < '2.4.0'
+if ruby_version < Gem::Version.new('2.4.0')
   gem 'minitest', '< 5.12.0'
 end
 
 
-gem 'contracts', '< 0.16' if RUBY_VERSION < '1.9.0'
+gem 'contracts', '< 0.16' if ruby_version < Gem::Version.new('1.9.0')
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')


### PR DESCRIPTION
Using `Gem::Version` will result in comparisons that handle `pre` and `rc` and other variations of versions properly.  Also it won't result in version silliness like `'2.2.10' < '2.2.2' # => true`. 

With string version comparison, you have to resort to whacky hacks like converting to Float (line 76), or knowing all possible variations of the comparator.

```
>> '2.2.10' < '2.2.2'
=> true
>> Gem::Version.new('2.2.10') < Gem::Version.new('2.2.2')
=> false
```

`Gem::Version` is also part of Rubygems proper, so it is always available!

Version comparison will always be an ongoing issue for rspec-core as it still supports back to Ruby 1.8.7.  Related: https://github.com/rspec/rspec-core/pull/2750