### PR TITLE
Allow configuration of backtrace exclusion based on wether a line has been matched

### DIFF
--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -41,11 +41,8 @@ module RSpec
         has_matched = false
 
         filtered = backtrace.map do |line|
-          unless exclude?(line)
-            has_matched = true
-            backtrace_line(line)
-          else
-            if !has_matched
+          if exclude?(line)
+            unless has_matched
               if !preexclude?(line)
                 prelines << raw_backtrace_line(line)
               else
@@ -54,6 +51,9 @@ module RSpec
               end
               nil
             end
+          else
+            has_matched = true
+            backtrace_line(line)
           end
         end.compact
 

--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -41,7 +41,7 @@ module RSpec
         has_matched = false
 
         filtered = backtrace.map do |line|
-          if !exclude?(line)
+          unless exclude?(line)
             has_matched = true
             backtrace_line(line)
           else

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -681,6 +681,27 @@ module RSpec
         @backtrace_formatter.exclusion_patterns = patterns
       end
 
+      # Regexps used to exclude lines from the top section of backtraces.
+      #
+      # Excludes only RSpec libs by default.  Any lines called by matching lines
+      # will also be excluded.
+      #
+      # You can modify the list via the getter, or replace it with the setter.
+      #
+      # To override this behaviour and display a full backtrace, use
+      # `--backtrace` on the command line, in a `.rspec` file, or in the
+      # `rspec_options` attribute of RSpec's rake task.
+      # @return [Array<Regexp>]
+      def backtrace_preexclusion_patterns
+        @backtrace_formatter.preexclusion_patterns
+      end
+
+      # Set regular expressions used to exclude lines in backtrace.
+      # @param patterns [Array<Regexp>] set backtrace_formatter exlusion_patterns
+      def backtrace_preexclusion_patterns=(patterns)
+        @backtrace_formatter.preexclusion_patterns = patterns
+      end
+
       # Regexps used to include lines in backtraces.
       #
       # Defaults to [Regexp.new Dir.getwd].

--- a/spec/rspec/core/formatters/html_formatter_spec.rb
+++ b/spec/rspec/core/formatters/html_formatter_spec.rb
@@ -21,6 +21,7 @@ module RSpec
 
             # This is to minimize churn on backtrace lines
             runner.configuration.backtrace_exclusion_patterns << /.*/
+            runner.configuration.backtrace_preexclusion_patterns << /.*/
             runner.configuration.backtrace_inclusion_patterns << /formatter_specs\.rb/
           end
         end

--- a/spec/rspec/core/reporter_spec.rb
+++ b/spec/rspec/core/reporter_spec.rb
@@ -319,8 +319,8 @@ module RSpec::Core
           |
           |ZeroDivisionError:
           |  divided by 0
-          |# #{Metadata.relative_path(__FILE__)}:#{line}
         EOS
+        expect(formatter_out.string).to match(/# #{Metadata.relative_path(__FILE__)}:#{line}/)
       end
 
       it "records the fact that a non example failure has occurred" do


### PR DESCRIPTION
If I call a gem or other library and it blows up, then I really want to
see those top lines of where the exception got thrown.

This patch preserves the behavior where if I call into (for example)
rspec-expectations and it throws in the backtrace I don't want to see
that.  I also don't want to see any exceptions thrown by gems that rspec
gems call to do their work.

Once a single user line (or rspec gem line) is hit, then the behavior
reverts to the old behavior and all the bundler/rubygems/rspec/thor spam
at the bottom of the exception is still pruned using the same
include/exclude tunables.

"Show me if something under my code blew up, do not show me if rspec
or something under rspec blew up."

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>