### PR TITLE
Make inspection value for Example::Procsy be the same as class name of it

### DIFF
--- a/lib/rspec/core/example.rb
+++ b/lib/rspec/core/example.rb
@@ -377,7 +377,7 @@ module RSpec
 
         # @private
         def inspect
-          @example.inspect.gsub('Example', 'ExampleProcsy')
+          @example.inspect.gsub('Example', 'Example::Procsy')
         end
       end
 

--- a/spec/rspec/core/hooks_spec.rb
+++ b/spec/rspec/core/hooks_spec.rb
@@ -325,7 +325,7 @@ module RSpec::Core
           end
 
           group.run
-          expect(inspect_value).to match(/ExampleProcsy/)
+          expect(inspect_value).to match(/Example::Procsy/)
         end
       end
 


### PR DESCRIPTION
I found inspect for `Example::Procsy` a little bit different from it's class name. Actually, I searched `ExampleProcsy` class to debug.
I think It's better that inspection of instance shows the class name. 

In this PR, I update the return value from `ExampleProcsy` to `Example::Procsy`. 