### PR TITLE
Remove deprecated `currently_executing_a_context_hook?`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,7 @@ Breaking Changes:
   (Phil Pirozhkov, #2864)
 * Unify multi-condition filtering to use "all" semantic. (Phil Pirozhkov, #2874)
 * Remove support for RR test double framework version < 3.0. (Phil Pirozhkov, #2884)
+* Remove deprecated `currently_executing_a_context_hook?`. (Phil Pirozhkov, #2911)
 
 Enhancements:
 

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -438,8 +438,6 @@ module RSpec
 
         ExampleGroups.assign_const(self)
 
-        @currently_executing_a_context_hook = false
-
         config.configure_group(self)
       end
 
@@ -534,30 +532,15 @@ module RSpec
         end
       end
 
-      # @deprecated use `RSpec.current_scope` instead
-      # Returns true if a `before(:context)` or `after(:context)`
-      # hook is currently executing.
-      def self.currently_executing_a_context_hook?
-        RSpec.deprecate(
-          "currently_executing_a_context_hook",
-          :replacement => "RSpec.current_scope"
-        )
-
-        @currently_executing_a_context_hook
-      end
-
       # @private
       def self.run_before_context_hooks(example_group_instance)
         set_ivars(example_group_instance, superclass_before_context_ivars)
-
-        @currently_executing_a_context_hook = true
 
         ContextHookMemoized::Before.isolate_for_context_hook(example_group_instance) do
           hooks.run(:before, :context, example_group_instance)
         end
       ensure
         store_before_context_ivars(example_group_instance)
-        @currently_executing_a_context_hook = false
       end
 
       # @private
@@ -569,14 +552,11 @@ module RSpec
       def self.run_after_context_hooks(example_group_instance)
         set_ivars(example_group_instance, before_context_ivars)
 
-        @currently_executing_a_context_hook = true
-
         ContextHookMemoized::After.isolate_for_context_hook(example_group_instance) do
           hooks.run(:after, :context, example_group_instance)
         end
       ensure
         before_context_ivars.clear
-        @currently_executing_a_context_hook = false
       end
 
       # Runs all the examples in this group.

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -683,51 +683,6 @@ module RSpec::Core
           group.run
           expect(order).to eq([:example, :after_example, :example, :after_example])
         end
-
-        describe "#currently_executing_a_context_hook?" do
-          it "sets currently_executing_a_context_hook? to false initially" do
-            group = RSpec.describe
-            expect(group.currently_executing_a_context_hook?).to be false
-          end
-
-          it "sets currently_executing_a_context_hook? during before(:context) execution" do
-            group = RSpec.describe
-            hook_result = nil
-            group.before(:context) { hook_result = group.currently_executing_a_context_hook? }
-            group.example("") {}
-            group.run
-            expect(hook_result).to be true
-          end
-
-          it "does not set currently_executing_a_context_hook? outside of before(:context) execution" do
-            group = RSpec.describe
-            hook_result = nil
-
-            group.before(:context) { hook_result = group.currently_executing_a_context_hook? }
-            group.before(:each) { hook_result = group.currently_executing_a_context_hook? }
-            group.example("") {}
-            group.run
-            expect(hook_result).to be false
-          end
-
-          it "sets currently_executing_a_context_hook? during after(:context) execution" do
-            group = RSpec.describe
-            hook_result = nil
-
-            group.after(:context) { hook_result = group.currently_executing_a_context_hook? }
-            group.example("") {}
-            group.run
-            expect(hook_result).to be true
-          end
-
-          it "unsets currently_executing_a_context_hook? after an after(:context) hook is done" do
-            group = RSpec.describe
-            group.after(:context) { }
-            group.example("") {}
-            group.run
-            expect(group.currently_executing_a_context_hook?).to be false
-          end
-        end
       end
 
       it "runs the before alls in order" do


### PR DESCRIPTION
Deprecated in https://github.com/rspec/rspec-core/pull/2880
Replacement `RSpec.current_scope` added in https://github.com/rspec/rspec-core/pull/2895, will be released in 3.11.0, and is cherry-picked to `4-0-dev`.