### PR TITLE
Warn about exit in helper

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -2122,6 +2122,11 @@ module RSpec
         relative_file = Metadata.relative_path(file)
         reporter.notify_non_example_exception(ex, "An error occurred while loading #{relative_file}.")
         RSpec.world.wants_to_quit = true
+      rescue SystemExit => ex
+        relative_file = Metadata.relative_path(file)
+        reporter.notify_non_example_exception(ex, "While loading #{relative_file} an `exit` / `raise SystemExit` occurred, RSpec will now quit.")
+        RSpec.world.rspec_is_quitting = true
+        raise ex
       end
 
       def handle_suite_hook(scope, meta)

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -2124,7 +2124,10 @@ module RSpec
         RSpec.world.wants_to_quit = true
       rescue SystemExit => ex
         relative_file = Metadata.relative_path(file)
-        reporter.notify_non_example_exception(ex, "While loading #{relative_file} an `exit` / `raise SystemExit` occurred, RSpec will now quit.")
+        reporter.notify_non_example_exception(
+          ex,
+          "While loading #{relative_file} an `exit` / `raise SystemExit` occurred, RSpec will now quit."
+        )
         RSpec.world.rspec_is_quitting = true
         raise ex
       end

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -82,6 +82,25 @@ RSpec.describe 'Spec file load errors' do
     EOS
   end
 
+  it 'prints a warning when a helper file exits early' do
+    write_file_formatted "helper_with_exit.rb", "exit 999"
+
+    expect {
+      run_command "--require ./helper_with_exit.rb"
+    }.to raise_error(SystemExit)
+    output = normalize_durations(last_cmd_stdout)
+    expect(output).to eq unindent(<<-EOS)
+
+      While loading ./helper_with_exit.rb an `exit` / `raise SystemExit` occurred, RSpec will now quit.
+      Failure/Error: exit 999
+
+      SystemExit:
+        exit
+      # ./helper_with_exit.rb:1:in `exit'
+      # ./helper_with_exit.rb:1#{spec_line_suffix}
+    EOS
+  end
+
   it 'nicely handles load-time errors in user spec files' do
     write_file_formatted "1_spec.rb", "
       boom

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -89,23 +89,28 @@ RSpec.describe 'Spec file load errors' do
       run_command "--require ./helper_with_exit.rb"
     }.to raise_error(SystemExit)
     output = normalize_durations(last_cmd_stdout)
-    expected_error_line = ->() {
-      if defined?(JRUBY_VERSION) && !JRUBY_VERSION.empty?
-        "Unable to find org/jruby/RubyKernel.java to read failed line"
-      else
-        "exit 999"
-      end
-    }
-    expect(output).to eq unindent(<<-EOS)
+    if defined?(JRUBY_VERSION) && !JRUBY_VERSION.empty?
+      expect(output).to eq unindent(<<-EOS)
 
-      While loading ./helper_with_exit.rb an `exit` / `raise SystemExit` occurred, RSpec will now quit.
-      Failure/Error: #{expected_error_line.call}
+        While loading ./helper_with_exit.rb an `exit` / `raise SystemExit` occurred, RSpec will now quit.
+        Failure/Error: Unable to find org/jruby/RubyKernel.java to read failed line
 
-      SystemExit:
-        exit
-      # ./helper_with_exit.rb:1:in `exit'
-      # ./helper_with_exit.rb:1#{spec_line_suffix}
-    EOS
+        SystemExit:
+          exit
+        # ./helper_with_exit.rb:1#{spec_line_suffix}
+      EOS
+    else
+      expect(output).to eq unindent(<<-EOS)
+
+        While loading ./helper_with_exit.rb an `exit` / `raise SystemExit` occurred, RSpec will now quit.
+        Failure/Error: exit 999
+
+        SystemExit:
+          exit
+        # ./helper_with_exit.rb:1:in `exit'
+        # ./helper_with_exit.rb:1#{spec_line_suffix}
+      EOS
+    end
   end
 
   it 'nicely handles load-time errors in user spec files' do

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -89,10 +89,17 @@ RSpec.describe 'Spec file load errors' do
       run_command "--require ./helper_with_exit.rb"
     }.to raise_error(SystemExit)
     output = normalize_durations(last_cmd_stdout)
+    expected_error_line = ->() {
+      if defined?(JRUBY_VERSION) && !JRUBY_VERSION.empty?
+        "Unable to find org/jruby/RubyKernel.java to read failed line"
+      else
+        "exit 999"
+      end
+    }
     expect(output).to eq unindent(<<-EOS)
 
       While loading ./helper_with_exit.rb an `exit` / `raise SystemExit` occurred, RSpec will now quit.
-      Failure/Error: exit 999
+      Failure/Error: #{expected_error_line.call}
 
       SystemExit:
         exit


### PR DESCRIPTION
In https://github.com/rspec/rspec-core/issues/2508, @JonRowe wondered:

> Yes using `exit` or `abort` will cause RSpec to quit .. I am wondering if we should print a warning about that happening...

I said:

> Yes, please! Such a warning will be very helpful, as in https://github.com/rspec/rspec-rails/issues/2441#issuecomment-1003212668 The current output "No examples found" is misleading.

Then, @pirj asked:

> Does anyone want to send a PR?

So, this is what you get. 😅  I'm sure it needs a lot of work. 🤦  If it's at all salvageable, please help me get it cleaned up.