### PR TITLE
Extend reserved name check

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Enhancements:
 
 * Improve pluralisation of words ending with `s` (like process). (Joshua Pinter, #2779)
 * Add ordering by file modification time (most recent first). (Matheus Richard, #2778)
+* Extend reserved memoized helper name checking for #let and #subject. (Nick Flückiger, #2886)
 
 Bug fixes:
 

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -308,18 +308,12 @@ EOS
           # allow it to use method constructs like `super` and `return`.
           raise "#let or #subject called without a block" if block.nil?
 
-          # A list of reserved names that may not be used inside #let or #subject
+          # A list of reserved words that can't be used as a name for a memoized helper
           # Matches for both symbols and passed strings
-          reserved_helper_names = [:initialize, :to_s]
-          matching_reserved_name = reserved_helper_names.find do | reserved_name |
-            reserved_name == name || reserved_name.to_s == name
+          if [:initialize, :to_s].include?(name.to_sym)
+            raise ArgumentError, "#let or #subject called with reserved name `#{name}`"
           end
 
-          unless matching_reserved_name.nil?
-            raise(
-              "#let or #subject called with reserved name ##{matching_reserved_name}"
-            )
-          end
           our_module = MemoizedHelpers.module_for(self)
 
           # If we have a module clash in our helper module

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -317,7 +317,7 @@ EOS
 
           unless matching_reserved_name.nil?
             raise(
-              "#let or #subject called with reserved name ##{matching_reserved_name.to_s}"
+              "#let or #subject called with reserved name ##{matching_reserved_name}"
             )
           end
           our_module = MemoizedHelpers.module_for(self)

--- a/lib/rspec/core/memoized_helpers.rb
+++ b/lib/rspec/core/memoized_helpers.rb
@@ -307,9 +307,19 @@ EOS
           # We have to pass the block directly to `define_method` to
           # allow it to use method constructs like `super` and `return`.
           raise "#let or #subject called without a block" if block.nil?
-          raise(
-            "#let or #subject called with a reserved name #initialize"
-          ) if :initialize == name
+
+          # A list of reserved names that may not be used inside #let or #subject
+          # Matches for both symbols and passed strings
+          reserved_helper_names = [:initialize, :to_s]
+          matching_reserved_name = reserved_helper_names.find do | reserved_name |
+            reserved_name == name || reserved_name.to_s == name
+          end
+
+          unless matching_reserved_name.nil?
+            raise(
+              "#let or #subject called with reserved name ##{matching_reserved_name.to_s}"
+            )
+          end
           our_module = MemoizedHelpers.module_for(self)
 
           # If we have a module clash in our helper module

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -520,11 +520,38 @@ module RSpec::Core
       end.to raise_error(/#let or #subject called without a block/)
     end
 
-    it 'raises an error when attempting to define a reserved method name' do
-      expect do
-        RSpec.describe { let(:initialize) { true }}
-      end.to raise_error(/#let or #subject called with a reserved name #initialize/)
+    context 'when defining a reserved name' do
+      context 'when name is initialize' do
+
+        it 'raises an error when attempting to define a reserved name #initialize' do
+          expect do
+            RSpec.describe { let(:initialize) { true }}
+          end.to raise_error(/#let or #subject called with reserved name #initialize/)
+        end
+
+        it 'raises an error when attempting to define a reserved name #initialize as a string' do
+          expect do
+            RSpec.describe { let('initialize') { true }}
+          end.to raise_error(/#let or #subject called with reserved name #initialize/)
+        end
+      end
+
+      context 'when name is to_s' do
+        it 'raises an error when attempting to define a reserved name #to_s' do
+          expect do
+            RSpec.describe { let(:to_s) { true }}
+          end.to raise_error(/#let or #subject called with reserved name #to_s/)
+        end
+
+        it 'raises an error when attempting to define a reserved name #to_s as a string' do
+          expect do
+            RSpec.describe { let('to_s') { true }}
+          end.to raise_error(/#let or #subject called with reserved name #to_s/)
+        end
+      end
     end
+
+
 
     let(:a_value) { "a string" }
 

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -520,35 +520,28 @@ module RSpec::Core
       end.to raise_error(/#let or #subject called without a block/)
     end
 
-    context 'when defining a reserved name' do
-      context 'when name is initialize' do
+    it 'raises an error when attempting to define a reserved name #initialize' do
+      expect do
+        RSpec.describe { let(:initialize) { true } }
+      end.to raise_error(/#let or #subject called with reserved name `initialize`/)
+    end
 
-        it 'raises an error when attempting to define a reserved name #initialize' do
-          expect do
-            RSpec.describe { let(:initialize) { true }}
-          end.to raise_error(/#let or #subject called with reserved name #initialize/)
-        end
+    it 'raises an error when attempting to define a reserved name #initialize as a string' do
+      expect do
+        RSpec.describe { let('initialize') { true } }
+      end.to raise_error(/#let or #subject called with reserved name `initialize`/)
+    end
 
-        it 'raises an error when attempting to define a reserved name #initialize as a string' do
-          expect do
-            RSpec.describe { let('initialize') { true }}
-          end.to raise_error(/#let or #subject called with reserved name #initialize/)
-        end
-      end
+    it 'raises an error when attempting to define a reserved name #to_s' do
+      expect do
+        RSpec.describe { let(:to_s) { true } }
+      end.to raise_error(/#let or #subject called with reserved name `to_s`/)
+    end
 
-      context 'when name is to_s' do
-        it 'raises an error when attempting to define a reserved name #to_s' do
-          expect do
-            RSpec.describe { let(:to_s) { true }}
-          end.to raise_error(/#let or #subject called with reserved name #to_s/)
-        end
-
-        it 'raises an error when attempting to define a reserved name #to_s as a string' do
-          expect do
-            RSpec.describe { let('to_s') { true }}
-          end.to raise_error(/#let or #subject called with reserved name #to_s/)
-        end
-      end
+    it 'raises an error when attempting to define a reserved name #to_s as a string' do
+      expect do
+        RSpec.describe { let('to_s') { true } }
+      end.to raise_error(/#let or #subject called with reserved name `to_s`/)
     end
 
 

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -544,8 +544,6 @@ module RSpec::Core
       end.to raise_error(/#let or #subject called with reserved name `to_s`/)
     end
 
-
-
     let(:a_value) { "a string" }
 
     context 'when overriding let in a nested context' do


### PR DESCRIPTION
# Description

Fixes https://github.com/rspec/rspec-rails/issues/2478
`to_s` is now also viewed as a reserved name and thus may not be used.
This also extends the name check to check against strings rather than just symbols.