### PR TITLE
Enable warning support explicitly

### DIFF
--- a/features/command_line/warnings_option.feature
+++ b/features/command_line/warnings_option.feature
@@ -15,6 +15,23 @@ Feature: `--warnings` option (run with warnings enabled)
     When I run `rspec --warnings example_spec.rb`
     Then the output should contain "warning"
 
+  @ruby-2-7
+  Scenario:
+    Given a file named "example_spec.rb" with:
+      """ruby
+      def foo(**kwargs)
+        kwargs
+      end
+
+      RSpec.describe do
+       it "should warn about keyword arguments with 'rspec -w'" do
+         expect(foo({a: 1})).to eq({a: 1})
+        end
+      end
+      """
+    When I run `rspec -w example_spec.rb`
+    Then the output should contain "warning"
+
   @unsupported-on-rbx
   Scenario:
     Given a file named "example_spec.rb" with:

--- a/features/support/ruby_27_support.rb
+++ b/features/support/ruby_27_support.rb
@@ -1,0 +1,7 @@
+Around "@ruby-2-7" do |scenario, block|
+  if RUBY_VERSION.to_f == 2.7
+    block.call
+  else
+    warn "Skipping scenario #{scenario.title} on Ruby v#{RUBY_VERSION}"
+  end
+end

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -184,6 +184,9 @@ module RSpec::Core
         end
 
         parser.on('-w', '--warnings', 'Enable ruby warnings') do
+          if Object.const_defined?(:Warning) && Warning.respond_to?(:[]=)
+            Warning[:deprecated] = true
+          end
           $VERBOSE = true
         end
 


### PR DESCRIPTION
When enabling RSpecs warning mode, it should include the keyword argument deprecations from Ruby.
See #2809 for the background for this.

(Fixes #2809) 