### PR TITLE
FailureListFormatter: use exception message as reason, not spec name

### DIFF
--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -1,3 +1,5 @@
+warn "This branch is deprecated. Please use `main`."
+
 # rubocop:disable Style/GlobalVars
 $_rspec_core_load_started_at = Time.now
 # rubocop:enable Style/GlobalVars

--- a/lib/rspec/core/formatters/failure_list_formatter.rb
+++ b/lib/rspec/core/formatters/failure_list_formatter.rb
@@ -8,7 +8,18 @@ module RSpec
         Formatters.register self, :example_failed, :dump_profile, :message
 
         def example_failed(failure)
-          output.puts "#{failure.example.location}:#{failure.example.description}"
+          if failure.exception.respond_to?(:all_exceptions)
+            exceptions = failure.exception.all_exceptions
+          else
+            exceptions = [failure.exception]
+          end
+
+          exceptions.each do |exception|
+            reason   = exception.message.lines.map(&:strip).reject(&:empty?).join ' '
+            location = find_relevant_location failure, exception
+
+            output.puts "#{location}:#{reason}"
+          end
         end
 
         # Discard profile and messages
@@ -17,6 +28,28 @@ module RSpec
         # list formatter.
         def dump_profile(_profile); end
         def message(_message); end
+
+        private
+
+        # @return [String] relevant locaton
+        def find_relevant_location(failure, exception)
+          bt = exception.backtrace
+
+          if bt && (line = bt.find { |l| backtrace_exclusion_patterns !~ l })
+            line[/[^:]+:\d+/]
+          else
+            failure.example.location
+          end
+        end
+
+        def backtrace_exclusion_patterns
+          @backtrace_exclusion_patterns ||=
+            begin
+              # ERB/eval lines
+              non_file = /^\(\w+\):/
+              Regexp.union(*RSpec.configuration.backtrace_exclusion_patterns, non_file)
+            end
+        end
       end
     end
   end

--- a/spec/rspec/core/formatters/failure_list_formatter_spec.rb
+++ b/spec/rspec/core/formatters/failure_list_formatter_spec.rb
@@ -7,12 +7,13 @@ module RSpec::Core::Formatters
     it 'produces the expected full output' do
       output = run_example_specs_with_formatter('failures')
       expect(output).to eq(<<-EOS.gsub(/^\s+\|/, ''))
-        |./spec/rspec/core/resources/formatter_specs.rb:4:is marked as pending but passes
-        |./spec/rspec/core/resources/formatter_specs.rb:36:fails
-        |./spec/rspec/core/resources/formatter_specs.rb:40:fails twice
-        |./spec/rspec/core/resources/formatter_specs.rb:47:fails with a backtrace that has no file
-        |./spec/rspec/core/resources/formatter_specs.rb:53:fails with a backtrace containing an erb file
-        |./spec/rspec/core/resources/formatter_specs.rb:71:raises
+        |./spec/rspec/core/resources/formatter_specs.rb:4:Expected example to fail since it is pending, but it passed.
+        |/home/roadster/dev/oss/rspec-core/spec/rspec/core/resources/formatter_specs.rb:37:expected: 2 got: 1 (compared using ==)
+        |/home/roadster/dev/oss/rspec-core/spec/rspec/core/resources/formatter_specs.rb:41:expected: 2 got: 1 (compared using ==)
+        |/home/roadster/dev/oss/rspec-core/spec/rspec/core/resources/formatter_specs.rb:42:expected: 4 got: 3 (compared using ==)
+        |/home/roadster/dev/oss/rspec-core/spec/rspec/core/resources/formatter_specs.rb:50:foo
+        |/foo.html.erb:1:Exception
+        |./spec/rspec/core/resources/formatter_specs.rb:71:boom
       EOS
     end
   end


### PR DESCRIPTION
For me, this improves the value of the 3rd field ("reason") when working with the Quickfix list in Vim. 

Additionally, `rspec --help` specifies this behavior:

```
    -f, --format FORMATTER             Choose a formatter.
                                         [p]rogress (default - dots)
                                         [d]ocumentation (group and example names)
                                         [h]tml
                                         [j]son
                                         [f]ailures ("file:line:reason", suitable for editors integration)
```