### PR TITLE
Clean up documentation leftovers for trigger_inclusion behaviour

### DIFF
--- a/features/example_groups/shared_examples.feature
+++ b/features/example_groups/shared_examples.feature
@@ -10,7 +10,6 @@ Feature: shared examples
   ```ruby
   include_examples "name"      # include the examples in the current context
   it_behaves_like "name"       # include the examples in a nested context
-  matching metadata            # include the examples in the current context
   ```
 
   **WARNING:** Files containing shared groups must be loaded before the files that

--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -112,9 +112,9 @@ module RSpec
       #
       # ### Warning: implicit before blocks
       #
-      # `before` hooks can also be declared in shared contexts which get
-      # included implicitly either by you or by extension libraries. Since
-      # RSpec runs these in the order in which they are declared within each
+      # `before` hooks can also be declared in configuration-level shared contexts
+      # which get included implicitly either by you or by extension libraries.
+      # Since RSpec runs these in the order in which they are declared within each
       # scope, load order matters, and can lead to confusing results when one
       # before block depends on state that is prepared in another before block
       # that gets run later.

--- a/lib/rspec/core/shared_example_group.rb
+++ b/lib/rspec/core/shared_example_group.rb
@@ -45,9 +45,8 @@ module RSpec
     # examples that you wish to use in multiple example groups.
     #
     # When defined, the shared group block is stored for later evaluation.
-    # It can later be included in an example group either explicitly
-    # (using `include_examples`, `include_context` or `it_behaves_like`)
-    # or implicitly (via matching metadata).
+    # It can later be included in an example group explicitly using
+    # `include_examples`, `include_context` or `it_behaves_like`.
     #
     # Named shared example groups are scoped based on where they are
     # defined. Shared groups defined in an example group are available
@@ -62,9 +61,7 @@ module RSpec
       # @overload shared_examples(name, metadata, &block)
       #   @param name [String, Symbol, Module] identifer to use when looking up
       #     this shared group
-      #   @param metadata [Array<Symbol>, Hash] metadata to attach to this
-      #     group; any example group or example with matching metadata will
-      #     automatically include this shared example group.
+      #   @param metadata [Array<Symbol>, Hash] metadata to attach to this group
       #   @param block The block to be eval'd
       #
       # Stores the block for later use. The block will be evaluated


### PR DESCRIPTION
Fixes #2775
Related:
 - #2834
 - #2832
 - #1762

To sum it all up, the current behavior (`apply_to_host_groups`) is:

1.1. Configuration-level methods (`include`, `extend`, `prepend`, `include_context`, `before`, `after`, `around`) are tagged with metadata that is matched against example group metadata (and example metadata, as an example has a singleton example group), and are included. E.g.:

```ruby
RSpec.configuration do |config|
  config.before(:example, litter_env: true) do
    ENV['litter'] = 'true'
  end
end

RSpec.describe do
  it 'survives litter flood', :litter_env do
    expect(ENV['litter']).to eq('true')
  end
end
```

1.2. Example group-level methods' (`shared_examples`/`shared_examples_for`, `shared_context`) metadata is applied to host groups that explicitly include them. E.g.:

```ruby
RSpec.describe do
  shared_context 'in the wild', cold: true do
    let(:temp) { -30 }
  end

  context 'winter' do
    include_context 'in the wild'

    it 'is cold' do |example|
      expect(example.metadata[:cold]).to be(true)
      expect(temp).to eq(-30)
    end
  end
end
```

1.3. Example group-level methods' (`shared_examples`/`shared_examples_for`, `shared_context`) do not include shared groups to example groups based on matching metadata. E.g.:

```ruby
RSpec.describe do
  shared_context 'done', done: true do
    before do
      ENV['done'] = 'done'
    end
  end

  it 'is done', :done do
    expect(ENV['done']).to be(nil)
  end
end
```

1.4 Example group-level hook methods are executed for examples with matching metadata. E.g.:

```ruby
RSpec.describe do
  let(:pocket) { [] }

  before(:example, profit: true) do
    pocket << :penny
  end

  it 'is empty' do
    expect(pocket).to be_empty
  end

  it 'is full', :profit do
    expect(pocket).to contain_exactly(:penny)
  end
end
```

Just to avoid any confusion:

2.1. Configuration-level methods `shared_context`/`shared_examples`/`shared_examples_for` are not defined

2.2. Configuration-level methods `include_examples`/`it_behaves_like` are not defined

2.3. Example group-level `include_context`/`include_examples`/`it_behaves_like` (as opposed to configuration-level counterparts) do not accept metadata, but rather parameters that are passed to the included shared group:

```ruby
RSpec.describe do
  shared_context 'foo' do |var:|
    let(:foo) { var }
  end

  include_context 'foo', var: :bar

  it 'foo is bar' do
    expect(foo).to eq(:bar)
  end
end
```

Quite obvious but [confused me](https://github.com/rspec/rspec-core/pull/2775#issuecomment-711878339):

3.1. Included example groups override memoized helpers defined in the including example group:

```ruby
RSpec.describe "open-close" do
  let(:open) { false }

  shared_context "is open" do
    let(:open) { true }
  end

  include_context "is open"

  it 'overrides open' do
    expect(open).to be(true)
  end
end
```