### PR TITLE
Add deprecation warnings for features to be removed/changed in RSpec 4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@ Bug fixes:
 * Fix exception presenter when the root cause exception has nil backtrace.
   (Zinovyev Ivan, #2903)
 
+Deprecations:
+
+* Add RSpec 4 deprecation warnings. (Phil Pirozhkov, #2880)
+
 ### 3.10.1 / 2020-12-27
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.10.0...v3.10.1)
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -327,7 +327,11 @@ module RSpec
       # (default: `false`).
       # @deprecated Use {#filter_run_when_matching} instead for the specific
       #   filters that you want to be ignored if none match.
-      add_setting :run_all_when_everything_filtered
+      def run_all_when_everything_filtered=(value)
+        RSpec.deprecate("`run_all_when_everything_filtered` setting", :replacement => "`filter_run_when_matching :focus`")
+        @run_all_when_everything_filtered = value
+      end
+      add_read_only_setting :run_all_when_everything_filtered
 
       # @macro add_setting
       # Color to use to indicate success.  Defaults to `:green` but can be set
@@ -440,6 +444,11 @@ module RSpec
             "shared_context_metadata_behavior` to `#{value.inspect}`. Only " \
             "`:trigger_inclusion` and `:apply_to_host_groups` are valid values."
         end
+
+        if value == :trigger_inclusion
+          RSpec.deprecate("`shared_context_metadata_behavior` setting",
+                          :message => "`:apply_to_host_groups` will become the default and only option.")
+        end
       end
 
       # Record the start time of the spec suite to measure load time.
@@ -492,7 +501,12 @@ module RSpec
 
       # @private
       # @deprecated Use {#color_mode} = :on, instead of {#color} with {#tty}
-      add_setting :tty
+      def tty=(value)
+        RSpec.deprecate("`tty` setting", :replacement => "`color_mode`")
+        @tty = value
+      end
+      add_read_only_setting :tty
+
       # @private
       attr_writer :files_to_run
       # @private
@@ -933,8 +947,11 @@ module RSpec
       #
       # @deprecated No longer recommended because of complex behavior. Instead,
       #   rely on the fact that TTYs will display color by default, or set
-      #   {:color_mode} to :on to display color on a non-TTY output.
-      attr_writer :color
+      #   {#color_mode} to :on to display color on a non-TTY output.
+      def color=(value)
+        RSpec.deprecate("`color` setting", :replacement => "`color_mode`")
+        @color = value
+      end
 
       # @private
       def libs=(libs)
@@ -1217,7 +1234,13 @@ module RSpec
       def alias_it_behaves_like_to(new_name, report_label='')
         RSpec::Core::ExampleGroup.define_nested_shared_group_method(new_name, report_label)
       end
-      alias_method :alias_it_should_behave_like_to, :alias_it_behaves_like_to
+
+      # Alias for `alias_it_behaves_like_to`.
+      # @deprecated Use {#alias_it_behaves_like_to} instead.
+      def alias_it_should_behave_like_to(new_name, report_label='')
+        RSpec.deprecate("`alias_it_should_behave_like_to`", :replacement => "`alias_it_behaves_like_to`")
+        alias_it_behaves_like_to(new_name, report_label)
+      end
 
       # Adds key/value pairs to the `inclusion_filter`. If `args`
       # includes any symbols that are not part of the hash, each symbol

--- a/lib/rspec/core/dsl.rb
+++ b/lib/rspec/core/dsl.rb
@@ -81,7 +81,10 @@ module RSpec
       def self.expose_example_group_alias_globally(method_name)
         change_global_dsl do
           remove_method(method_name) if method_defined?(method_name)
-          define_method(method_name) { |*a, &b| ::RSpec.__send__(method_name, *a, &b) }
+          define_method(method_name) do |*a, &b|
+            RSpec.deprecate("Globally-exposed DSL (`#{method_name}`)", :replacement => "`RSpec.#{method_name}`")
+            ::RSpec.__send__(method_name, *a, &b)
+          end
         end
       end
 

--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -109,6 +109,7 @@ module RSpec
       # @note If there are multiple examples identified by this location, they will use {#id}
       #   to rerun instead, but this method will still return the location (that's why it is deprecated!).
       def rerun_argument
+        RSpec.deprecate("`rerun_argument`", :replacement => "`location_rerun_argument`")
         location_rerun_argument
       end
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -316,6 +316,8 @@ module RSpec
       #   @see SharedExampleGroup
       def self.define_nested_shared_group_method(new_name, report_label="it should behave like")
         idempotently_define_singleton_method(new_name) do |name, *args, &customization_block|
+          yield if block_given? # to print a deprecation warning for it_should_behave_like usage
+
           # Pass :caller so the :location metadata is set properly.
           # Otherwise, it'll be set to the next line because that's
           # the block's source_location.
@@ -332,7 +334,9 @@ module RSpec
       define_nested_shared_group_method :it_behaves_like, "behaves like"
       # Generates a nested example group and includes the shared content
       # mapped to `name` in the nested group.
-      define_nested_shared_group_method :it_should_behave_like
+      define_nested_shared_group_method(:it_should_behave_like) do
+        RSpec.deprecate("`it_should_behave_like`", :replacement => "`it_behaves_like`")
+      end
 
       # Includes shared content mapped to `name` directly in the group in which
       # it is declared, as opposed to `it_behaves_like`, which creates a nested
@@ -517,6 +521,9 @@ module RSpec
       # @private
       def self.ensure_example_groups_are_configured
         unless defined?(@@example_groups_configured)
+          unless RSpec.configuration.disable_monkey_patching
+            RSpec.deprecate("Monkey-patching mode", :call_site => nil)
+          end
           RSpec.configuration.configure_mock_framework
           RSpec.configuration.configure_expectation_framework
           # rubocop:disable Style/ClassVars

--- a/lib/rspec/core/filter_manager.rb
+++ b/lib/rspec/core/filter_manager.rb
@@ -89,6 +89,15 @@ module RSpec
       def prune_conditionally_filtered_examples(examples)
         examples.reject do |ex|
           meta = ex.metadata
+          if meta.key?(:if)
+            RSpec.deprecate("`:if` metadata will have no special meaning in RSpec 4 and",
+                            :replacement => "`:skip` with a negated condition",
+                            :call_site => meta[:location])
+          end
+          if meta.key?(:unless)
+            RSpec.deprecate("`:unless` metadata will have no special meaning in RSpec 4 and",
+                            :replacement => "`:skip`")
+          end
           !meta.fetch(:if, true) || meta[:unless]
         end
       end

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -78,6 +78,7 @@ module RSpec
       # @note If you are using RSpec's newer expect-based syntax you may
       #       want to use `is_expected.to` instead of `should`.
       def should(matcher=nil, message=nil)
+        RSpec.deprecate("Monkey-patching `should`", :replacement => "RSpec Expectations' `is_expected.to`")
         enforce_value_expectation(matcher, 'should')
         RSpec::Expectations::PositiveExpectationHandler.handle_matcher(subject, matcher, message)
       end
@@ -98,6 +99,7 @@ module RSpec
       # @note If you are using RSpec's newer expect-based syntax you may
       #       want to use `is_expected.to_not` instead of `should_not`.
       def should_not(matcher=nil, message=nil)
+        RSpec.deprecate("Monkey-patching `should_not`", :replacement => "RSpec Expectations' `is_expected.not_to`")
         enforce_value_expectation(matcher, 'should_not')
         RSpec::Expectations::NegativeExpectationHandler.handle_matcher(subject, matcher, message)
       end

--- a/spec/integration/bisect_runners_spec.rb
+++ b/spec/integration/bisect_runners_spec.rb
@@ -53,8 +53,7 @@ module RSpec::Core
     it 'honors `run_all_when_everything_filtered`' do
       write_file 'spec/a_spec.rb', "
         RSpec.configure do |c|
-          c.filter_run :focus
-          c.run_all_when_everything_filtered = true
+          c.filter_run_when_matching :focus
         end
 
         RSpec.describe 'A group' do

--- a/spec/integration/bisect_runners_spec.rb
+++ b/spec/integration/bisect_runners_spec.rb
@@ -98,7 +98,7 @@ module RSpec::Core
     include_examples 'a bisect runner'
   end
 
-  RSpec.describe Bisect::ForkRunner, :if => RSpec::Support::RubyFeatures.fork_supported? do
+  RSpec.describe Bisect::ForkRunner, :skip => !RSpec::Support::RubyFeatures.fork_supported? do
     include_examples 'a bisect runner'
 
     context 'when a `--require` option has been provided' do

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -38,7 +38,7 @@ module RSpec::Core
         expect(output).to include("No failures found.")
       end
 
-      it 'does not leave zombie processes', :unless => RSpec::Support::OS.windows? do
+      it 'does not leave zombie processes', :skip => RSpec::Support::OS.windows? do
         bisect(['--format', 'json', 'spec/rspec/core/resources/blocking_pipe_bisect_spec.rb_'], 1)
 
         zombie_process = RSpecChildProcess.new(Process.pid).zombie_process

--- a/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/spec/rspec/core/backtrace_formatter_spec.rb
@@ -21,7 +21,7 @@ module RSpec::Core
         expect(make_backtrace_formatter.exclude?("exe/rspec")).to be true
       end
 
-      it "excludes java files (for JRuby)", :if => (RUBY_PLATFORM == 'java')  do
+      it "excludes java files (for JRuby)", :skip => RUBY_PLATFORM != 'java'  do
         expect(make_backtrace_formatter.exclude?("org/jruby/RubyArray.java:2336")).to be true
       end
 
@@ -172,7 +172,7 @@ module RSpec::Core
       end
 
       context "when rspec is installed in the current working directory" do
-        it "excludes lines from rspec libs by default", :unless => RSpec::Support::OS.windows? do
+        it "excludes lines from rspec libs by default", :skip => RSpec::Support::OS.windows? do
           backtrace = [
             "#{Dir.getwd}/.bundle/path/to/rspec-expectations/lib/rspec/expectations/foo.rb:37",
             "#{Dir.getwd}/.bundle/path/to/rspec-expectations/lib/rspec/matchers/foo.rb:37",

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
 
   # On Ruby 2.4, `File.expand("~")` works even if `ENV['HOME']` is not set.
   # But on earlier versions, it fails.
-  it "warns when HOME env var is not set", :unless => (RUBY_PLATFORM == 'java' || RSpec::Support::OS.windows? || RUBY_VERSION >= '2.4') do
+  it "warns when HOME env var is not set", :skip => (RUBY_PLATFORM == 'java' || RSpec::Support::OS.windows? || RUBY_VERSION >= '2.4') do
     without_env_vars 'HOME' do
       expect_warning_with_call_site(__FILE__, __LINE__ + 1)
       RSpec::Core::ConfigurationOptions.new([]).options

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -611,12 +611,12 @@ module RSpec::Core
           expect(config.files_to_run).to contain_files("spec/rspec/core/resources/a_spec.rb", "spec/rspec/core/resources/acceptance/foo_spec.rb")
         end
 
-        it "loads files in Windows", :if => RSpec::Support::OS.windows? do
+        it "loads files in Windows", :skip => !RSpec::Support::OS.windows? do
           assign_files_or_directories_to_run "C:\\path\\to\\project\\spec\\sub\\foo_spec.rb"
           expect(config.files_to_run).to contain_files("C:/path/to/project/spec/sub/foo_spec.rb")
         end
 
-        it "loads files in Windows when directory is specified", :failing_on_windows_ci, :if => RSpec::Support::OS.windows? do
+        it "loads files in Windows when directory is specified", :failing_on_windows_ci, :skip => !RSpec::Support::OS.windows? do
           assign_files_or_directories_to_run "spec\\rspec\\core\\resources"
           expect(config.files_to_run).to contain_files("spec/rspec/core/resources/a_spec.rb")
         end
@@ -1233,7 +1233,7 @@ module RSpec::Core
       end
     end
 
-    describe "#prepend", :if => RSpec::Support::RubyFeatures.module_prepends_supported? do
+    describe "#prepend", :skip => !RSpec::Support::RubyFeatures.module_prepends_supported? do
       include_examples "warning of deprecated `:example_group` during filtering configuration", :prepend, Enumerable
 
       module SomeRandomMod
@@ -2337,7 +2337,7 @@ module RSpec::Core
       end
 
       it "doesn't prepend a module when already present in ancestor chain",
-        :if => RSpec::Support::RubyFeatures.module_prepends_supported? do
+        :skip => !RSpec::Support::RubyFeatures.module_prepends_supported? do
         config.prepend(IncludeExtendOrPrependMeOnce, :foo => :bar)
 
         group = RSpec.describe("group", :foo => :bar)

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1306,6 +1306,18 @@ module RSpec::Core
         config.run_all_when_everything_filtered = true
         expect(config.run_all_when_everything_filtered?).to be(true)
       end
+
+      it "emits a deprecation message when set" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /run_all_when_everything_filtered/)
+        config.run_all_when_everything_filtered = true
+      end
+    end
+
+    describe "#tty=" do
+      it "emits a deprecation message when set" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /tty/)
+        config.tty = true
+      end
     end
 
     describe "#color_mode" do
