### PR TITLE
Tweaks to prevent flakeyness with local builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,7 @@ elsif RUBY_VERSION < '2.0'
 elsif RUBY_VERSION < '2.3.0'
   gem 'ffi', '~> 1.12.0'
 else
-  # Until 1.13.2 is released due to Rubygems usage
-  gem 'ffi', '~> 1.12.0'
+  gem 'ffi', '~> 1.15.0'
 end
 
 if RUBY_VERSION < '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -129,9 +129,13 @@ function documentation_enforced {
 }
 
 function style_and_lint_enforced {
- if [ -x ./bin/rubocop ]; then
-   return 0
- else
+ if is_ruby_head; then
    return 1
+ else
+   if [ -x ./bin/rubocop ]; then
+     return 0
+   else
+     return 1
+   fi
  fi
 }

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Spec file load errors' do
 
     RSpec.configure do |c|
       c.filter_gems_from_backtrace "gems/aruba"
+      c.filter_gems_from_backtrace "gems/bundler"
       c.backtrace_exclusion_patterns << %r{/rspec-core/spec/} << %r{rspec_with_simplecov}
       c.failure_exit_code = failure_exit_code
       c.error_exit_code = error_exit_code

--- a/spec/integration/suite_hooks_errors_spec.rb
+++ b/spec/integration/suite_hooks_errors_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Suite hook errors' do
 
     RSpec.configure do |c|
       c.filter_gems_from_backtrace "gems/aruba"
+      c.filter_gems_from_backtrace "gems/bundler"
       c.backtrace_exclusion_patterns << %r{/rspec-core/spec/} << %r{rspec_with_simplecov}
       c.failure_exit_code = failure_exit_code
       c.error_exit_code = error_exit_code

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
       it "does not show the error class" do
         group.example("example name") { expect("this").to eq("that") }
         run_all_and_dump_failures
-        expect(formatter_output.string).not_to match(/RSpec/m)
+        expect(formatter_output.string).not_to match(/RSpec::/m)
       end
     end
 
@@ -209,7 +209,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
       it "does not show the error class" do
         group.example("example name") { expect("this").to receive("that") }
         run_all_and_dump_failures
-        expect(formatter_output.string).not_to match(/RSpec/m)
+        expect(formatter_output.string).not_to match(/RSpec::/m)
       end
     end
 

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -33,6 +33,7 @@ module FormatterSupport
 
     runner = RSpec::Core::Runner.new(options)
     configuration = runner.configuration
+    configuration.filter_gems_from_backtrace "gems/bundler"
     configuration.backtrace_formatter.exclusion_patterns << /rspec_with_simplecov/
     configuration.backtrace_formatter.inclusion_patterns = []
 
@@ -41,6 +42,7 @@ module FormatterSupport
     runner.run(err, out)
     out.string
   end
+  RUN_LINE = __LINE__ - 3
 
   def normalize_durations(output)
     output.gsub(/(?:\d+ minutes? )?\d+(?:\.\d+)?(s| seconds?)/) do |dur|
@@ -67,7 +69,7 @@ module FormatterSupport
         |
         |       (compared using ==)
         |     # ./spec/rspec/core/resources/formatter_specs.rb:18
-        |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:#{RUN_LINE}:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:16
         |     # ./spec/support/sandboxing.rb:7
@@ -87,7 +89,7 @@ module FormatterSupport
         |
         |       (compared using ==)
         |     # ./spec/rspec/core/resources/formatter_specs.rb:37
-        |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:#{RUN_LINE}:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:16
         |     # ./spec/support/sandboxing.rb:7
@@ -162,7 +164,7 @@ module FormatterSupport
         |
         |       (compared using ==)
         |     # ./spec/rspec/core/resources/formatter_specs.rb:18:in `block (3 levels) in <top (required)>'
-        |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:#{RUN_LINE}:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
@@ -182,7 +184,7 @@ module FormatterSupport
         |
         |       (compared using ==)
         |     # ./spec/rspec/core/resources/formatter_specs.rb:37:in `block (2 levels) in <top (required)>'
-        |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:#{RUN_LINE}:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'
@@ -213,7 +215,7 @@ module FormatterSupport
         |       foo
         |     # (erb):1:in `<main>'
         |     # ./spec/rspec/core/resources/formatter_specs.rb:50:in `block (2 levels) in <top (required)>'
-        |     # ./spec/support/formatter_support.rb:41:in `run_rspec_with_formatter'
+        |     # ./spec/support/formatter_support.rb:#{RUN_LINE}:in `run_rspec_with_formatter'
         |     # ./spec/support/formatter_support.rb:3:in `run_example_specs_with_formatter'
         |     # ./spec/support/sandboxing.rb:16:in `block (3 levels) in <top (required)>'
         |     # ./spec/support/sandboxing.rb:7:in `block (2 levels) in <top (required)>'


### PR DESCRIPTION
Debugging some stuff locally I was frustrated that my setup (rvm) inserts extra backtrace lines from bundler as its in a non standard location on 3.0.0 for some reason, manually filtering bundler solves it and I see no reason why we shouldn't do this.