### PR TITLE
Spec tweaks for legacy ci

### DIFF
--- a/features/command_line/rake_task.feature
+++ b/features/command_line/rake_task.feature
@@ -39,7 +39,7 @@ Feature: rake task
     When I run `rake`
     Then the output should match:
       """
-      (ruby|rbx) -I\S+ [\/\S]+\/exe\/rspec
+      (ruby(\d\.\d)?|rbx) -I\S+ [\/\S]+\/exe\/rspec
       """
     Then the exit status should be 0
 
@@ -122,7 +122,7 @@ Feature: rake task
     Then the exit status should be 0
     Then the output should match:
       """
-      (ruby|rbx) -I\S+ [\/\S]+\/exe\/rspec --pattern spec[\/\\*{,}]+_spec.rb --tag fast
+      (ruby(\d\.\d)?|rbx) -I\S+ [\/\S]+\/exe\/rspec --pattern spec[\/\\*{,}]+_spec.rb --tag fast
       """
 
   Scenario: Passing rake task arguments to the `rspec` command via `rspec_opts`
@@ -154,5 +154,5 @@ Feature: rake task
     Then the exit status should be 0
     Then the output should match:
       """
-      (ruby|rbx) -I\S+ [\/\S]+\/exe\/rspec --pattern spec[\/\\*{,}]+_spec.rb --tag fast
+      (ruby(\d\.\d)?|rbx) -I\S+ [\/\S]+\/exe\/rspec --pattern spec[\/\\*{,}]+_spec.rb --tag fast
       """

--- a/spec/integration/persistence_failures_spec.rb
+++ b/spec/integration/persistence_failures_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'Persistence failures' do
 
 
       it 'emits a helpful warning to the user, indicating we cannot read from it, and still runs the spec suite' do
+        skip "Legacy builds run as root and this will never pass" if ENV['LEGACY_CI']
         run_command "spec/1_spec.rb"
 
         expected_snippets = [


### PR DESCRIPTION
My upcoming builds for legacy CI run as root, so a spec has to be skipped. This might be reversible later on.

The cucumber scenarios also needed tweaking to account for differently named ruby binaries.