@@ -1399,6 +1411,11 @@ module RSpec::Core
 
     describe "#color=" do
       before { config.color_mode = :automatic }
+
+      it "emits a deprecation message when set" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /color/)
+        config.color = true
+      end
 
       context "given false" do
         before { config.color = false }
@@ -2369,6 +2386,13 @@ module RSpec::Core
         end
       end
 
+      describe '#alias_it_should_behave_like_to' do
+        it "emits a deprecation message when used" do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /alias_it_should_behave_like_to/)
+          config.alias_it_should_behave_like_to :it_should_have_behaved_like
+        end
+      end
+
       it_behaves_like "metadata hash builder" do
         def metadata_hash(*args)
           config.alias_example_group_to :my_group_method, *args
@@ -2903,6 +2927,16 @@ module RSpec::Core
           "shared_context_metadata_behavior",
           ":another_value", ":trigger_inclusion", ":apply_to_host_groups"
         ))
+      end
+
+      it "emits a deprecation message when set to :trigger_inclusion" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /shared_context_metadata_behavior/)
+        config.shared_context_metadata_behavior = :trigger_inclusion
+      end
+
+      it "does not emit a deprecation message when set to :apply_to_host_groups" do
+        expect_no_deprecation
+        config.shared_context_metadata_behavior = :apply_to_host_groups
       end
     end
 

