### PR TITLE
Fix YARD type syntax

### DIFF
--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -79,7 +79,7 @@ module RSpec::Core::Formatters
 
   # Register the formatter class
   # @param formatter_class [Class] formatter class to register
-  # @param notifications [Symbol, ...] one or more notifications to be
+  # @param notifications [Array<Symbol>] one or more notifications to be
   #   registered to the specified formatter
   #
   # @see RSpec::Core::Formatters::BaseFormatter


### PR DESCRIPTION
* Another method using this way
  * https://github.com/rspec/rspec-core/blob/fe3084758857f0714f05ada44a18f1dfe9bf7a7e/lib/rspec/core/configuration.rb#L1125
  * https://github.com/rspec/rspec-core/blob/fe3084758857f0714f05ada44a18f1dfe9bf7a7e/lib/rspec/core/configuration.rb#L1154
* https://yardoc.org/types.html can't parse `Symbol, ...`

ref: This syntax issue is found by https://github.com/lsegal/yard/pull/1369