### PR TITLE
Skip using the default pattern from Rake task

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ Breaking Changes:
   (Phil Pirozhkov, #2851)
 * Remove deprecated Hash-like behavior from example
   execution result. (Phil Pirozhkov, #2862)
+* Skip setting the default pattern from Rake task. (Phil Pirozhkov, #2868)
 
 Enhancements:
 

--- a/features/command_line/rake_task.feature
+++ b/features/command_line/rake_task.feature
@@ -122,7 +122,7 @@ Feature: rake task
     Then the exit status should be 0
     Then the output should match:
       """
-      (ruby|rbx) -I\S+ [\/\S]+\/exe\/rspec --pattern spec[\/\\*{,}]+_spec.rb --tag fast
+      (ruby|rbx) -I\S+ [\/\S]+\/exe\/rspec --tag fast
       """
 
   Scenario: Passing rake task arguments to the `rspec` command via `rspec_opts`
@@ -154,5 +154,5 @@ Feature: rake task
     Then the exit status should be 0
     Then the output should match:
       """
-      (ruby|rbx) -I\S+ [\/\S]+\/exe\/rspec --pattern spec[\/\\*{,}]+_spec.rb --tag fast
+      (ruby|rbx) -I\S+ [\/\S]+\/exe\/rspec --tag fast
       """

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -24,14 +24,11 @@ module RSpec
       # Default path to the RSpec executable.
       DEFAULT_RSPEC_PATH = File.expand_path('../../../../exe/rspec', __FILE__)
 
-      # Default pattern for spec files.
-      DEFAULT_PATTERN = 'spec/**{,/*/**}/*_spec.rb'
-
       # Name of task. Defaults to `:spec`.
       attr_accessor :name
 
       # Files matching this pattern will be loaded.
-      # Defaults to `'spec/**{,/*/**}/*_spec.rb'`.
+      # Defaults to `nil`.
       attr_accessor :pattern
 
       # Files matching this pattern will be excluded.
@@ -81,7 +78,7 @@ module RSpec
         @verbose       = true
         @fail_on_error = true
         @rspec_path    = DEFAULT_RSPEC_PATH
-        @pattern       = DEFAULT_PATTERN
+        @pattern       = nil
 
         define(args, &task_block)
       end
@@ -124,6 +121,8 @@ module RSpec
         elsif String === pattern && !File.exist?(pattern)
           return if [*rspec_opts].any? { |opt| opt =~ /--pattern/ }
           "--pattern #{escape pattern}"
+        elsif pattern.nil?
+          ""
         else
           # Before RSpec 3.1, we used `FileList` to get the list of matched
           # files, and then pass that along to the `rspec` command. Starting

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -62,27 +62,25 @@ module RSpec::Core
     end
 
     context "with rspec_opts" do
-      include RSpec::Core::ShellEscape
-
       it "adds the rspec_opts" do
         task.rspec_opts = "-Ifoo"
-        expect(spec_command).to match(/#{task.rspec_path}.*-Ifoo/).and(
-          include(escape(RSpec::Core::RakeTask::DEFAULT_PATTERN)) # sanity check for following specs
-        )
+        expect(spec_command).to match(/#{task.rspec_path}.*-Ifoo/)
       end
 
-      it 'correctly excludes the default pattern if rspec_opts includes --pattern' do
+      it "doesn't add a default pattern that would override CLI configuration from files" do
+        expect(spec_command).to exclude("--pattern")
+      end
+
+      it 'only uses the pattern passed via rspec_opts' do
         task.rspec_opts = "--pattern some_specs"
-        expect(spec_command).to include("--pattern some_specs").and(
-          exclude(escape(RSpec::Core::RakeTask::DEFAULT_PATTERN))
-        )
+        expect(spec_command).to include("--pattern some_specs")
+        expect(spec_command).to include("--pattern").once
       end
 
       it 'behaves properly if rspec_opts is an array' do
         task.rspec_opts = %w[--pattern some_specs]
-        expect(spec_command).to include("--pattern some_specs").and(
-          exclude(escape(RSpec::Core::RakeTask::DEFAULT_PATTERN))
-        )
+        expect(spec_command).to include("--pattern some_specs")
+        expect(spec_command).to include("--pattern").once
       end
     end
 


### PR DESCRIPTION
Previously, if the pattern was not set in the Rakefile, RSpec was passing `--pattern` option to the `rspec` command effectively overriding the setting from `.rspec` config file.

This is an inconsistency between running CLI `rspec` directly and running the Rake task.

Fixes #2859