--- a/spec/rspec/core/did_you_mean_spec.rb
+++ b/spec/rspec/core/did_you_mean_spec.rb
@@ -23,7 +23,7 @@ module RSpec
             end
           end
         end
-        context "when `DidYouMean::SpellChecker` is not available", :unless => defined?(::DidYouMean::SpellChecker) do
+        context "when `DidYouMean::SpellChecker` is not available", :skip => defined?(::DidYouMean::SpellChecker) do
           describe 'Success' do
             let(:name) { './spec/rspec/core/did_you_mean_spec.rb' }
             it 'returns a hint' do

--- a/spec/rspec/core/drb_spec.rb
+++ b/spec/rspec/core/drb_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec/core/drb'
 
-RSpec.describe RSpec::Core::DRbRunner, :isolated_directory => true, :isolated_home => true, :type => :drb, :unless => RUBY_PLATFORM == 'java' do
+RSpec.describe RSpec::Core::DRbRunner, :isolated_directory => true, :isolated_home => true, :type => :drb, :skip => RUBY_PLATFORM == 'java' do
   let(:config) { RSpec::Core::Configuration.new }
   let(:out)    { StringIO.new }
   let(:err)    { StringIO.new }

--- a/spec/rspec/core/dsl_spec.rb
+++ b/spec/rspec/core/dsl_spec.rb
@@ -27,6 +27,21 @@ RSpec.describe "The RSpec DSL" do
           expect(Object.new).not_to respond_to(*method_names)
         end
       end
