### PR TITLE
Skip output check if output not defined on formatter

### DIFF
--- a/lib/rspec/core/formatters.rb
+++ b/lib/rspec/core/formatters.rb
@@ -194,8 +194,14 @@ module RSpec::Core::Formatters
 
     def duplicate_formatter_exists?(new_formatter)
       @formatters.any? do |formatter|
-        formatter.class == new_formatter.class && formatter.output == new_formatter.output
+        formatter.class == new_formatter.class &&
+          has_matching_output?(formatter, new_formatter)
       end
+    end
+
+    def has_matching_output?(formatter, new_formatter)
+      return true unless formatter.respond_to?(:output) && new_formatter.respond_to?(:output)
+      formatter.output == new_formatter.output
     end
 
     def existing_formatter_implements?(notification)

--- a/spec/rspec/core/formatters_spec.rb
+++ b/spec/rspec/core/formatters_spec.rb
@@ -144,6 +144,28 @@ module RSpec::Core::Formatters
             loader.add :documentation, path
           }.to change { loader.formatters.length }
         end
+
+        context "formatters do not subclass BaseFormatter" do
+          before do
+            stub_const("CustomFormatter", Class.new)
+            stub_const("OtherCustomFormatter", Class.new)
+            Loader.formatters[CustomFormatter] = []
+            Loader.formatters[OtherCustomFormatter] = []
+            loader.add "CustomFormatter"
+          end
+
+          it "adds different formatters" do
+            expect {
+              loader.add "OtherCustomFormatter"
+            }.to change { loader.formatters.length }
+          end
+
+          it "doesn't add the same formatter" do
+            expect {
+              loader.add "CustomFormatter"
+            }.not_to change { loader.formatters.length }
+          end
+        end
       end
 
       context "When a custom formatter exists" do

--- a/spec/rspec/core/formatters_spec.rb
+++ b/spec/rspec/core/formatters_spec.rb
@@ -145,30 +145,26 @@ module RSpec::Core::Formatters
           }.to change { loader.formatters.length }
         end
 
-        context "formatters do not subclass BaseFormatter" do
-          before do
-            stub_const("CustomFormatter", Class.new)
-            stub_const("OtherCustomFormatter", Class.new)
-            Loader.formatters[CustomFormatter] = []
-            Loader.formatters[OtherCustomFormatter] = []
-            loader.add "CustomFormatter"
-          end
+        plain_old_formatter = Class.new do
+          RSpec::Core::Formatters.register self, :example_started
 
-          it "adds different formatters" do
-            expect {
-              loader.add "OtherCustomFormatter"
-            }.to change { loader.formatters.length }
+          def initialize(output)
           end
+        end
 
-          it "doesn't add the same formatter" do
-            expect {
-              loader.add "CustomFormatter"
-            }.not_to change { loader.formatters.length }
-          end
+        it "handles formatters which do not subclass our formatters" do
+          expect {
+            loader.add plain_old_formatter, output
+          }.to change { loader.formatters.length }
+
+          # deliberate duplicate to ensure we can check for them correctly
+          expect {
+            loader.add plain_old_formatter, output
+          }.to_not change { loader.formatters.length }
         end
       end
 
-      context "When a custom formatter exists" do
+      context "when a custom formatter exists" do
         specific_formatter = RSpec::Core::Formatters::JsonFormatter
         generic_formatter = specific_formatter.superclass
 


### PR DESCRIPTION
If a custom formatter doesn't subclass the `BaseTextFormatter` it doesn't have the `output` method, then the duplicate formatter check throws a "undefined method output" error, just PR just skips that part of the check if the `output` method isn't defined. 

Also I've noticed in the documentation for [custom formatters](https://relishapp.com/rspec/rspec-core/docs/formatters/custom-formatters) that the text recommends subclassing from `BaseTextFormatter` but the example doesn't show that? I totally just read the code and skimmed the text 😛