### PR TITLE
Do not fail if an Exception has no backtrace

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@ Enhancements:
 Bug fixes:
 
 * Ensure bisect communication uses consistent encoding. (Mike Jarema, #2852)
+* Fix exception presenter when the root cause exception has nil backtrace.
+  (Zinovyev Ivan, #2903)
 
 ### 3.10.1 / 2020-12-27
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.10.0...v3.10.1)

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -55,7 +55,7 @@ module RSpec
                 cause << "  #{line}"
               end
 
-              unless last_cause.backtrace.empty?
+              unless last_cause.backtrace.nil? || last_cause.backtrace.empty?
                 cause << ("  #{backtrace_formatter.format_backtrace(last_cause.backtrace, example.metadata).first}")
               end
             end

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -202,6 +202,42 @@ module RSpec::Core
         EOS
       end
 
+      context "when the first exception doesn't have a backgrace" do
+        let(:first_exception) { FakeException.new("Real\nculprit", backtrace) }
+
+        shared_examples 'expected result for the case when there is no backtrace' do
+          it 'wont fail for the exception with a nil backtrace', :if => RSpec::Support::RubyFeatures.supports_exception_cause? do
+            the_presenter = Formatters::ExceptionPresenter.new(the_exception, example)
+
+            expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+              |
+              |  1) Example
+              |     Failure/Error: # The failure happened here!#{ encoding_check }
+              |
+              |       Boom
+              |       Bam
+              |     # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+              |     # ------------------
+              |     # --- Caused by: ---
+              |     #   Real
+              |     #   culprit
+            EOS
+          end
+        end
+
+        context 'when backtrace is []' do
+          let(:backtrace) { [] }
+
+          it_behaves_like 'expected result for the case when there is no backtrace'
+        end
+
+        context 'when backtrace is nil' do
+          let(:backtrace) { nil }
+
+          it_behaves_like 'expected result for the case when there is no backtrace'
+        end
+      end
+
       it 'wont produce a stack error when cause is the exception itself', :if => RSpec::Support::RubyFeatures.supports_exception_cause? do
         allow(the_exception).to receive(:cause) { the_exception }
         the_presenter = Formatters::ExceptionPresenter.new(the_exception, example)


### PR DESCRIPTION
Currently `backtrace` of an exception is checked by the `empty?` method. But it sometimes occur that the Exception class will return `nil` for backtrace:
```
StandardError.new.backtrace.empty?
NoMethodError: undefined method `empty?' for nil:NilClass
```