### PR TITLE
Ensure Bisect::Channel is able to send data successfully when UTF-8 encoding is set

### DIFF
--- a/lib/rspec/core/bisect/utilities.rb
+++ b/lib/rspec/core/bisect/utilities.rb
@@ -29,11 +29,22 @@ module RSpec
       end
 
       # Wraps a pipe to support sending objects between a child and
-      # parent process.
+      # parent process. Where supported, encoding is explicitly
+      # set to ensure binary data is able to pass from child to
+      # parent.
       # @private
       class Channel
+        if String.method_defined?(:encoding)
+          MARSHAL_DUMP_ENCODING = Marshal.dump("").encoding
+        end
+
         def initialize
           @read_io, @write_io = IO.pipe
+
+          if defined?(MARSHAL_DUMP_ENCODING) && IO.method_defined?(:set_encoding)
+            # Ensure the pipe can send any content produced by Marshal.dump
+            @write_io.set_encoding MARSHAL_DUMP_ENCODING
+          end
         end
 
         def send(message)


### PR DESCRIPTION
This PR is the outcome of debugging an issue that arose when running `rspec --bisect` on a Rails project.

My environment:
Ubuntu 20.04 running under Windows WSL
RSpec 3.10.1
Rails 5.2.4.4
Ruby 2.6.6

One of our specs fails sporadically so I tried using `rspec --bisect` to find the source of the failure. 

```
$ bundle exec rspec --seed 1638 --bisect
Bisect started using options: "--seed 1638"
Running suite to find failures...
```

Rspec would hang like this indefinitely. By inspecting `ps aux | grep rspec` I confirmed that the forked spec runner did complete, but did *not* report back its results to the parent process.

The problem was in RSpec::Core::Bisect::Channel.

Namely, [RSpec::Core::Bisect::Channel#send](https://github.com/rspec/rspec-core/blob/6543181b4ae91e2ecc7e1a7385532b4aca716bcb/lib/rspec/core/bisect/utilities.rb#L41) was silently failing in the forked process with the following error on `@write_io.write`.

```
Encoding::UndefinedConversionError: "\xF8" from ASCII-8BIT to UTF-8
```

The [results from the spec run (`latest_run_results`)](https://github.com/rspec/rspec-core/blob/6543181b4ae91e2ecc7e1a7385532b4aca716bcb/lib/rspec/core/bisect/fork_runner.rb#L126) would contain a non-UTF-8 character after being sent through [Marshal.dump](https://github.com/rspec/rspec-core/blob/6543181b4ae91e2ecc7e1a7385532b4aca716bcb/lib/rspec/core/bisect/utilities.rb#L40).

Since I'm running these specs in the context of Rails, and [Rails by default sets UTF-8 encoding](https://github.com/rails/rails/blob/2a3f8a29e5d7d17a0448fa47fd756c8d11b175b1/railties/lib/rails.rb#L20), the IO::pipe itself was set to use UTF-8 encoding. Since the output of Marshal.dump contained binary characters, the `@write_io` pipe couldn't accept the data.

My PR addresses this by proactively setting the encoding on the `@write_io` pipe to use the same encoding as the data dumped by `Marshal.dump`. I've added specs which reproduce, in isolation, the preconditions which caused the failure I saw and ensure that 1) the data is sent to `@write_io` pipe successfully and 2) that the parent process receives it successfully.