### PR TITLE
Update aruba timeout to use config block

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,11 +3,13 @@ require 'aruba/cucumber'
 Before do
   # Force ids to be printed unquoted for consistency
   set_environment_variable('SHELL', '/usr/bin/bash')
+end
 
-  if RUBY_PLATFORM =~ /java/ || defined?(Rubinius)
-    @aruba_timeout_seconds = 120
+Aruba.configure do |config|
+  config.exit_timeout = if RUBY_PLATFORM =~ /java/ || defined?(Rubinius) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'truffleruby')
+    120
   else
-    @aruba_timeout_seconds = 10
+    10
   end
 end
 


### PR DESCRIPTION
This updates to be similar to:
https://github.com/rspec/rspec-mocks/blob/4be625e322ed1da7607ecab0e838efd9453ac0c6/features/support/env.rb#L4-L10

The current usage `@aruba_timeout_seconds` appears to be deprecated:
https://github.com/cucumber/aruba/blob/1c6bc8731891692f5064fcfd1ff8a885c23298a6/CHANGELOG.md#080pre