+
+      it 'emits a deprecation warning' do
+        in_sub_process do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 6, /Globally-exposed DSL \(`describe`\)/)
+          changing_expose_dsl_globally do
+            RSpec.configuration.expose_dsl_globally = true
+            expect(RSpec.configuration.expose_dsl_globally?).to eq true
+
+            Module.new do
+              describe 'monkey' do
+              end
+            end
+          end
+        end
+      end
     end
 
     context "when expose_dsl_globally is disabled" do

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -140,7 +140,7 @@ module RSpec::Core
         expect(child).to have_class_const("SomeParentGroup::Hash")
       end
 
-      it 'disambiguates name collisions by appending a number', :unless => RUBY_VERSION == '1.9.2' do
+      it 'disambiguates name collisions by appending a number', :skip => RUBY_VERSION == '1.9.2' do
         groups = 10.times.map { RSpec.describe("Collision") }
         expect(groups[0]).to have_class_const("Collision")
         expect(groups[1]).to have_class_const("Collision_2")
@@ -178,7 +178,7 @@ module RSpec::Core
         )
       end
 
-      it 'does not have problems with example groups named "Core"', :unless => RUBY_VERSION == '1.9.2' do
+      it 'does not have problems with example groups named "Core"', :skip => RUBY_VERSION == '1.9.2' do
         RSpec.describe("Core")
         expect(defined?(::RSpec::ExampleGroups::Core)).to be
 
@@ -188,7 +188,7 @@ module RSpec::Core
         expect(group).to have_class_const("AnotherGroup")
       end
 
-      it 'does not have problems with example groups named "RSpec"', :unless => RUBY_VERSION == '1.9.2' do
+      it 'does not have problems with example groups named "RSpec"', :skip => RUBY_VERSION == '1.9.2' do
         RSpec.describe("RSpec")
         expect(defined?(::RSpec::ExampleGroups::RSpec)).to be
 
@@ -1919,7 +1919,7 @@ module RSpec::Core
       }.to raise_error(/not allowed/)
     end
 
-    describe 'inspect output', :unless => RUBY_VERSION == '1.9.2' do
+    describe 'inspect output', :skip => RUBY_VERSION == '1.9.2' do
       context 'when there is no inspect output provided' do
         it "uses '(no description provided)' instead" do
           expect(ExampleGroup.new.inspect).to eq('#<RSpec::Core::ExampleGroup (no description provided)>')

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1883,6 +1883,14 @@ module RSpec::Core
           end
         }.to raise_error("boom").and avoid_changing(RSpec::Support, :thread_local_data)
       end
+
+      it "emits a deprecation warning when used" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 3, /it_should_behave_like/)
+        RSpec.describe do
+          shared_examples_for("stuff") { }
+          it_should_behave_like "stuff"
+        end
+      end
     end
 
     it 'minimizes the number of methods that users could inadvertantly overwrite' do

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       example = RSpec.describe.example
       expect(example.rerun_argument).to eq("#{RSpec::Core::Metadata.relative_path(__FILE__)}:#{__LINE__ - 1}")
     end
