### PR TITLE
Add SnippetExtractor spec examples for end-less methods support

### DIFF
--- a/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -1,6 +1,5 @@
 require 'rspec/core/formatters/snippet_extractor'
 require 'support/helper_methods'
-require 'tempfile'
 
 module RSpec::Core::Formatters
   RSpec.describe SnippetExtractor do
@@ -188,6 +187,11 @@ module RSpec::Core::Formatters
 
       context 'when the expression line includes an "end"-less method definition', :if => RUBY_VERSION.to_f >= 3.0 do
         include RSpec::Support::InSubProcess
+
+        around(:example) do |example|
+          require 'tempfile'
+          example.call
+        end
 
         let(:source) do
           in_sub_process do

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -1,3 +1,5 @@
+require 'support/helper_methods'
+
 if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version == "9.1.17.0"
   # A regression appeared in require_relative in JRuby 9.1.17.0 where require some
   # how ends up private, this monkey patch uses `send`
@@ -29,6 +31,7 @@ end
 
 RSpec.shared_context "aruba support" do
   include Aruba::Api
+  include RSpecHelpers
   let(:stderr) { StringIO.new }
   let(:stdout) { StringIO.new }
 
@@ -69,13 +72,6 @@ RSpec.shared_context "aruba support" do
     # strip extra indentation.
     formatted_contents = unindent(contents.sub(/\A\n/, ""))
     write_file file_name, formatted_contents
-  end
-
-  # Intended for use with indented heredocs.
-  # taken from Ruby Tapas:
-  # https://rubytapas.dpdcart.com/subscriber/post?id=616#files
-  def unindent(s)
-    s.gsub(/^#{s.scan(/^[ \t]+(?=\S)/).min}/, "")
   end
 end
 

--- a/spec/support/helper_methods.rb
+++ b/spec/support/helper_methods.rb
@@ -14,6 +14,13 @@ module RSpecHelpers
     result
   end
 
+  # Intended for use with indented heredocs.
+  # taken from Ruby Tapas:
+  # https://rubytapas.dpdcart.com/subscriber/post?id=616#files
+  def unindent(s)
+    s.gsub(/^#{s.scan(/^[ \t]+(?=\S)/).min}/, "")
+  end
+
   # In Ruby 2.7 taint was removed and has no effect, whilst SAFE warns that it
   # has no effect and will become a normal varible in 3.0. Other engines do not
   # implement SAFE.


### PR DESCRIPTION
This PR adds spec examples for https://github.com/rspec/rspec-core/issues/2892.
Actual fix is done in https://github.com/rspec/rspec-support/pull/505.