### PR TITLE
Unify multi-condition filtering

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -31,6 +31,7 @@ Breaking Changes:
 * Remove deprecated `rerun_argument` example method. (Phil Pirozhkov, #2864)
 * Raise on attempt to use a legacy formatter without `rspec-legacy_formatters`.
   (Phil Pirozhkov, #2864)
+* Unify multi-condition filtering to use "all" semantic. (Phil Pirozhkov, #2874)
 
 Enhancements:
 

--- a/benchmarks/module_inclusion_filtering.rb
+++ b/benchmarks/module_inclusion_filtering.rb
@@ -21,7 +21,7 @@ module RSpecConfigurationOverrides
 
   def old_configure_group(group)
     @include_extend_or_prepend_modules.each do |include_extend_or_prepend, mod, filters|
-      next unless filters.empty? || RSpec::Core::MetadataFilter.apply?(:any?, filters, group.metadata)
+      next unless filters.empty? || RSpec::Core::MetadataFilter.apply?(filters, group.metadata)
       __send__("safe_#{include_extend_or_prepend}", mod, group)
     end
   end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -413,9 +413,9 @@ module RSpec
         @start_time = $_rspec_core_load_started_at || ::RSpec::Core::Time.now
         # rubocop:enable Style/GlobalVars
         @expectation_frameworks = []
-        @include_modules = FilterableItemRepository::QueryOptimized.new(:any?)
-        @extend_modules  = FilterableItemRepository::QueryOptimized.new(:any?)
-        @prepend_modules = FilterableItemRepository::QueryOptimized.new(:any?)
+        @include_modules = FilterableItemRepository::QueryOptimized.new
+        @extend_modules  = FilterableItemRepository::QueryOptimized.new
+        @prepend_modules = FilterableItemRepository::QueryOptimized.new
 
         @bisect_runner = RSpec::Support::RubyFeatures.fork_supported? ? :fork : :shell
         @bisect_runner_class = nil
@@ -455,7 +455,7 @@ module RSpec
         @profile_examples = false
         @requires = []
         @libs = []
-        @derived_metadata_blocks = FilterableItemRepository::QueryOptimized.new(:any?)
+        @derived_metadata_blocks = FilterableItemRepository::QueryOptimized.new
         @threadsafe = true
         @max_displayed_failure_line_count = 10
         @world = World::Null
@@ -2134,7 +2134,7 @@ module RSpec
       end
 
       def metadata_applies_to_group?(meta, group)
-        meta.empty? || MetadataFilter.apply?(:any?, meta, group.metadata)
+        meta.empty? || MetadataFilter.apply?(meta, group.metadata)
       end
 
       def safe_prepend(mod, host)

--- a/lib/rspec/core/filter_manager.rb
+++ b/lib/rspec/core/filter_manager.rb
@@ -46,7 +46,7 @@ module RSpec
 
           examples.select do |ex|
             file_scoped_include?(ex.metadata, ids, locations) do
-              !exclusions.include_example?(ex) && non_scoped_inclusions.include_example?(ex)
+              (exclusions.empty? || !exclusions.include_example?(ex)) && non_scoped_inclusions.include_example?(ex)
             end
           end
         end
@@ -166,7 +166,7 @@ module RSpec
       end
 
       def include_example?(example)
-        MetadataFilter.apply?(:any?, @rules, example.metadata)
+        MetadataFilter.apply?(@rules, example.metadata)
       end
     end
 

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -540,18 +540,18 @@ module RSpec
         def ensure_hooks_initialized_for(position, scope)
           if position == :before
             if scope == :example
-              @before_example_hooks ||= @filterable_item_repo_class.new(:all?)
+              @before_example_hooks ||= @filterable_item_repo_class.new
             else
-              @before_context_hooks ||= @filterable_item_repo_class.new(:all?)
+              @before_context_hooks ||= @filterable_item_repo_class.new
             end
           elsif position == :after
             if scope == :example
-              @after_example_hooks ||= @filterable_item_repo_class.new(:all?)
+              @after_example_hooks ||= @filterable_item_repo_class.new
             else
-              @after_context_hooks ||= @filterable_item_repo_class.new(:all?)
+              @after_context_hooks ||= @filterable_item_repo_class.new
             end
           else # around
-            @around_example_hooks ||= @filterable_item_repo_class.new(:all?)
+            @around_example_hooks ||= @filterable_item_repo_class.new
           end
         end
 

--- a/lib/rspec/core/metadata_filter.rb
+++ b/lib/rspec/core/metadata_filter.rb
@@ -8,8 +8,8 @@ module RSpec
     module MetadataFilter
       class << self
         # @private
-        def apply?(predicate, filters, metadata)
-          filters.__send__(predicate) { |k, v| filter_applies?(k, v, metadata) }
+        def apply?(filters, metadata)
+          filters.all? { |k, v| filter_applies?(k, v, metadata) }
         end
 
         # @private
@@ -88,8 +88,7 @@ module RSpec
       class UpdateOptimized
         attr_reader :items_and_filters
 
-        def initialize(applies_predicate)
-          @applies_predicate = applies_predicate
+        def initialize
           @items_and_filters = []
         end
 
@@ -108,7 +107,7 @@ module RSpec
         def items_for(request_meta)
           @items_and_filters.each_with_object([]) do |(item, item_meta), to_return|
             to_return << item if item_meta.empty? ||
-                                 MetadataFilter.apply?(@applies_predicate, item_meta, request_meta)
+                                 MetadataFilter.apply?(item_meta, request_meta)
           end
         end
       end
@@ -129,7 +128,7 @@ module RSpec
         alias find_items_for items_for
         private :find_items_for
 
-        def initialize(applies_predicate)
+        def initialize
           super
           @applicable_keys   = Set.new
           @proc_keys         = Set.new

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1828,20 +1828,18 @@ module RSpec::Core
           expect(e3.metadata).not_to include(:reverse_description)
         end
 
-        it 'applies if any of multiple filters apply (to align with module inclusion semantics)' do
+        it 'applies if all of multiple filters apply (to align with module inclusion semantics)' do
           RSpec.configure do |c|
             c.define_derived_metadata(:a => 1, :b => 2) do |metadata|
               metadata[:reverse_description] = metadata[:description].reverse
             end
           end
 
-          g1 = RSpec.describe("G1", :a => 1)
+          g1 = RSpec.describe("G1", :a => 1, :b => 2)
           g2 = RSpec.describe("G2", :b => 2)
-          g3 = RSpec.describe("G3", :c => 3)
 
           expect(g1.metadata).to include(:reverse_description => "1G")
-          expect(g2.metadata).to include(:reverse_description => "2G")
-          expect(g3.metadata).not_to include(:reverse_description)
+          expect(g2.metadata).not_to include(:reverse_description)
         end
 
         it 'allows a metadata filter to be passed as a raw symbol' do
@@ -2099,13 +2097,22 @@ module RSpec::Core
         expect(group.included_modules).to include(mod)
       end
 
-      it "requires only one matching filter" do
+      it "requires exact matching filter" do
+        mod = Module.new
+        group = RSpec.describe("group", :foo => :bar, :baz => :bam)
+
+        config.include(mod, :foo => :bar, :baz => :bam)
+        config.configure_group(group)
+        expect(group.included_modules).to include(mod)
+      end
+
+      it "doesn't include on incomplete matching filter" do
         mod = Module.new
         group = RSpec.describe("group", :foo => :bar)
 
         config.include(mod, :foo => :bar, :baz => :bam)
         config.configure_group(group)
-        expect(group.included_modules).to include(mod)
+        expect(group.included_modules).not_to include(mod)
       end
 
       module IncludeExtendOrPrependMeOnce

--- a/spec/rspec/core/filter_manager_spec.rb
+++ b/spec/rspec/core/filter_manager_spec.rb
@@ -292,15 +292,15 @@ module RSpec::Core
       end
 
       context "with multiple inclusion filters" do
-        it 'includes objects that match any of them' do
+        it 'includes objects that match all of them' do
           examples = [
-            included_1 = example_with(:foo => true),
-            included_2 = example_with(:bar => true),
-                         example_with(:bazz => true)
+            included = example_with(:foo => true, :bar => true),
+                       example_with(:foo => true),
+                       example_with(:baz => true)
           ]
 
           filter_manager.include :foo => true, :bar => true
-          expect(prune(examples)).to contain_exactly(included_1, included_2)
+          expect(prune(examples)).to contain_exactly(included)
         end
       end
 


### PR DESCRIPTION
Always use `all?` semantic when applying metadata conditions for filtering.
Previously `all?` was only used for hooks, and `any?` was used for everything else (module inclusions, shared example group inclusion, define derived metadata).

**Before** this change `MyModule` would be included to example groups defining **any** of `foo: true` or `bar: true`:
```ruby
RSpec.configure do |c|
  c.include MyModule, :foo => true, :bar => true
end
```

**After** the change the same `any?` behaviour is achievable splitting into two statements:

```ruby
RSpec.configure do |c|
  c.include MyModule, :foo => true
  c.include MyModule, :bar => true
end
```

`MyModule` will only be included in groups with **both** `:foo => true` AND `:bar => true`
```ruby
RSpec.configure do |c|
  c.include MyModule, :foo => true, :bar => true
end
```

Fixes #1821

Depends on:
- ~https://github.com/rspec/rspec-rails/pull/2468~
- https://github.com/rspec/rspec-rails/pull/2469