+
+    it "emits a deprecation warning when used" do
+      example = RSpec.describe.example
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /rerun_argument/)
+      example.rerun_argument
+    end
   end
 
   describe "#update_inherited_metadata" do

--- a/spec/rspec/core/example_spec.rb
+++ b/spec/rspec/core/example_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
         expect(get_all.call).to eq opts.fetch(:post_gc)
       end
 
-      it 'releases references to the examples / their ivars', :if => reliable_gc do
+      it 'releases references to the examples / their ivars', :skip => !reliable_gc do
         config        = RSpec::Core::Configuration.new
         real_reporter = RSpec::Core::Reporter.new(config) # in case it is the cause of a leak
         garbage       = Struct.new :defined_in
@@ -505,7 +505,7 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       end
     end
 
-    it "leaves raised exceptions unmodified (GH-1103)", :if => RUBY_VERSION < '2.5' do
+    it "leaves raised exceptions unmodified (GH-1103)", :skip => RUBY_VERSION >= '2.5' do
       # set the backtrace, otherwise MRI will build a whole new object,
       # and thus mess with our expectations. Rubinius and JRuby are not
       # affected.

--- a/spec/rspec/core/formatters/deprecation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/deprecation_formatter_spec.rb
@@ -111,7 +111,7 @@ module RSpec::Core::Formatters
           expect(File.read(deprecation_stream.path)).to eq("foo is deprecated.\n#{DeprecationFormatter::RAISE_ERROR_CONFIG_NOTICE}")
         end
 
-        it "can handle when the stream is reopened to a system stream", :unless => RSpec::Support::OS.windows? do
+        it "can handle when the stream is reopened to a system stream", :skip => RSpec::Support::OS.windows? do
           send_notification :deprecation, notification(:deprecated => 'foo')
           deprecation_stream.reopen(IO.for_fd(IO.sysopen('/dev/null', "w+")))
           send_notification :deprecation_summary, null_notification

--- a/spec/rspec/core/formatters/documentation_formatter_spec.rb
+++ b/spec/rspec/core/formatters/documentation_formatter_spec.rb
@@ -130,7 +130,7 @@ root
     end
 
     # The backtrace is slightly different on JRuby/Rubinius so we skip there.
-    it 'produces the expected full output', :if => RSpec::Support::Ruby.mri? do
+    it 'produces the expected full output', :skip => !RSpec::Support::Ruby.mri? do
       output = run_example_specs_with_formatter("doc")
       output.gsub!(/ +$/, '') # strip trailing whitespace
 

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -183,7 +183,7 @@ module RSpec::Core
       caused_by_line_num = __LINE__ + 1
       let(:first_exception) { FakeException.new("Real\nculprit", ["#{__FILE__}:#{__LINE__}"]) }
 
-      it 'includes the first exception that caused the failure', :if => RSpec::Support::RubyFeatures.supports_exception_cause? do
+      it 'includes the first exception that caused the failure', :skip => !RSpec::Support::RubyFeatures.supports_exception_cause? do
         the_presenter = Formatters::ExceptionPresenter.new(the_exception, example)
 
         expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
@@ -202,7 +202,7 @@ module RSpec::Core
         EOS
       end
 
-      context "when the first exception doesn't have a backgrace" do
+      context "when the first exception doesn't have a backtrace" do
         let(:first_exception) { FakeException.new("Real\nculprit", backtrace) }
 
         shared_examples 'expected result for the case when there is no backtrace' do
@@ -258,7 +258,7 @@ module RSpec::Core
         EOS
       end
 
-      it 'wont produce a stack error when the cause is an older exception', :if => RSpec::Support::RubyFeatures.supports_exception_cause? do
+      it 'wont produce a stack error when the cause is an older exception', :skip => !RSpec::Support::RubyFeatures.supports_exception_cause? do
         allow(the_exception).to receive(:cause) do
           FakeException.new("A loop", the_exception.backtrace, the_exception)
         end
@@ -280,7 +280,7 @@ module RSpec::Core
         EOS
       end
 
-      it 'will work when cause is incorrectly overridden', :if => RSpec::Support::RubyFeatures.supports_exception_cause? do
+      it 'will work when cause is incorrectly overridden', :skip => !RSpec::Support::RubyFeatures.supports_exception_cause? do
         incorrect_cause_exception = FakeException.new("A badly implemented exception", [], "An incorrect cause")
 
         the_presenter = Formatters::ExceptionPresenter.new(incorrect_cause_exception, example)
@@ -384,7 +384,7 @@ module RSpec::Core
           end
         end
 
