### PR TITLE
Update Cucumber

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,2 +1,2 @@
-default: --require features --strict --format progress --tags ~@wip features
+default: --require features --strict --format progress --tags 'not @wip' features
 wip:     --require features --tags @wip:30 --wip features

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -108,7 +108,7 @@ Given(/^a vendored gem named "(.*?)" containing a file named "(.*?)" with:$/) do
   set_environment_variable('RUBYOPT', ENV['RUBYOPT'] + " -I#{gem_dir}/lib")
 end
 
-When "I accept the recommended settings by removing `=begin` and `=end` from `spec/spec_helper.rb`" do
+When /I accept the recommended settings by removing `=begin` and `=end` from `spec\/spec_helper.rb`/ do
   cd('.') do
     spec_helper = File.read("spec/spec_helper.rb")
     expect(spec_helper).to include("=begin", "=end")

--- a/features/support/require_expect_syntax_in_aruba_specs.rb
+++ b/features/support/require_expect_syntax_in_aruba_specs.rb
@@ -1,6 +1,6 @@
 if defined?(Cucumber)
   require 'shellwords'
-  Before('~@with-clean-spec-opts') do
+  Before('not @with-clean-spec-opts') do
     set_environment_variable('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
   end
 else

--- a/features/support/ruby_27_support.rb
+++ b/features/support/ruby_27_support.rb
@@ -1,7 +1,6 @@
-Around "@ruby-2-7" do |scenario, block|
-  if RUBY_VERSION.to_f == 2.7
-    block.call
-  else
+Before "@ruby-2-7" do |scenario|
+  unless RUBY_VERSION.to_f == 2.7
     warn "Skipping scenario #{scenario.title} on Ruby v#{RUBY_VERSION}"
+    skip_this_scenario
   end
 end

--- a/features/support/ruby_27_support.rb
+++ b/features/support/ruby_27_support.rb
@@ -1,6 +1,6 @@
 Before "@ruby-2-7" do |scenario|
   unless RUBY_VERSION.to_f == 2.7
-    warn "Skipping scenario #{scenario.title} on Ruby v#{RUBY_VERSION}"
+    warn "Skipping scenario #{scenario.name} on Ruby v#{RUBY_VERSION}"
     skip_this_scenario
   end
 end

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['3']).join('.')}"
   end
 
-  s.add_development_dependency "cucumber", "~> 3.2.0"
+  s.add_development_dependency 'cucumber', '>= 3.2', '!= 4.0.0', '< 8.0.0'
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.14.9"
 

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['3']).join('.')}"
   end
 
-  s.add_development_dependency "cucumber", "~> 1.3"
+  s.add_development_dependency "cucumber", "~> 2.4.0"
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.14.9"
 

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['3']).join('.')}"
   end
 
-  s.add_development_dependency "cucumber", "~> 2.4.0"
+  s.add_development_dependency "cucumber", "~> 3.2.0"
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.14.9"
 


### PR DESCRIPTION
Cucumber 3.2 is the last version that combines the following two properties:
- It supports Ruby 2.3
- It supports installation together with diff-lcs 1.4.4

This pull requests fixes the errors when running with Cucumber 2.x and up by improving the handler for the `@ruby-2-7` tag so it uses Cucumber's standard support for skipping scenarios.

Sibling PRs:
 - https://github.com/rspec/rspec-expectations/pull/1320
 - https://github.com/rspec/rspec-mocks/pull/1439
 - https://github.com/rspec/rspec-support/pull/517