### PR TITLE
Reset patch-level dependency to 0

### DIFF
--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "rspec-support", "= #{RSpec::Core::Version::STRING}"
   else
     # rspec-support must otherwise match our major/minor version
-    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['3']).join('.')}"
+    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 
   s.add_development_dependency "cucumber", "~> 1.3"


### PR DESCRIPTION
I was having trouble upgrading rspec to 3.10, and it seems like this change (https://github.com/rspec/rspec-core/commit/acc718ed9dcb343c9d756610dcbe2e6a03eb5e1a) means no one can upgrade to 3.10 until rspec-support gets to 3.10.3.

Maybe I'm missing some new idiosyncrasy in the dependency relationships for rspec, but setting this back to 0 allows upgrade to 3.10 since any patch level will be accepted.