-        context 'with multiline expression and single line RSpec exception message', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+        context 'with multiline expression and single line RSpec exception message', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
           let(:expression) do
             expect('RSpec').
               to be_a(Integer)
@@ -422,7 +422,7 @@ module RSpec::Core
           end
         end
 
-        context 'with multiline expression and multiline RSpec exception message', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+        context 'with multiline expression and multiline RSpec exception message', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
           let(:expression) do
             expect('RSpec').
               to be_falsey
@@ -463,7 +463,7 @@ module RSpec::Core
           end
         end
 
-        context 'with multiline expression and RSpec exception message starting with linefeed (like `eq` matcher)', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+        context 'with multiline expression and RSpec exception message starting with linefeed (like `eq` matcher)', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
           let(:expression) do
             expect('Rspec').
               to eq('RSpec')
@@ -504,7 +504,7 @@ module RSpec::Core
           end
         end
 
-        context 'with multiline expression and single line non-RSpec exception message', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+        context 'with multiline expression and single line non-RSpec exception message', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
           let(:expression) do
             expect { fail 'Something is wrong!' }.
               to change { RSpec }
@@ -532,7 +532,7 @@ module RSpec::Core
         presenter.send(:read_failed_lines)
       end
 
-      context 'when the failed expression spans multiple lines', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+      context 'when the failed expression spans multiple lines', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
         let(:exception) do
           begin
             expect('RSpec').to be_a(String).

--- a/spec/rspec/core/formatters/html_formatter_spec.rb
+++ b/spec/rspec/core/formatters/html_formatter_spec.rb
@@ -31,7 +31,7 @@ module RSpec
 
         # Uncomment this group temporarily in order to overwrite the expected
         # with actual.  Use with care!!!
-        describe "file generator", :if => ENV['GENERATE'] do
+        describe "file generator", :skip => !ENV['GENERATE'] do
           it "generates a new comparison file" do
             Dir.chdir(root) do
               File.open(expected_file, 'w') {|io| io.write(actual_html)}
@@ -46,7 +46,7 @@ module RSpec
             select  {|e| e =~ /formatter_specs\.rb/}
         end
 
-        describe 'produced HTML', :if => RUBY_VERSION <= '2.0.0' do
+        describe 'produced HTML', :skip => RUBY_VERSION > '2.0.0' do
           # Rubies before 2 are a wild west of different outputs, and it's not
           # worth the effort to maintain accurate fixtures for all of them.
           # Since we are verifying fixtures on other rubies, if this code at
@@ -57,7 +57,7 @@ module RSpec
           end
         end
 
-        describe 'produced HTML', :slow, :if => RUBY_VERSION >= '2.0.0' do
+        describe 'produced HTML', :slow, :skip => RUBY_VERSION < '2.0.0' do
           it "is identical to the one we designed manually", :pending => (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby') do
             expect(actual_html).to eq(expected_html)
           end

--- a/spec/rspec/core/formatters/profile_formatter_spec.rb
+++ b/spec/rspec/core/formatters/profile_formatter_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RSpec::Core::Formatters::ProfileFormatter do
         end)
       end
 
-      it_should_behave_like "profiles examples"
+      it_behaves_like "profiles examples"
 
       it "doesn't profile a single example group" do
         expect(formatter_output.string).not_to match(/slowest example groups/)
@@ -72,7 +72,7 @@ RSpec.describe RSpec::Core::Formatters::ProfileFormatter do
         profile group1, group2
       end
 
-      it_should_behave_like "profiles examples"
+      it_behaves_like "profiles examples"
 
       it "prints the slowest example groups" do
         expect(formatter_output.string).to match(/slowest example groups/)

--- a/spec/rspec/core/formatters/progress_formatter_spec.rb
+++ b/spec/rspec/core/formatters/progress_formatter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RSpec::Core::Formatters::ProgressFormatter do
   end
 
   # The backtrace is slightly different on JRuby/Rubinius so we skip there.
-  it 'produces the expected full output', :if => RSpec::Support::Ruby.mri? do
+  it 'produces the expected full output', :skip => !RSpec::Support::Ruby.mri? do
     output = run_example_specs_with_formatter("progress")
     output.gsub!(/ +$/, '') # strip trailing whitespace
 

--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -161,7 +161,7 @@ module RSpec::Core::Formatters
         end
       end
 
-      argument_error_points_invoker = RSpec::Support::Ruby.jruby? && !RUBY_VERSION.start_with?('1.8.')
+      argument_error_points_invoker = RSpec::Support::Ruby.jruby? || RUBY_VERSION.start_with?('1.8.')
       context 'when the expression is a method definition and ends with "end"-only line', :skip => argument_error_points_invoker do
         let(:source) do
           obj = Object.new

