### PR TITLE
This is a reproduction of the variable number of examples being executed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ Breaking Changes:
   `alias_it_should_behave_like_to` configuration option. (Phil Pirozhkov, #2864)
 * Remove deprecated `treat_symbols_as_metadata_keys_with_true_values` configuration
   option. (Phil Pirozhkov, #2864)
+* Remove support for Mocha version < 1.0. (Phil Pirozhkov, #2864)
 
 Enhancements:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,8 @@ Breaking Changes:
   execution result. (Phil Pirozhkov, #2862)
 * Remove deprecated `color` configuration option and `--color` command line
   option. (Phil Pirozhkov, #2864)
+* Remove `it_should_behave_like` nested shared group method and
+  `alias_it_should_behave_like_to` configuration option. (Phil Pirozhkov, #2864)
 
 Enhancements:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,8 @@ Breaking Changes:
 * Remove deprecated `treat_symbols_as_metadata_keys_with_true_values` configuration
   option. (Phil Pirozhkov, #2864)
 * Remove support for Mocha version < 1.0. (Phil Pirozhkov, #2864)
+* Remove deprecated `PendingExampleFixedNotification` and
+  `PendingExampleFailedAsExpectedNotification` classes. (Phil Pirozhkov, #2864)
 
 Enhancements:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,8 @@ Breaking Changes:
   option. (Phil Pirozhkov, #2864)
 * Remove `it_should_behave_like` nested shared group method and
   `alias_it_should_behave_like_to` configuration option. (Phil Pirozhkov, #2864)
+* Remove deprecated `treat_symbols_as_metadata_keys_with_true_values` configuration
+  option. (Phil Pirozhkov, #2864)
 
 Enhancements:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@ Breaking Changes:
 * Remove support for Mocha version < 1.0. (Phil Pirozhkov, #2864)
 * Remove deprecated `PendingExampleFixedNotification` and
   `PendingExampleFailedAsExpectedNotification` classes. (Phil Pirozhkov, #2864)
+* Remove deprecated `rerun_argument` example method. (Phil Pirozhkov, #2864)
 
 Enhancements:
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ Breaking Changes:
   (Phil Pirozhkov, #2851)
 * Remove deprecated Hash-like behavior from example
   execution result. (Phil Pirozhkov, #2862)
+* Remove deprecated `color` configuration option and `--color` command line
+  option. (Phil Pirozhkov, #2864)
 
 Enhancements:
 

--- a/features/example_groups/shared_examples.feature
+++ b/features/example_groups/shared_examples.feature
@@ -10,7 +10,6 @@ Feature: shared examples
   ```ruby
   include_examples "name"      # include the examples in the current context
   it_behaves_like "name"       # include the examples in a nested context
-  it_should_behave_like "name" # include the examples in a nested context
   matching metadata            # include the examples in the current context
   ```
 
@@ -206,12 +205,12 @@ Feature: shared examples
 
     RSpec.describe Array, "with 3 items" do
       subject { [1, 2, 3] }
-      it_should_behave_like "a measurable object", 3, [:size, :length]
+      it_behaves_like "a measurable object", 3, [:size, :length]
     end
 
     RSpec.describe String, "of 6 characters" do
       subject { "FooBar" }
-      it_should_behave_like "a measurable object", 6, [:size, :length]
+      it_behaves_like "a measurable object", 6, [:size, :length]
     end
     """
     When I run `rspec shared_example_group_params_spec.rb --format documentation`
@@ -219,21 +218,21 @@ Feature: shared examples
     And the output should contain:
       """
       Array with 3 items
-        it should behave like a measurable object
+        behaves like a measurable object
           should return 3 from #size
           should return 3 from #length
 
       String of 6 characters
-        it should behave like a measurable object
+        behaves like a measurable object
           should return 6 from #size
           should return 6 from #length
       """
 
-  Scenario: Aliasing `it_should_behave_like` to `it_has_behavior`
+  Scenario: Aliasing `it_behaves_like` to `it_has_behavior`
     Given a file named "shared_example_group_spec.rb" with:
       """ruby
       RSpec.configure do |c|
-        c.alias_it_should_behave_like_to :it_has_behavior, 'has behavior:'
+        c.alias_it_behaves_like_to :it_has_behavior, 'has behavior:'
       end
 
       RSpec.shared_examples 'sortability' do

--- a/features/formatters/custom_formatter.feature
+++ b/features/formatters/custom_formatter.feature
@@ -13,7 +13,7 @@ Feature: custom formatters
       """ruby
       class CustomFormatter
         # This registers the notifications this formatter supports, and tells
-        # us that this was written against the RSpec 3.x formatter API.
+        # us that this was written against the RSpec 4.x formatter API.
         RSpec::Core::Formatters.register self, :example_started
 
         def initialize(output)

--- a/lib/rspec/core.rb
+++ b/lib/rspec/core.rb
@@ -100,23 +100,7 @@ module RSpec
   # The example being executed.
   #
   # The primary audience for this method is library authors who need access
-  # to the example currently being executed and also want to support RSpec 2.
-  #
-  # @example support for RSpec version 2
-  #
-  #     RSpec.configure do |c|
-  #       # context.example is deprecated, but RSpec.current_example is not
-  #       # available until RSpec 3.0.
-  #       fetch_current_example = RSpec.respond_to?(:current_example) ?
-  #         proc { RSpec.current_example } : proc { |context| context.example }
-  #
-  #       c.before(:example) do
-  #         example = fetch_current_example.call(self)
-  #
-  #         # ...
-  #       end
-  #     end
-  #
+  # to the example currently being executed.
   def self.current_example
     RSpec::Support.thread_local_data[:current_example]
   end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -409,9 +409,6 @@ module RSpec
       end
 
       # @private
-      # @deprecated Use {#color_mode} = :on, instead of {#color} with {#tty}
-      add_setting :tty
-      # @private
       attr_writer :files_to_run
       # @private
       attr_accessor :filter_manager, :world
@@ -441,7 +438,6 @@ module RSpec
         @mock_framework = nil
         @files_or_directories_to_run = []
         @loaded_spec_files = Set.new
-        @color = false
         @color_mode = :automatic
         @pattern = '**{,/*/**}/*_spec.rb'
         @exclude_pattern = ''
@@ -803,20 +799,6 @@ module RSpec
         @backtrace_formatter.full_backtrace = true_or_false
       end
 
-      # Enables color output if the output is a TTY.  As of RSpec 3.6, this is
-      # the default behavior and this option is retained only for backwards
-      # compatibility.
-      #
-      # @deprecated No longer recommended because of complex behavior. Instead,
-      #   rely on the fact that TTYs will display color by default, or set
-      #   {#color_mode} to :on to display color on a non-TTY output.
-      # @see color_mode
-      # @see color_enabled?
-      # @return [Boolean]
-      def color
-        value_for(:color) { @color }
-      end
-
       # The mode for determining whether to display output in color. One of:
       #
       # - :automatic - the output will be in color if the output is a TTY (the
@@ -839,19 +821,12 @@ module RSpec
         when :on then true
         when :off then false
         else # automatic
-          output_to_tty?(output) || (color && tty?)
+          output_to_tty?(output)
         end
       end
 
       # Set the color mode.
       attr_writer :color_mode
-
-      # Toggle output color.
-      #
-      # @deprecated No longer recommended because of complex behavior. Instead,
-      #   rely on the fact that TTYs will display color by default, or set
-      #   {:color_mode} to :on to display color on a non-TTY output.
-      attr_writer :color
 
       # @private
       def libs=(libs)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -348,18 +348,6 @@ module RSpec
       # return [Boolean]
       add_setting :silence_filter_announcements
 
-      # @deprecated This config option was added in RSpec 2 to pave the way
-      #   for this being the default behavior in RSpec 3. Now this option is
-      #   a no-op.
-      def treat_symbols_as_metadata_keys_with_true_values=(_value)
-        RSpec.deprecate(
-          "RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=",
-          :message => "RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values= " \
-                      "is deprecated, it is now set to true as default and " \
-                      "setting it to false has no effect."
-        )
-      end
-
       # Record the start time of the spec suite to measure load time.
       # return [Time]
       add_setting :start_time

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1076,8 +1076,8 @@ module RSpec
         RSpec::Core::ExampleGroup.define_example_group_method(new_name, extra_options)
       end
 
-      # Define an alias for it_should_behave_like that allows different
-      # language (like "it_has_behavior" or "it_behaves_like") to be
+      # Define an alias for it_behaves_like that allows different
+      # language (like "it_has_behavior" or "it_is_able_to") to be
       # employed when including shared examples.
       #
       # @example
@@ -1099,13 +1099,10 @@ module RSpec
       #   #     ...sortability examples here
       #
       # @note Use with caution. This extends the language used in your
-      #   specs, but does not add any additional documentation. We use this
-      #   in RSpec to define `it_should_behave_like` (for backward
-      #   compatibility), but we also add docs for that method.
+      #   specs, but does not add any additional documentation.
       def alias_it_behaves_like_to(new_name, report_label='')
         RSpec::Core::ExampleGroup.define_nested_shared_group_method(new_name, report_label)
       end
-      alias_method :alias_it_should_behave_like_to, :alias_it_behaves_like_to
 
       # Adds key/value pairs to the `inclusion_filter`. If `args`
       # includes any symbols that are not part of the hash, each symbol

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -58,7 +58,7 @@ module RSpec
 
       UNFORCED_OPTIONS = Set.new([
         :requires, :profile, :drb, :libs, :files_or_directories_to_run,
-        :full_description, :full_backtrace, :tty
+        :full_description, :full_backtrace
       ])
 
       UNPROCESSABLE_OPTIONS = Set.new([:formatters])

--- a/lib/rspec/core/drb.rb
+++ b/lib/rspec/core/drb.rb
@@ -40,12 +40,10 @@ module RSpec
 
       def options
         argv = []
-        argv << "--color"        if @submitted_options[:color]
         argv << "--force-color"  if @submitted_options[:color_mode] == :on
         argv << "--no-color"     if @submitted_options[:color_mode] == :off
         argv << "--profile"      if @submitted_options[:profile_examples]
         argv << "--backtrace"    if @submitted_options[:full_backtrace]
-        argv << "--tty"          if @submitted_options[:tty]
         argv << "--fail-fast"    if @submitted_options[:fail_fast]
         argv << "--options"      << @submitted_options[:custom_options_file] if @submitted_options[:custom_options_file]
         argv << "--order"        << @submitted_options[:order]               if @submitted_options[:order]

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -105,15 +105,6 @@ module RSpec
         end
       end
 
-      # Returns the location-based argument that can be passed to the `rspec` command to rerun this example.
-      #
-      # @deprecated Use {#location_rerun_argument} instead.
-      # @note If there are multiple examples identified by this location, they will use {#id}
-      #   to rerun instead, but this method will still return the location (that's why it is deprecated!).
-      def rerun_argument
-        location_rerun_argument
-      end
-
       # @return [String] the unique id of this example. Pass
       #   this at the command line to re-run this exact example.
       def id

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -314,7 +314,7 @@ module RSpec
       #   @!scope class
       #
       #   @see SharedExampleGroup
-      def self.define_nested_shared_group_method(new_name, report_label="it should behave like")
+      def self.define_nested_shared_group_method(new_name, report_label="behaves like")
         idempotently_define_singleton_method(new_name) do |name, *args, &customization_block|
           # Pass :caller so the :location metadata is set properly.
           # Otherwise, it'll be set to the next line because that's
@@ -329,10 +329,7 @@ module RSpec
 
       # Generates a nested example group and includes the shared content
       # mapped to `name` in the nested group.
-      define_nested_shared_group_method :it_behaves_like, "behaves like"
-      # Generates a nested example group and includes the shared content
-      # mapped to `name` in the nested group.
-      define_nested_shared_group_method :it_should_behave_like
+      define_nested_shared_group_method :it_behaves_like
 
       # Includes shared content mapped to `name` directly in the group in which
       # it is declared, as opposed to `it_behaves_like`, which creates a nested

--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -164,7 +164,7 @@ module RSpec::Core::Formatters
 
         RSpec.warn_deprecation <<-WARNING.gsub(/\s*\|/, ' ')
           |The #{formatter_class} formatter uses the deprecated formatter
-          |interface not supported directly by RSpec 3.
+          |interface not supported directly by RSpec 4.
           |
           |To continue to use this formatter you must install the
           |`rspec-legacy_formatters` gem, which provides support

--- a/lib/rspec/core/mocking_adapters/mocha.rb
+++ b/lib/rspec/core/mocking_adapters/mocha.rb
@@ -1,28 +1,4 @@
-# In order to support all versions of mocha, we have to jump through some
-# hoops here.
-#
-# mocha >= '0.13.0':
-#   require 'mocha/api' is required.
-#   require 'mocha/object' raises a LoadError b/c the file no longer exists.
-# mocha < '0.13.0', >= '0.9.7'
-#   require 'mocha/api' is required.
-#   require 'mocha/object' is required.
-# mocha < '0.9.7':
-#   require 'mocha/api' raises a LoadError b/c the file does not yet exist.
-#   require 'mocha/standalone' is required.
-#   require 'mocha/object' is required.
-begin
-  require 'mocha/api'
-
-  begin
-    require 'mocha/object'
-  rescue LoadError
-    # Mocha >= 0.13.0 no longer contains this file nor needs it to be loaded.
-  end
-rescue LoadError
-  require 'mocha/standalone'
-  require 'mocha/object'
-end
+require 'mocha/api'
 
 module RSpec
   module Core
@@ -33,12 +9,7 @@ module RSpec
           :mocha
         end
 
-        # Mocha::Standalone was deprecated as of Mocha 0.9.7.
-        begin
-          include ::Mocha::API
-        rescue NameError
-          include ::Mocha::Standalone
-        end
+        include ::Mocha::API
 
         def setup_mocks_for_rspec
           mocha_setup

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -42,17 +42,9 @@ module RSpec::Core
         execution_result = example.execution_result
 
         return SkippedExampleNotification.new(example) if execution_result.example_skipped?
-        return new(example) unless execution_result.status == :pending || execution_result.status == :failed
+        return FailedExampleNotification.new(example) if execution_result.status == :pending || execution_result.status == :failed
 
-        klass = if execution_result.pending_fixed?
-                  PendingExampleFixedNotification
-                elsif execution_result.status == :pending
-                  PendingExampleFailedAsExpectedNotification
-                else
-                  FailedExampleNotification
-                end
-
-        klass.new(example)
+        new(example)
       end
 
       private_class_method :new
@@ -213,12 +205,6 @@ module RSpec::Core
         super(example)
       end
     end
-
-    # @deprecated Use {FailedExampleNotification} instead.
-    class PendingExampleFixedNotification < FailedExampleNotification; end
-
-    # @deprecated Use {FailedExampleNotification} instead.
-    class PendingExampleFailedAsExpectedNotification < FailedExampleNotification; end
 
     # The `SkippedExampleNotification` extends `ExampleNotification` with
     # things useful for specs that are skipped.

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -18,7 +18,7 @@ module RSpec::Core
       return { :files_or_directories_to_run => [] } if original_args.empty?
       args = original_args.dup
 
-      options = args.delete('--tty') ? { :tty => true } : {}
+      options = {}
       begin
         parser(options).parse!(args)
       rescue OptionParser::InvalidOption => e
@@ -138,12 +138,6 @@ module RSpec::Core
 
         parser.on('-b', '--backtrace', 'Enable full backtrace.') do |_o|
           options[:full_backtrace] = true
-        end
-
-        parser.on('-c', '--color', '--colour', '') do |_o|
-          # flag will be excluded from `--help` output because it is deprecated
-          options[:color] = true
-          options[:color_mode] = :automatic
         end
 
         parser.on('--force-color', '--force-colour', 'Force the output to be in color, even if the output is not a TTY') do |_o|

--- a/lib/rspec/core/pending.rb
+++ b/lib/rspec/core/pending.rb
@@ -51,36 +51,12 @@ module RSpec
       #         raise "broken"
       #       end
       #     end
-      #
-      # @note `before(:example)` hooks are eval'd when you use the `pending`
-      #   method within an example. If you want to declare an example `pending`
-      #   and bypass the `before` hooks as well, you can pass `:pending => true`
-      #   to the `it` method:
-      #
-      #       it "does something", :pending => true do
-      #         # ...
-      #       end
-      #
-      #   or pass `:pending => "something else getting finished"` to add a
-      #   message to the summary report:
-      #
-      #       it "does something", :pending => "something else getting finished" do
-      #         # ...
-      #       end
       def pending(message=nil)
         current_example = RSpec.current_example
 
         if block_given?
           raise ArgumentError, <<-EOS.gsub(/^\s+\|/, '')
-            |The semantics of `RSpec::Core::Pending#pending` have changed in
-            |RSpec 3. In RSpec 2.x, it caused the example to be skipped. In
-            |RSpec 3, the rest of the example is still run but is expected to
-            |fail, and will be marked as a failure (rather than as pending) if
-            |the example passes.
-            |
-            |Passing a block within an example is now deprecated. Marking the
-            |example as pending provides the same behavior in RSpec 3 which was
-            |provided only by the block in RSpec 2.x.
+            |Passing a block within an example is not supported.
             |
             |Move the code in the block provided to `pending` into the rest of
             |the example body.

--- a/lib/rspec/core/project_initializer/spec/spec_helper.rb
+++ b/lib/rspec/core/project_initializer/spec/spec_helper.rb
@@ -27,8 +27,8 @@ RSpec.configure do |config|
   # library (such as bogus or mocha) by changing the `mock_with` option here.
   config.mock_with :rspec do |mocks|
     # Prevents you from mocking or stubbing a method that does not exist on
-    # a real object. This is generally recommended, and will default to
-    # `true` in RSpec 4.
+    # a real object. This is generally recommended, and is the default since
+    # RSpec 4.
     mocks.verify_partial_doubles = true
   end
 

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -136,13 +136,6 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
       expect(config.exclusion_filter.rules).to have_key(:slow)
     end
 
-    it "forces color" do
-      opts = config_options_object(*%w[--color])
-      expect(config).to receive(:force).with(:color => true)
-      expect(config).to receive(:force).with(:color_mode => :automatic)
-      opts.configure(config)
-    end
-
     it "forces force_color" do
       opts = config_options_object(*%w[--force-color])
       expect(config).to receive(:force).with(:color_mode => :on)
@@ -204,25 +197,13 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
     end
   end
 
-  describe "-c, --color, and --colour" do
-    it "sets :color_mode => :automatic" do
-      expect(parse_options('-c')).to include(:color_mode => :automatic)
-      expect(parse_options('--color')).to include(:color_mode => :automatic)
-      expect(parse_options('--colour')).to include(:color_mode => :automatic)
-    end
-
-    it "overrides previous color flag" do
-      expect(parse_options('--no-color', '--color')).to include(:color_mode => :automatic)
-    end
-  end
-
   describe "--no-color" do
     it "sets :color_mode => :off" do
       expect(parse_options('--no-color')).to include(:color_mode => :off)
     end
 
     it "overrides previous color flag" do
-      expect(parse_options('--color', '--no-color')).to include(:color_mode => :off)
+      expect(parse_options('--force-color', '--no-color')).to include(:color_mode => :off)
     end
   end
 
@@ -232,7 +213,7 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
     end
 
     it "overrides previous color flag" do
-      expect(parse_options('--color', '--force-color')).to include(:color_mode => :on)
+      expect(parse_options('--no-color', '--force-color')).to include(:color_mode => :on)
     end
   end
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1583,13 +1583,6 @@ module RSpec::Core
     it_behaves_like "a spec filter", :inclusion_filter
     it_behaves_like "a spec filter", :exclusion_filter
 
-    describe "#treat_symbols_as_metadata_keys_with_true_values=" do
-      it 'is deprecated' do
-        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
-        config.treat_symbols_as_metadata_keys_with_true_values = true
-      end
-    end
-
     describe "#full_backtrace=" do
       it "doesn't impact other instances of config" do
         config_1 = Configuration.new

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1265,216 +1265,85 @@ module RSpec::Core
 
     end
 
-    describe "#color_mode" do
-      context ":automatic" do
-        before do
-          config.color_mode = :automatic
-        end
-
-        context "with output.tty?" do
-          it "sets color_enabled?" do
-            config.output_stream = StringIO.new
-            allow(config.output_stream).to receive_messages(:tty? => true)
-            expect(config.color_enabled?).to be true
-          end
-        end
-
-        context "with !output.tty?" do
-          it "sets !color_enabled?" do
-            config.output_stream = StringIO.new
-            allow(config.output_stream).to receive_messages(:tty? => false)
-            expect(config.color_enabled?).to be false
-          end
-        end
-      end
-
-      context ":on" do
-        before do
-          config.color_mode = :on
-        end
-
-        context "with output.tty?" do
-          it "sets color_enabled?" do
-            config.output_stream = StringIO.new
-            allow(config.output_stream).to receive_messages(:tty? => true)
-            expect(config.color_enabled?).to be true
-          end
-        end
-
-        context "with !output.tty?" do
-          it "sets color_enabled?" do
-            config.output_stream = StringIO.new
-            allow(config.output_stream).to receive_messages(:tty? => false)
-            expect(config.color_enabled?).to be true
-          end
-        end
-      end
-
-      context ":off" do
-        before do
-          config.color_mode = :off
-        end
-
-        context "with output.tty?" do
-          it "sets !color_enabled?" do
-            config.output_stream = StringIO.new
-            allow(config.output_stream).to receive_messages(:tty? => true)
-            expect(config.color_enabled?).to be false
-          end
-        end
-
-        context "with !output.tty?" do
-          it "sets !color_enabled?" do
-            config.output_stream = StringIO.new
-            allow(config.output_stream).to receive_messages(:tty? => false)
-            expect(config.color_enabled?).to be false
-          end
-        end
-
-        it "prefers incoming cli_args" do
-          config.output_stream = StringIO.new
-          config.force :color_mode => :on
-          config.color_mode = :off
-          expect(config.color_mode).to be :on
-        end
-      end
-    end
-
     describe "#color_enabled?" do
       it "allows overriding instance output stream with an argument" do
         config.output_stream = StringIO.new
         output_override = StringIO.new
 
-        config.color_mode = :automatic
         allow(config.output_stream).to receive_messages(:tty? => false)
         allow(output_override).to receive_messages(:tty? => true)
 
         expect(config.color_enabled?).to be false
         expect(config.color_enabled?(output_override)).to be true
       end
+
+      context "with color_mode :automatic" do
+        before { config.color_mode = :automatic }
+
+        context "with output.tty?" do
+          it "sets color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => true)
+            expect(config.color_enabled?).to be true
+          end
+        end
+
+        context "with !output.tty?" do
+          it "sets !color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => false)
+            expect(config.color_enabled?).to be false
+          end
+        end
+      end
+
+      context "with color_mode :on" do
+        before { config.color_mode = :on }
+
+        context "with output.tty?" do
+          it "sets color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => true)
+            expect(config.color_enabled?).to be true
+          end
+        end
+
+        context "with !output.tty?" do
+          it "sets color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => false)
+            expect(config.color_enabled?).to be true
+          end
+        end
+      end
+
+      context "with color_mode :off" do
+        before { config.color_mode = :off }
+
+        context "with output.tty?" do
+          it "sets !color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => true)
+            expect(config.color_enabled?).to be false
+          end
+        end
+
+        context "with !output.tty?" do
+          it "sets !color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => false)
+            expect(config.color_enabled?).to be false
+          end
+        end
+      end
     end
 
-    describe "#color=" do
-      before { config.color_mode = :automatic }
-
-      context "given false" do
-        before { config.color = false }
-
-        context "with config.tty? and output.tty?" do
-          it "sets color_enabled?" do
-            output = StringIO.new
-            config.output_stream = output
-
-            config.tty = true
-            allow(config.output_stream).to receive_messages(:tty? => true)
-
-            expect(config.color_enabled?).to be true
-            expect(config.color_enabled?(output)).to be true
-          end
-        end
-
-        context "with config.tty? and !output.tty?" do
-          it "does not set color_enabled?" do
-            output = StringIO.new
-            config.output_stream = output
-
-            config.tty = true
-            allow(config.output_stream).to receive_messages(:tty? => false)
-
-            expect(config.color_enabled?).to be false
-            expect(config.color_enabled?(output)).to be false
-          end
-        end
-
-        context "with !config.tty? and output.tty?" do
-          it "sets color_enabled?" do
-            output = StringIO.new
-            config.output_stream = output
-
-            config.tty = false
-            allow(config.output_stream).to receive_messages(:tty? => true)
-
-            expect(config.color_enabled?).to be true
-            expect(config.color_enabled?(output)).to be true
-          end
-        end
-
-        context "with !config.tty? and !output.tty?" do
-          it "does not set color_enabled?" do
-            output = StringIO.new
-            config.output_stream = output
-
-            config.tty = false
-            allow(config.output_stream).to receive_messages(:tty? => false)
-
-            expect(config.color_enabled?).to be false
-            expect(config.color_enabled?(output)).to be false
-          end
-        end
-      end
-
-      context "given true" do
-        before { config.color = true }
-
-        context "with config.tty? and output.tty?" do
-          it "sets color_enabled?" do
-            output = StringIO.new
-            config.output_stream = output
-
-            config.tty = true
-            allow(config.output_stream).to receive_messages(:tty? => true)
-
-            expect(config.color_enabled?).to be true
-            expect(config.color_enabled?(output)).to be true
-          end
-        end
-
-        context "with config.tty? and !output.tty?" do
-          it "sets color_enabled?" do
-            output = StringIO.new
-            config.output_stream = output
-
-            config.tty = true
-            allow(config.output_stream).to receive_messages(:tty? => false)
-
-            expect(config.color_enabled?).to be true
-            expect(config.color_enabled?(output)).to be true
-          end
-        end
-
-        context "with !config.tty? and output.tty?" do
-          it "sets color_enabled?" do
-            output = StringIO.new
-            config.output_stream = output
-
-            config.tty = false
-            allow(config.output_stream).to receive_messages(:tty? => true)
-
-            expect(config.color_enabled?).to be true
-            expect(config.color_enabled?(output)).to be true
-          end
-        end
-
-        context "with !config.tty? and !output.tty?" do
-          it "does not set color_enabled?" do
-            output = StringIO.new
-            config.output_stream = output
-
-            config.tty = false
-            allow(config.output_stream).to receive_messages(:tty? => false)
-
-            expect(config.color_enabled?).to be false
-            expect(config.color_enabled?(output)).to be false
-          end
-        end
-      end
-
+    describe '#color_mode' do
       it "prefers incoming cli_args" do
         config.output_stream = StringIO.new
-        allow(config.output_stream).to receive_messages(:tty? => true)
-        config.force :color => true
-        config.color = false
-        expect(config.color).to be true
+        config.force :color_mode => :on
+        config.color_mode = :off
+        expect(config.color_mode).to be :on
       end
     end
 

--- a/spec/rspec/core/drb_spec.rb
+++ b/spec/rspec/core/drb_spec.rb
@@ -125,10 +125,10 @@ RSpec.describe RSpec::Core::DRbOptions, :isolated_directory => true, :isolated_h
 
     it "preserves extra arguments" do
       allow(File).to receive(:exist?) { false }
-      expect(drb_argv_for(%w[ a --drb b --color c ])).to match_array %w[ --color a b c ]
+      expect(drb_argv_for(%w[ a --drb b --no-color c ])).to match_array %w[ --no-color a b c ]
     end
 
-    %w(--color --force-color --no-color --fail-fast --profile --backtrace --tty).each do |option|
+    %w(--force-color --no-color --fail-fast --profile --backtrace).each do |option|
       it "includes #{option}" do
         expect(drb_argv_for([option])).to include(option)
       end
@@ -243,41 +243,41 @@ RSpec.describe RSpec::Core::DRbOptions, :isolated_directory => true, :isolated_h
 
     context "--drb specified in ARGV" do
       it "renders all the original arguments except --drb" do
-        argv = drb_argv_for(%w[ --drb --color --format s --example pattern
+        argv = drb_argv_for(%w[ --drb --no-color --format s --example pattern
                                 --profile --backtrace -I
                                 path/a -I path/b --require path/c --require
                                 path/d])
-        expect(argv).to eq(%w[ --color --profile --backtrace --example pattern --format s -I path/a -I path/b --require path/c --require path/d])
+        expect(argv).to eq(%w[ --no-color --profile --backtrace --example pattern --format s -I path/a -I path/b --require path/c --require path/d])
       end
     end
 
     context "--drb specified in the options file" do
       it "renders all the original arguments except --drb" do
-        File.open("./.rspec", "w") {|f| f << "--drb --color"}
-        drb_argv = drb_argv_for(%w[ --tty --format s --example pattern --profile --backtrace ])
-        expect(drb_argv).to eq(%w[ --color --profile --backtrace --tty --example pattern --format s])
+        File.open("./.rspec", "w") {|f| f << "--drb --no-color"}
+        drb_argv = drb_argv_for(%w[ --format s --example pattern --profile --backtrace ])
+        expect(drb_argv).to eq(%w[ --no-color --profile --backtrace --example pattern --format s])
       end
     end
 
     context "--drb specified in ARGV and the options file" do
       it "renders all the original arguments except --drb" do
-        File.open("./.rspec", "w") {|f| f << "--drb --color"}
+        File.open("./.rspec", "w") {|f| f << "--drb --no-color"}
         argv = drb_argv_for(%w[ --drb --format s --example pattern --profile --backtrace])
-        expect(argv).to eq(%w[ --color --profile --backtrace --example pattern --format s])
+        expect(argv).to eq(%w[ --no-color --profile --backtrace --example pattern --format s])
       end
     end
 
     context "--drb specified in ARGV and in as ARGV-specified --options file" do
       it "renders all the original arguments except --drb and --options" do
-        File.open("./.rspec", "w") {|f| f << "--drb --color"}
+        File.open("./.rspec", "w") {|f| f << "--drb --no-color"}
         argv = drb_argv_for(%w[ --drb --format s --example pattern --profile --backtrace])
-        expect(argv).to eq(%w[ --color --profile --backtrace --example pattern --format s ])
+        expect(argv).to eq(%w[ --no-color --profile --backtrace --example pattern --format s ])
       end
     end
 
     describe "--drb, -X" do
       it "does not send --drb back to the parser after parsing options" do
-        expect(drb_argv_for(%w[--drb --color])).not_to include("--drb")
+        expect(drb_argv_for(%w[--drb --no-color])).not_to include("--drb")
       end
     end
   end

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1723,11 +1723,11 @@ module RSpec::Core
       end
     end
 
-    describe "#it_should_behave_like" do
+    describe "#it_behaves_like" do
       it "creates a nested group" do
         group = RSpec.describe('fake group')
         group.shared_examples_for("thing") {}
-        group.it_should_behave_like("thing")
+        group.it_behaves_like("thing")
         expect(group.children.count).to eq(1)
       end
 
@@ -1735,7 +1735,7 @@ module RSpec::Core
         klass = Class.new
         group = RSpec.describe('fake group')
         group.shared_examples_for(klass) {}
-        group.it_should_behave_like(klass)
+        group.it_behaves_like(klass)
         expect(group.children.count).to eq(1)
       end
 
@@ -1744,7 +1744,7 @@ module RSpec::Core
         group.shared_examples_for("thing") do
           it("does something")
         end
-        shared_group = group.it_should_behave_like("thing")
+        shared_group = group.it_behaves_like("thing")
         expect(shared_group.examples.count).to eq(1)
       end
 
@@ -1753,7 +1753,7 @@ module RSpec::Core
         group.shared_examples_for("thing") do
           def foo; end
         end
-        shared_group = group.it_should_behave_like("thing")
+        shared_group = group.it_behaves_like("thing")
         expect(shared_group.public_instance_methods.map{|m| m.to_s}).to include("foo")
       end
 
@@ -1762,7 +1762,7 @@ module RSpec::Core
         group.shared_examples_for("thing") do
           def self.foo; end
         end
-        shared_group = group.it_should_behave_like("thing")
+        shared_group = group.it_behaves_like("thing")
         expect(shared_group.methods.map{|m| m.to_s}).to include("foo")
       end
 
@@ -1777,7 +1777,7 @@ module RSpec::Core
             end
           end
 
-          it_should_behave_like "thing", :value1, :value2
+          it_behaves_like "thing", :value1, :value2
         end
 
         group.run
@@ -1790,7 +1790,7 @@ module RSpec::Core
         group.shared_examples_for("thing") do |param1|
           def foo; end
         end
-        shared_group = group.it_should_behave_like("thing", :a)
+        shared_group = group.it_behaves_like("thing", :a)
         expect(shared_group.public_instance_methods.map{|m| m.to_s}).to include("foo")
       end
 
@@ -1798,7 +1798,7 @@ module RSpec::Core
         eval_count = 0
         group = RSpec.describe('fake group')
         group.shared_examples_for("thing") { |p| eval_count += 1 }
-        group.it_should_behave_like("thing", :a)
+        group.it_behaves_like("thing", :a)
         expect(eval_count).to eq(1)
       end
 
@@ -1811,7 +1811,7 @@ module RSpec::Core
                 scopes << self.class
               end
             end
-            it_should_behave_like "thing" do
+            it_behaves_like "thing" do
               it("gets run in the same nested group") do
                 scopes << self.class
               end
@@ -1826,7 +1826,7 @@ module RSpec::Core
       it "raises a helpful error message when shared context is not found" do
         expect do
           RSpec.describe do
-            it_should_behave_like "shared stuff"
+            it_behaves_like "shared stuff"
           end
         end.to raise_error(ArgumentError,%q|Could not find shared examples "shared stuff"|)
       end
@@ -1835,7 +1835,7 @@ module RSpec::Core
         expect {
           RSpec.describe do
             shared_examples_for("stuff") { }
-            it_should_behave_like "stuff"
+            it_behaves_like "stuff"
           end
         }.to avoid_changing(RSpec::Support, :thread_local_data)
       end
@@ -1844,7 +1844,7 @@ module RSpec::Core
         expect {
           RSpec.describe do
             shared_examples_for("stuff") { }
-            it_should_behave_like "stuff" do
+            it_behaves_like "stuff" do
               raise "boom"
             end
           end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -744,7 +744,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
         group.run
         expect(example).to fail_with ArgumentError
         expect(example.exception.message).to match(
-          /Passing a block within an example is now deprecated./
+          /Passing a block within an example is not supported./
         )
       end
     end

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
     end
   end
 
-  describe "#rerun_argument" do
+  describe "#location_rerun_argument" do
     it "returns the location-based rerun argument" do
       allow(RSpec.configuration).to receive_messages(:loaded_spec_files => [__FILE__])
       example = RSpec.describe.example
-      expect(example.rerun_argument).to eq("#{RSpec::Core::Metadata.relative_path(__FILE__)}:#{__LINE__ - 1}")
+      expect(example.location_rerun_argument).to eq("#{RSpec::Core::Metadata.relative_path(__FILE__)}:#{__LINE__ - 1}")
     end
   end
 

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
       end
     end
 
-    %w[ include_examples it_should_behave_like ].each do |inclusion_method|
+    %w[ include_examples it_behaves_like ].each do |inclusion_method|
       context "for #shared_examples included using #{inclusion_method}" do
         it 'outputs the name and location' do
           group.shared_examples 'foo bar' do

--- a/spec/rspec/core/formatters/profile_formatter_spec.rb
+++ b/spec/rspec/core/formatters/profile_formatter_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RSpec::Core::Formatters::ProfileFormatter do
         end)
       end
 
-      it_should_behave_like "profiles examples"
+      it_behaves_like "profiles examples"
 
       it "doesn't profile a single example group" do
         expect(formatter_output.string).not_to match(/slowest example groups/)
@@ -72,7 +72,7 @@ RSpec.describe RSpec::Core::Formatters::ProfileFormatter do
         profile group1, group2
       end
 
-      it_should_behave_like "profiles examples"
+      it_behaves_like "profiles examples"
 
       it "prints the slowest example groups" do
         expect(formatter_output.string).to match(/slowest example groups/)

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -615,17 +615,17 @@ module RSpec::Core
 
     describe Object do
       context 'with implicit subject' do
-        it_should_behave_like 'a subject'
+        it_behaves_like 'a subject'
       end
 
       context 'with explicit subject' do
         subject { Object.new }
-        it_should_behave_like 'a subject'
+        it_behaves_like 'a subject'
       end
 
       context 'with a constant subject'do
         subject { 123 }
-        it_should_behave_like 'a subject'
+        it_behaves_like 'a subject'
       end
     end
   end

--- a/spec/rspec/core/pending_example_spec.rb
+++ b/spec/rspec/core/pending_example_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe "an example" do
       group.run
       expect(example).to fail_with ArgumentError
       expect(example.exception.message).to match(
-        /Passing a block within an example is now deprecated./
+        /Passing a block within an example is not supported./
       )
     end
 

--- a/spec/rspec/core/runner_spec.rb
+++ b/spec/rspec/core/runner_spec.rb
@@ -357,7 +357,7 @@ module RSpec::Core
       end
 
       it "assigns submitted ConfigurationOptions to @options" do
-        config_options = ConfigurationOptions.new(%w[--color])
+        config_options = ConfigurationOptions.new([])
         runner         = Runner.new(config_options)
         expect(runner.instance_exec { @options }).to be(config_options)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,7 +76,6 @@ RSpec.configure do |c|
 
   # runtime options
   c.raise_errors_for_deprecations!
-  c.color = true
   c.include CommonHelpers
 
   c.expect_with :rspec do |expectations|

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -35,8 +35,6 @@ RSpec.shared_context "aruba support" do
   attr_reader :last_cmd_stdout, :last_cmd_stderr, :last_cmd_exit_status
 
   def run_command(cmd)
-    RSpec.configuration.color = true
-
     temp_stdout = StringIO.new
     temp_stderr = StringIO.new
 
@@ -51,7 +49,6 @@ RSpec.shared_context "aruba support" do
     end
   ensure
     RSpec.reset
-    RSpec.configuration.color = true
 
     # Ensure it gets cached with a proper value -- if we leave it set to nil,
     # and the next spec operates in a different dir, it could get set to an


### PR DESCRIPTION
The funniest part is that RSpec returns with exit code 0, while skipping examples:
```
Finished in 6.55 seconds (files took 1.32 seconds to load)
716 examples, 0 failures
```

```
Finished in 10.13 seconds (files took 1.13 seconds to load)
420 examples, 0 failures
```

```
Finished in 22.02 seconds (files took 1.14 seconds to load)
1977 examples, 0 failures
```

```
Finished in 9.51 seconds (files took 1.25 seconds to load)
1070 examples, 0 failures
```

While there are ~2000 examples

RuboCop does not report any error parsing Ruby files.