### PR TITLE
Filter content of /usr/share/ruby

### DIFF
--- a/lib/rspec/core/backtrace_formatter.rb
+++ b/lib/rspec/core/backtrace_formatter.rb
@@ -8,7 +8,7 @@ module RSpec
       def initialize
         @full_backtrace = false
 
-        patterns = %w[ /lib\d*/ruby/ bin/ exe/rspec /lib/bundler/ /exe/bundle: ]
+        patterns = %w[ /lib\d*/ruby/ /share/ruby/ bin/ exe/rspec /lib/bundler/ /exe/bundle: ]
         patterns << "org/jruby/" if RUBY_PLATFORM == 'java'
         patterns.map! { |s| Regexp.new(s.gsub("/", File::SEPARATOR)) }
 


### PR DESCRIPTION
Some Linux distributions, such as Fedora, are using this location to store Ruby StdLib. Therefore, it would be nice to filter this location similarly to `/lib\d*/ruby/`