### PR TITLE
Remove the hint about did_you_mean

### DIFF
--- a/lib/rspec/core/did_you_mean.rb
+++ b/lib/rspec/core/did_you_mean.rb
@@ -19,9 +19,8 @@ module RSpec
           formats probables
         end
       else
-        # return a hint if API for ::DidYouMean::SpellChecker not supported
         def call
-          "\nHint: Install the `did_you_mean` gem in order to provide suggestions for similarly named files."
+          ""
         end
       end
 

--- a/spec/rspec/core/did_you_mean_spec.rb
+++ b/spec/rspec/core/did_you_mean_spec.rb
@@ -27,7 +27,7 @@ module RSpec
           describe 'Success' do
             let(:name) { './spec/rspec/core/did_you_mean_spec.rb' }
             it 'returns a hint' do
-              expect(DidYouMean.new(name[0..-2]).call).to include 'Hint:'
+              expect(DidYouMean.new(name[0..-2]).call).to eq('')
             end
           end
         end


### PR DESCRIPTION
The `did_you_mean` suggestions can be distracting for some people. If
you're one of those people, you'd intentionally remove the
`did_you_mean` gem to avoid these.

Remove the hint that prints out when that gem isn't installed to
continue to reduce the distractions.