### PR TITLE
Fix cucumber issues blocking ruby-head

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,10 @@ if RUBY_VERSION < '2.4.0'
   gem 'minitest', '< 5.12.0'
 end
 
+if RUBY_VERSION < '2.0.0'
+  gem 'cucumber', "<= 1.3.22"
+end
+
 gem 'contracts', '< 0.16' if RUBY_VERSION < '1.9.0'
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,6 +1,11 @@
 <%
+
+USE_TILDE_TAGS = !defined?(::RUBY_ENGINE_VERSION) || (::RUBY_ENGINE_VERSION < '2.0.0')
+NOT_WIP_TAG = USE_TILDE_TAGS ? '~@wip' : '"not @wip"'
+NOT_JRUBY_TAG = USE_TILDE_TAGS ? '~@no-jruby' : '"not @no-jruby"'
+
 exclusions = []
-exclusions << ' --tags ~@no-jruby' if RUBY_PLATFORM == 'java'
+exclusions << " --tags #{NOT_JRUBY_TAG}" if RUBY_PLATFORM == 'java'
 %>
-default: --require features --strict --format progress --tags ~@wip<%= exclusions.join %> features
+default: --require features --strict --format progress --tags <%= NOT_WIP_TAG %><%= exclusions.join %> features
 wip:     --require features --tags @wip:30 --wip features

--- a/features/command_line/init.feature
+++ b/features/command_line/init.feature
@@ -25,7 +25,7 @@ Feature: `--init` option
   Scenario: Accept and use the recommended settings in `spec_helper` (which are initially commented out)
     Given I have a brand new project with no files
       And I have run `rspec --init`
-     When I accept the recommended settings by removing `=begin` and `=end` from `spec/spec_helper.rb`
+     When I accept the recommended settings by removing `=begin` and `=end` from `spec_helper.rb`
       And I create "spec/addition_spec.rb" with the following content:
         """ruby
         RSpec.describe "Addition" do

--- a/features/metadata/described_class.feature
+++ b/features/metadata/described_class.feature
@@ -6,7 +6,11 @@ Feature: described class
   Scenario: Access the described class from the example
     Given a file named "spec/example_spec.rb" with:
       """ruby
-      RSpec.describe Fixnum do
+      RSpec.describe Symbol do
+        it "is available as described_class" do
+          expect(described_class).to eq(Symbol)
+        end
+
         describe 'inner' do
           describe String do
             it "is available as described_class" do

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -114,7 +114,7 @@ Given(/^a vendored gem named "(.*?)" containing a file named "(.*?)" with:$/) do
   set_environment_variable('RUBYOPT', ENV['RUBYOPT'] + " -I#{gem_dir}/lib")
 end
 
-When "I accept the recommended settings by removing `=begin` and `=end` from `spec/spec_helper.rb`" do
+When('I accept the recommended settings by removing `=begin` and `=end` from `spec_helper.rb`') do
   cd('.') do
     spec_helper = File.read("spec/spec_helper.rb")
     expect(spec_helper).to include("=begin", "=end")

--- a/features/support/diff_lcs_versions.rb
+++ b/features/support/diff_lcs_versions.rb
@@ -1,16 +1,16 @@
 require 'diff-lcs'
 
 Around "@skip-when-diff-lcs-1.4" do |scenario, block|
-  if Diff::LCS::VERSION.to_f >= 1.4
-    warn "Skipping scenario #{scenario.title} on `diff-lcs` v#{Diff::LCS::VERSION.to_f}"
+  if Diff::LCS::VERSION >= '1.4'
+    skip_this_scenario "Skipping scenario #{scenario.name} on `diff-lcs` v#{Diff::LCS::VERSION}"
   else
     block.call
   end
 end
 
 Around "@skip-when-diff-lcs-1.3" do |scenario, block|
-  if Diff::LCS::VERSION.to_f < 1.4
-    warn "Skipping scenario #{scenario.title} on `diff-lcs` v#{Diff::LCS::VERSION.to_f}"
+  if Diff::LCS::VERSION < '1.4'
+    skip_this_scenario "Skipping scenario #{scenario.name} on `diff-lcs` v#{Diff::LCS::VERSION}"
   else
     block.call
   end

--- a/features/support/jruby.rb
+++ b/features/support/jruby.rb
@@ -1,4 +1,8 @@
 Around "@broken-on-jruby-9000" do |scenario, block|
   require 'rspec/support/ruby_features'
-  block.call unless RSpec::Support::Ruby.jruby_9000?
+  if RSpec::Support::Ruby.jruby_9000?
+    skip_this_scenario "Skipping scenario #{scenario.name} not supported on JRuby 9000"
+  else
+    block.call
+  end
 end

--- a/features/support/require_expect_syntax_in_aruba_specs.rb
+++ b/features/support/require_expect_syntax_in_aruba_specs.rb
@@ -1,6 +1,9 @@
 if defined?(Cucumber)
   require 'shellwords'
-  Before('~@allow-should-syntax', '~@with-clean-spec-opts') do
+  use_tilde_tags = !defined?(::RUBY_ENGINE_VERSION) || (::RUBY_ENGINE_VERSION < '2.0.0')
+  exclude_allow_should_syntax = use_tilde_tags ? '~@allow-should-syntax' : 'not @allow-should-syntax'
+  exclude_with_clean_spec_ops = use_tilde_tags ? '~@with-clean-spec-opts' : 'not @with-clean-spec-opts'
+  Before(exclude_allow_should_syntax, exclude_with_clean_spec_ops) do
     set_environment_variable('SPEC_OPTS', "-r#{Shellwords.escape(__FILE__)}")
   end
 

--- a/features/support/rubinius.rb
+++ b/features/support/rubinius.rb
@@ -2,5 +2,9 @@
 ENV['RBXOPT'] = "#{ENV["RBXOPT"]} -Xcompiler.no_rbc"
 
 Around "@unsupported-on-rbx" do |scenario, block|
-  block.call unless defined?(Rubinius)
+  if defined?(Rubinius)
+    block.call
+  else
+    skip_this_scenario "Skipping scenario #{scenario.name} not supported on Rubinius"
+  end
 end

--- a/features/support/ruby_27_support.rb
+++ b/features/support/ruby_27_support.rb
@@ -2,6 +2,6 @@ Around "@ruby-2-7" do |scenario, block|
   if RUBY_VERSION.to_f == 2.7
     block.call
   else
-    warn "Skipping scenario #{scenario.title} on Ruby v#{RUBY_VERSION}"
+    skip_this_scenario "Skipping scenario #{scenario.name} on Ruby v#{RUBY_VERSION}"
   end
 end

--- a/rspec-core.gemspec
+++ b/rspec-core.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 
-  s.add_development_dependency "cucumber", "~> 1.3"
+  s.add_development_dependency "cucumber", ">= 1.3"
   s.add_development_dependency "minitest", "~> 5.3"
   s.add_development_dependency "aruba",    "~> 0.14.9"
 


### PR DESCRIPTION
This PR gets CI to green against ruby-head.  It does so by:

1. Loosening the cucumber version restrictions such that a ruby-head compatible version
2. Making the tag syntax logic dynamic, based on the Ruby version
3. Removing Fixnum from the described_class spec.  (Also added a spec for the outer case)
4. Renaming a when condition to avoid a string escape behavior that varies between cucumber versions.

cc: @JonRowe 