--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -90,7 +90,7 @@ module RSpec::Core::Formatters
       end
     end
 
-    context 'in Ripper supported environment', :if => RSpec::Support::RubyFeatures.ripper_supported? do
+    context 'in Ripper supported environment', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
       context 'when the expression spans multiple lines' do
         let(:source) do
           do_something_fail :foo,
@@ -162,7 +162,7 @@ module RSpec::Core::Formatters
       end
 
       argument_error_points_invoker = RSpec::Support::Ruby.jruby? && !RUBY_VERSION.start_with?('1.8.')
-      context 'when the expression is a method definition and ends with "end"-only line', :unless => argument_error_points_invoker do
+      context 'when the expression is a method definition and ends with "end"-only line', :skip => argument_error_points_invoker do
         let(:source) do
           obj = Object.new
 
@@ -351,7 +351,7 @@ module RSpec::Core::Formatters
       end
     end
 
-    context 'in Ripper unsupported environment', :unless => RSpec::Support::RubyFeatures.ripper_supported? do
+    context 'in Ripper unsupported environment', :skip => RSpec::Support::RubyFeatures.ripper_supported? do
       context 'when the expression spans multiple lines' do
         let(:source) do
           do_something_fail :foo,

--- a/spec/rspec/core/formatters/syntax_highlighter_spec.rb
+++ b/spec/rspec/core/formatters/syntax_highlighter_spec.rb
@@ -5,7 +5,7 @@ module RSpec::Core::Formatters
     let(:config)      { RSpec::Core::Configuration.new.tap { |config| config.color_mode = :on } }
     let(:highlighter) { SyntaxHighlighter.new(config)  }
 
-    context "when CodeRay is available", :unless => RSpec::Support::OS.windows? do
+    context "when CodeRay is available", :skip => RSpec::Support::OS.windows? do
       before { expect { require 'coderay' }.not_to raise_error }
 
       it 'highlights the syntax of the provided lines' do

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -660,11 +660,13 @@ module RSpec::Core
     subject { 'value or a Proc' }
 
     it '`should` prints a deprecation warning when given a value' do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 2, /Monkey-patching `should`/)
       expect_warn_deprecation(/The implicit block expectation syntax is deprecated, you should pass/)
       expect { should block_matcher }.not_to raise_error
     end
 
     it '`should_not` prints a deprecation warning when given a value' do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 2, /Monkey-patching `should_not`/)
       expect_warn_deprecation(/The implicit block expectation syntax is deprecated, you should pass/)
       expect { should_not block_matcher }.to raise_error(Exception)
     end

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -633,17 +633,17 @@ module RSpec::Core
 
     describe Object do
       context 'with implicit subject' do
-        it_should_behave_like 'a subject'
+        it_behaves_like 'a subject'
       end
 
       context 'with explicit subject' do
         subject { Object.new }
-        it_should_behave_like 'a subject'
+        it_behaves_like 'a subject'
       end
 
       context 'with a constant subject'do
         subject { 123 }
-        it_should_behave_like 'a subject'
+        it_behaves_like 'a subject'
       end
     end
   end

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -671,10 +671,9 @@ module RSpec::Core
   end
 
   RSpec.describe 'Module#define_method' do
-    it 'retains its normal private visibility on Ruby versions where it is normally private', :if => RUBY_VERSION < '2.5' do
+    it 'retains its normal private visibility on Ruby versions where it is normally private', :skip => RUBY_VERSION >= '2.5' do
       a_module = Module.new
       expect { a_module.define_method(:name) { "implementation" } }.to raise_error NoMethodError
     end
   end
 end
-

--- a/spec/rspec/core/rake_task_spec.rb
+++ b/spec/rspec/core/rake_task_spec.rb
@@ -40,14 +40,14 @@ module RSpec::Core
       end
     end
 
