### PR TITLE
Bring formatters_spec in line with changes to formatters

### DIFF
--- a/spec/rspec/core/formatters_spec.rb
+++ b/spec/rspec/core/formatters_spec.rb
@@ -77,6 +77,7 @@ module RSpec::Core::Formatters
 
       context "when a legacy formatter is added without RSpec::LegacyFormatters" do
         formatter_class = Struct.new(:output)
+        reserved = %w(. ( ) )
 
         before do
           allow_deprecation
@@ -84,7 +85,7 @@ module RSpec::Core::Formatters
 
         it "issues a deprecation" do
           expect_warn_deprecation(
-            /The #{formatter_class} formatter uses the deprecated formatter interface.+#{__FILE__}:#{__LINE__ + 1}/)
+            /The #{formatter_class} formatter uses the deprecated formatter interface not supported directly by RSpec 3\.  To continue to use this formatter you must install the `rspec-legacy_formatters` gem, which provides support for legacy formatters or upgrade the formatter to a compatible version\.  Formatter added at: #{::RSpec::CallerFilter.first_non_rspec_line.gsub(/:\d+:/) { |text| ":#{text[/\d+/].succ}:" }.gsub(/\W/) { |char| reserved.include?(char) ? "\\#{char}" : char }}/)
           loader.add formatter_class, output
         end
       end


### PR DESCRIPTION
Back in [2014](https://github.com/rspec/rspec-core/commit/b8440af70ae1dfacdbec9518c89e5cc839c2a4f8), the legacy formatter deprecation message was changed, but that change was never carried over to the spec file.

This PR is mostly driven by [another PR](https://github.com/ruby-formatter/rufo/pull/256), which has one test failing.