### PR TITLE
Remove support for older RR test double framework versions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,7 @@ Breaking Changes:
 * Raise on attempt to use a legacy formatter without `rspec-legacy_formatters`.
   (Phil Pirozhkov, #2864)
 * Unify multi-condition filtering to use "all" semantic. (Phil Pirozhkov, #2874)
+* Remove support for RR test double framework version < 3.0. (Phil Pirozhkov, #2884)
 
 Enhancements:
 

--- a/lib/rspec/core/mocking_adapters/rr.rb
+++ b/lib/rspec/core/mocking_adapters/rr.rb
@@ -12,7 +12,7 @@ module RSpec
           :rr
         end
 
-        include ::RR::Extensions::InstanceMethods
+        include ::RR::DSL
 
         def setup_mocks_for_rspec
           ::RR::Space.instance.reset

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "coderay",  "~> 1.1.1"
 
   s.add_development_dependency "mocha",        "~> 0.13.0"
-  s.add_development_dependency "rr",           "~> 1.0.4"
+  s.add_development_dependency "rr",           "~> 3.0.0"
   s.add_development_dependency "flexmock",     "~> 0.9.0"
   s.add_development_dependency "thread_order", "~> 1.1.0"
 

--- a/spec/support/fake_libs/rr.rb
+++ b/spec/support/fake_libs/rr.rb
@@ -3,8 +3,6 @@ module RR
     BACKTRACE_IDENTIFIER = /doesn't matter/
   end
 
-  module Extensions
-    module InstanceMethods
-    end
+  module DSL
   end
 end


### PR DESCRIPTION
This is due to this rearrangement: https://github.com/rr/rr/commit/65a29643515575bbde9686c5ccade87f7b2a73df#diff-6aad5729c760c1d242cb39250fe9c9e57a15753e3a347a8413520b3415454e42R56

fixes #2882
see https://github.com/rr/rr/issues/65