### PR TITLE
Remove deprecated `:example_group` example metadata sub-hash

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,8 @@ Breaking Changes:
 * Raise on usage of metadata on suite-level scopes. (Phil Pirozhkov, #2849)
 * Raise an error when `fail_fast` is configured with
   an unsupported value. (Phil Pirozhkov, #2849)
+* Remove deprecated access to an example group's metadata through the example.
+  (Phil Pirozhkov, #2851)
 
 Enhancements:
 

--- a/benchmarks/module_inclusion_filtering.rb
+++ b/benchmarks/module_inclusion_filtering.rb
@@ -14,7 +14,7 @@ module RSpecConfigurationOverrides
   end
 
   def include(mod, *filters)
-    meta = RSpec::Core::Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
+    meta = RSpec::Core::Metadata.build_hash_from(filters)
     @include_extend_or_prepend_modules << [:include, mod, meta]
     super
   end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1163,7 +1163,7 @@ module RSpec
       #
       #     filter_run_including :foo # same as filter_run_including :foo => true
       def filter_run_including(*args)
-        meta = Metadata.build_hash_from(args, :warn_about_example_group_filtering)
+        meta = Metadata.build_hash_from(args)
         filter_manager.include_with_low_priority meta
         static_config_filter_manager.include_with_low_priority Metadata.deep_hash_dup(meta)
       end
@@ -1192,7 +1192,7 @@ module RSpec
       # This overrides any inclusion filters/tags set on the command line or in
       # configuration files.
       def inclusion_filter=(filter)
-        meta = Metadata.build_hash_from([filter], :warn_about_example_group_filtering)
+        meta = Metadata.build_hash_from([filter])
         filter_manager.include_only meta
       end
 
@@ -1237,7 +1237,7 @@ module RSpec
       #
       #     filter_run_excluding :foo # same as filter_run_excluding :foo => true
       def filter_run_excluding(*args)
-        meta = Metadata.build_hash_from(args, :warn_about_example_group_filtering)
+        meta = Metadata.build_hash_from(args)
         filter_manager.exclude_with_low_priority meta
         static_config_filter_manager.exclude_with_low_priority Metadata.deep_hash_dup(meta)
       end
@@ -1250,7 +1250,7 @@ module RSpec
       # This overrides any exclusion filters/tags set on the command line or in
       # configuration files.
       def exclusion_filter=(filter)
-        meta = Metadata.build_hash_from([filter], :warn_about_example_group_filtering)
+        meta = Metadata.build_hash_from([filter])
         filter_manager.exclude_only meta
       end
 
@@ -1732,7 +1732,7 @@ module RSpec
       #     end
       #   end
       def define_derived_metadata(*filters, &block)
-        meta = Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
+        meta = Metadata.build_hash_from(filters)
         @derived_metadata_blocks.append(block, meta)
       end
 
@@ -1755,7 +1755,7 @@ module RSpec
       #     end
       #   end
       def when_first_matching_example_defined(*filters)
-        specified_meta = Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
+        specified_meta = Metadata.build_hash_from(filters)
 
         callback = lambda do |example_or_group_meta|
           # Example groups do not have `:example_group` metadata
@@ -2194,7 +2194,7 @@ module RSpec
           raise TypeError, "`RSpec.configuration.#{config_method}` expects a module but got: #{mod.inspect}"
         end
 
-        meta = Metadata.build_hash_from(filters, :warn_about_example_group_filtering)
+        meta = Metadata.build_hash_from(filters)
         mod_list.append(mod, meta)
         on_existing_matching_groups(meta, &block)
       end

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -571,7 +571,7 @@ module RSpec
         def scope_and_options_from(*args)
           return :suite if args.first == :suite
           scope = extract_scope_from(args)
-          meta  = Metadata.build_hash_from(args, :warn_about_example_group_filtering)
+          meta  = Metadata.build_hash_from(args)
           return scope, meta
         end
 

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -77,15 +77,10 @@ module RSpec
       # Symbols are converted into hash keys with a value of `true`.
       # This is done to support simple tagging using a symbol, rather
       # than needing to do `:symbol => true`.
-      def self.build_hash_from(args, warn_about_example_group_filtering=false)
+      def self.build_hash_from(args)
         hash = args.last.is_a?(Hash) ? args.pop : {}
 
         hash[args.pop] = true while args.last.is_a?(Symbol)
-
-        if warn_about_example_group_filtering && hash.key?(:example_group)
-          RSpec.deprecate("Filtering by an `:example_group` subhash",
-                          :replacement => "the subhash to filter directly")
-        end
 
         hash
       end
@@ -213,11 +208,6 @@ module RSpec
       class ExampleHash < HashPopulator
         def self.create(group_metadata, user_metadata, index_provider, description, block)
           example_metadata = group_metadata.dup
-          group_metadata = Hash.new(&ExampleGroupHash.backwards_compatibility_default_proc do |hash|
-            hash[:parent_example_group]
-          end)
-          group_metadata.update(example_metadata)
-
           example_metadata[:execution_result] = Example::ExecutionResult.new
           example_metadata[:example_group] = group_metadata
           example_metadata[:shared_group_inclusion_backtrace] = SharedExampleGroupInclusionStackFrame.current_backtrace
@@ -246,57 +236,16 @@ module RSpec
       # @private
       class ExampleGroupHash < HashPopulator
         def self.create(parent_group_metadata, user_metadata, example_group_index, *args, &block)
-          group_metadata = hash_with_backwards_compatibility_default_proc
-
-          if parent_group_metadata
-            group_metadata.update(parent_group_metadata)
-            group_metadata[:parent_example_group] = parent_group_metadata
-          end
+          group_metadata =
+            if parent_group_metadata
+              { **parent_group_metadata, :parent_example_group => parent_group_metadata }
+            else
+              {}
+            end
 
           hash = new(group_metadata, user_metadata, example_group_index, args, block)
           hash.populate
           hash.metadata
-        end
-
-        def self.hash_with_backwards_compatibility_default_proc
-          Hash.new(&backwards_compatibility_default_proc { |hash| hash })
-        end
-
-        def self.backwards_compatibility_default_proc(&example_group_selector)
-          Proc.new do |hash, key|
-            case key
-            when :example_group
-              # We commonly get here when rspec-core is applying a previously
-              # configured filter rule, such as when a gem configures:
-              #
-              #   RSpec.configure do |c|
-              #     c.include MyGemHelpers, :example_group => { :file_path => /spec\/my_gem_specs/ }
-              #   end
-              #
-              # It's confusing for a user to get a deprecation at this point in
-              # the code, so instead we issue a deprecation from the config APIs
-              # that take a metadata hash, and MetadataFilter sets this thread
-              # local to silence the warning here since it would be so
-              # confusing.
-              unless RSpec::Support.thread_local_data[:silence_metadata_example_group_deprecations]
-                RSpec.deprecate("The `:example_group` key in an example group's metadata hash",
-                                :replacement => "the example group's hash directly for the " \
-                                "computed keys and `:parent_example_group` to access the parent " \
-                                "example group metadata")
-              end
-
-              group_hash = example_group_selector.call(hash)
-              LegacyExampleGroupHash.new(group_hash) if group_hash
-            when :example_group_block
-              RSpec.deprecate("`metadata[:example_group_block]`",
-                              :replacement => "`metadata[:block]`")
-              hash[:block]
-            when :describes
-              RSpec.deprecate("`metadata[:describes]`",
-                              :replacement => "`metadata[:described_class]`")
-              hash[:described_class]
-            end
-          end
         end
 
       private
@@ -441,57 +390,6 @@ module RSpec
           hash_attribute_names.concat(names)
           super
         end
-      end
-    end
-
-    # @private
-    # Together with the example group metadata hash default block,
-    # provides backwards compatibility for the old `:example_group`
-    # key. In RSpec 2.x, the computed keys of a group's metadata
-    # were exposed from a nested subhash keyed by `[:example_group]`, and
-    # then the parent group's metadata was exposed by sub-subhash
-    # keyed by `[:example_group][:example_group]`.
-    #
-    # In RSpec 3, we reorganized this to that the computed keys are
-    # exposed directly of the group metadata hash (no nesting), and
-    # `:parent_example_group` returns the parent group's metadata.
-    #
-    # Maintaining backwards compatibility was difficult: we wanted
-    # `:example_group` to return an object that:
-    #
-    #   * Exposes the top-level metadata keys that used to be nested
-    #     under `:example_group`.
-    #   * Supports mutation (rspec-rails, for example, assigns
-    #     `metadata[:example_group][:described_class]` when you use
-    #     anonymous controller specs) such that changes are written
-    #     back to the top-level metadata hash.
-    #   * Exposes the parent group metadata as
-    #     `[:example_group][:example_group]`.
-    class LegacyExampleGroupHash
-      include HashImitatable
-
-      def initialize(metadata)
-        @metadata = metadata
-        parent_group_metadata = metadata.fetch(:parent_example_group) { {} }[:example_group]
-        self[:example_group] = parent_group_metadata if parent_group_metadata
-      end
-
-      def to_h
-        super.merge(@metadata)
-      end
-
-    private
-
-      def directly_supports_attribute?(name)
-        name != :example_group
-      end
-
-      def get_value(name)
-        @metadata[name]
-      end
-
-      def set_value(name, value)
-        @metadata[name] = value
       end
     end
   end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -11,14 +11,6 @@ module RSpec::Core
 
     before { config.world = RSpec.world }
 
-    shared_examples_for "warning of deprecated `:example_group` during filtering configuration" do |method, *args|
-      it "issues a deprecation warning when filtering by `:example_group`" do
-        args << { :example_group => { :file_location => /spec\/unit/ } }
-        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /:example_group/)
-        config.__send__(method, *args)
-      end
-    end
-
     describe '#on_example_group_definition' do
       before do
         RSpec.configure do |c|
@@ -1043,8 +1035,6 @@ module RSpec::Core
     end
 
     describe "#include" do
-      include_examples "warning of deprecated `:example_group` during filtering configuration", :include, Enumerable
-
       module InstanceLevelMethods
         def you_call_this_a_blt?
           "egad man, where's the mayo?!?!?"
@@ -1088,16 +1078,6 @@ module RSpec::Core
           end
 
           group = RSpec.describe('does like, stuff and junk', :magic_key => :include) { }
-          expect(group).not_to respond_to(:you_call_this_a_blt?)
-          expect(group.new.you_call_this_a_blt?).to eq("egad man, where's the mayo?!?!?")
-        end
-
-        it "includes in example groups that match a deprecated `:example_group` filter" do
-          RSpec.configure do |c|
-            c.include(InstanceLevelMethods, :example_group => { :file_path => /./ })
-          end
-
-          group = RSpec.describe('does like, stuff and junk')
           expect(group).not_to respond_to(:you_call_this_a_blt?)
           expect(group.new.you_call_this_a_blt?).to eq("egad man, where's the mayo?!?!?")
         end
@@ -1187,8 +1167,6 @@ module RSpec::Core
     end
 
     describe "#extend" do
-      include_examples "warning of deprecated `:example_group` during filtering configuration", :extend, Enumerable
-
       module ThatThingISentYou
         def that_thing
         end
@@ -1226,8 +1204,6 @@ module RSpec::Core
     end
 
     describe "#prepend" do
-      include_examples "warning of deprecated `:example_group` during filtering configuration", :prepend, Enumerable
-
       module SomeRandomMod
         def foo
           "foobar"
@@ -1672,8 +1648,6 @@ module RSpec::Core
         end
       end
 
-      include_examples "warning of deprecated `:example_group` during filtering configuration", :filter_run_including
-
       it "sets the filter with a hash" do
         config.filter_run_including :foo => true
         expect(inclusion_filter).to eq( {:foo => true} )
@@ -1698,8 +1672,6 @@ module RSpec::Core
           config.exclusion_filter.rules
         end
       end
-
-      include_examples "warning of deprecated `:example_group` during filtering configuration", :filter_run_excluding
 
       it "sets the filter" do
         config.filter_run_excluding :foo => true
@@ -1737,8 +1709,6 @@ module RSpec::Core
           config.send("#{type}=", {:want => :this})
           expect(send(type)).to eq( {:want => :this} )
         end
-
-        include_examples "warning of deprecated `:example_group` during filtering configuration", :"#{type}="
       end
     end
     it_behaves_like "a spec filter", :inclusion_filter
@@ -1848,8 +1818,6 @@ module RSpec::Core
     end
 
     describe "#define_derived_metadata" do
-      include_examples "warning of deprecated `:example_group` during filtering configuration", :define_derived_metadata
-
       it 'allows the provided block to mutate example group metadata' do
         RSpec.configuration.define_derived_metadata do |metadata|
           metadata[:reverse_description] = metadata[:description].reverse
@@ -2031,8 +1999,6 @@ module RSpec::Core
     end
 
     describe "#when_first_matching_example_defined" do
-      include_examples "warning of deprecated `:example_group` during filtering configuration", :when_first_matching_example_defined
-
       it "runs the block when the first matching example is defined" do
         sequence = []
         RSpec.configuration.when_first_matching_example_defined(:foo) do
@@ -2701,10 +2667,6 @@ module RSpec::Core
         config.start_time = 42
         expect(config.start_time).to eq 42
       end
-    end
-
-    describe "hooks" do
-      include_examples "warning of deprecated `:example_group` during filtering configuration", :before, :each
     end
 
     describe '#threadsafe', :threadsafe => true do


### PR DESCRIPTION
See:
 - https://github.com/rspec/rspec-core/pull/1490
 - https://github.com/rspec/rspec-core/commit/9ffcc3873365730e12a2a5b6883db9da06fd1eda