-    context "with space", :unless => RSpec::Support::OS.windows? do
+    context "with space", :skip => RSpec::Support::OS.windows? do
       it "renders rspec with space escaped" do
         task.rspec_path = '/path with space/exe/rspec'
         expect(spec_command).to match(/^#{ruby} #{default_load_path_opts} \/path\\ with\\ space\/exe\/rspec/)
       end
     end
 
-    context "on windows, with a quote in the name", :if => RSpec::Support::OS.windows? do
+    context "on windows, with a quote in the name", :skip => !RSpec::Support::OS.windows? do
       it "renders rspec quoted, with quote escaped" do
         task.rspec_path = "/foo'bar/exe/rspec"
         expect(spec_command).to include(%q|'/foo\'bar/exe/rspec'|)
@@ -92,7 +92,7 @@ module RSpec::Core
         expect(spec_command).to match(/ --pattern '?complex_pattern'?/)
       end
 
-      it "shellescapes the pattern as necessary", :unless => RSpec::Support::OS.windows? do
+      it "shellescapes the pattern as necessary", :skip => RSpec::Support::OS.windows? do
         task.pattern = "foo'bar"
         expect(spec_command).to include(" --pattern foo\\'bar")
       end
@@ -160,7 +160,7 @@ module RSpec::Core
     end
 
     context "with_clean_environment is set" do
-      it "removes the environment variables", :if => RUBY_VERSION >= '1.9.0', :unless => RSpec::Support::Ruby.jruby? do
+      it "removes the environment variables", :skip => (RUBY_VERSION < '1.9.0' || RSpec::Support::Ruby.jruby?) do
         with_env_vars 'MY_ENV' => 'ABC' do
           if RSpec::Support::OS.windows?
             essential_shell_variables = /\["ANSICON", "ANSICON_DEF", "HOME", "TMPDIR", "USER"\]/
@@ -417,7 +417,7 @@ module RSpec::Core
         make_files_in_dir "acceptance"
       end
 
-      it "shellescapes the pattern as necessary", :unless => RSpec::Support::OS.windows? do
+      it "shellescapes the pattern as necessary", :skip => RSpec::Support::OS.windows? do
         task.exclude_pattern = "foo'bar"
         expect(spec_command).to include(" --exclude-pattern foo\\'bar")
       end

--- a/spec/rspec/core/shared_example_group_spec.rb
+++ b/spec/rspec/core/shared_example_group_spec.rb
@@ -122,12 +122,12 @@ module RSpec
             end
           end
 
-          it "displays a warning when adding an example group without a block", :unless => RUBY_VERSION == '1.8.7' do
+          it "displays a warning when adding an example group without a block", :skip => RUBY_VERSION == '1.8.7' do
             expect_warning_with_call_site(__FILE__, __LINE__ + 1)
             group.send(shared_method_name, 'name but no block')
           end
 
-          it "displays a warning when adding an example group without a block", :if => RUBY_VERSION == '1.8.7' do
+          it "displays a warning when adding an example group without a block", :skip => RUBY_VERSION != '1.8.7' do
             # In 1.8.7 this spec breaks unless we run it isolated like this
             in_sub_process do
               expect_warning_with_call_site(__FILE__, __LINE__ + 1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,7 +81,6 @@ RSpec.configure do |c|
 
   # runtime options
   c.raise_errors_for_deprecations!
-  c.color = true
   c.include CommonHelpers
 
   c.expect_with :rspec do |expectations|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,7 +80,10 @@ RSpec.configure do |c|
   c.disable_monkey_patching!
 
   # runtime options
-  c.raise_errors_for_deprecations!
+
+  # Temporary measure to prevent failures when run in a sub-build from other repos
+  # c.raise_errors_for_deprecations!
+
   c.include CommonHelpers
 
   c.expect_with :rspec do |expectations|

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -35,8 +35,6 @@ RSpec.shared_context "aruba support" do
   attr_reader :last_cmd_stdout, :last_cmd_stderr, :last_cmd_exit_status
 
   def run_command(cmd)
-    RSpec.configuration.color = true
-
     temp_stdout = StringIO.new
     temp_stderr = StringIO.new
 
@@ -51,7 +49,6 @@ RSpec.shared_context "aruba support" do
     end
   ensure
     RSpec.reset
-    RSpec.configuration.color = true
 
     # Ensure it gets cached with a proper value -- if we leave it set to nil,
     # and the next spec operates in a different dir, it could get set to an


### PR DESCRIPTION
A few things are a bit off, e.g.:
 - no deprecation for multi-condition filtering usages 🤷 
 - no specs for `:if`/`:unless` deprecation usages
 - had to *flip* the `unless` condition in `snippet_extractor_spec.rb` to skip it on Ruby 1.8 builds. Puzzled to understand how `:unless => RSpec::Support::Ruby.jruby? && !RUBY_VERSION.start_with?('1.8.')` was working ([example failure](https://github.com/rspec/rspec-core/runs/2110374357))
 - should we add deprecation warnings when running on rbx/ree/Ruby < 2.3?

This is purposed to be released as version 3.99.
Sibling PRs:
 - https://github.com/rspec/rspec-mocks/pull/1418
 - https://github.com/rspec/rspec-expectations/pull/1301

Release strategy: https://github.com/rspec/rspec-core/pull/2880#issuecomment-797756681
RSpec 4 plan: https://github.com/rspec/rspec/issues/61
Changes: https://github.com/rspec/rspec-core/blob/4-0-dev/Changelog.md#development

## TODO

 - [ ] merge this PR, then `rspec-expectations` PR, then `rspec-mocks` PR
 - [ ] revert [this](https://github.com/rspec/rspec-core/pull/2880/files#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94R84) `spec/spec_helper.rb` change