### PR TITLE
Skip backtrace for pending examples

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ Enhancements:
 
 * Support the `--backtrace` flag when using the JSON formatter. (Matt Larraz, #2980)
 * Ignore commented out lines in CLI config files (e.g. `.rspec`). (Junichi Ito, #2984)
+* Add `pending_failure_output` config option to allow skipping backtraces or
+  muting pending specs output. (Phil Pirozhkov, #2957)
 
 ### 3.12.0 / 2022-10-26
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.11.0...v3.12.0)

--- a/features/configuration/pending_failure_output.feature
+++ b/features/configuration/pending_failure_output.feature
@@ -1,0 +1,58 @@
+Feature: Pending failure output
+
+  Configure the format of pending examples output with an option (defaults to `:full`):
+
+  ```ruby
+  RSpec.configure do |c|
+    c.pending_failure_output = :no_backtrace
+  end
+  ```
+
+  Allowed options are `:full`, `:no_backtrace` and `:skip`.
+
+  Background:
+    Given a file named "spec/example_spec.rb" with:
+      """ruby
+      require "spec_helper"
+
+      RSpec.describe "something" do
+        pending "will never happen again" do
+          expect(Time.now.year).to eq(2021)
+        end
+      end
+      """
+
+  Scenario: By default outputs backtrace and details
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      """
+    When I run `rspec spec`
+    Then the examples should all pass
+    And the output should contain "Pending: (Failures listed here are expected and do not affect your suite's status)"
+    And the output should contain "1) something will never happen again"
+    And the output should contain "expected: 2021"
+    And the output should contain "./spec/example_spec.rb:5"
+
+  Scenario: Setting `pending_failure_output` to `:no_backtrace` hides the backtrace
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure { |c| c.pending_failure_output = :no_backtrace }
+      """
+    When I run `rspec spec`
+    Then the examples should all pass
+    And the output should contain "Pending: (Failures listed here are expected and do not affect your suite's status)"
+    And the output should contain "1) something will never happen again"
+    And the output should contain "expected: 2021"
+    And the output should not contain "./spec/example_spec.rb:5"
+
+  Scenario: Setting `pending_failure_output` to `:skip` hides the backtrace
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure { |c| c.pending_failure_output = :skip }
+      """
+    When I run `rspec spec`
+    Then the examples should all pass
+    And the output should not contain "Pending: (Failures listed here are expected and do not affect your suite's status)"
+    And the output should not contain "1) something will never happen again"
+    And the output should not contain "expected: 2021"
+    And the output should not contain "./spec/example_spec.rb:5"

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -458,6 +458,20 @@ module RSpec
       # return [Integer]
       add_setting :max_displayed_failure_line_count
 
+      # @macro add_setting
+      # Format the output for pending examples. Can be set to:
+      #  - :full (default) - pending examples appear similarly to failures
+      #  - :no_backtrace - same as above, but with no backtrace
+      #  - :skip - do not show the section at all
+      # return [Symbol]
+      add_read_only_setting :pending_failure_output
+      def pending_failure_output=(mode)
+        raise ArgumentError,
+              "`pending_failure_output` can be set to :full, :no_backtrace, " \
+              "or :skip" unless [:full, :no_backtrace, :skip].include?(mode)
+        @pending_failure_output = mode
+      end
+
       # Determines which bisect runner implementation gets used to run subsets
       # of the suite during a bisection. Your choices are:
       #
@@ -559,6 +573,7 @@ module RSpec
         @max_displayed_failure_line_count = 10
         @world = World::Null
         @shared_context_metadata_behavior = :trigger_inclusion
+        @pending_failure_output = :full
 
         define_built_in_hooks
       end

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -312,10 +312,14 @@ module RSpec
                 ]
               }
             elsif @execution_result.status == :pending
-              {
+              options = {
                 :message_color    => RSpec.configuration.pending_color,
                 :detail_formatter => PENDING_DETAIL_FORMATTER
               }
+              if RSpec.configuration.pending_failure_output == :no_backtrace
+                options[:backtrace_formatter] = EmptyBacktraceFormatter
+              end
+              options
             end
           end
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -120,6 +120,8 @@ module RSpec::Core
       # @return [String] The list of pending examples, fully formatted in the
       #   way that RSpec's built-in formatters emit.
       def fully_formatted_pending_examples(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
+        return if RSpec.configuration.pending_failure_output == :skip
+
         formatted = "\nPending: (Failures listed here are expected and do not affect your suite's status)\n".dup
 
         pending_notifications.each_with_index do |notification, index|

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -2906,6 +2906,36 @@ module RSpec::Core
       end
     end
 
+    describe '#pending_failure_output' do
+      it 'defaults to :full' do
+        expect(config.pending_failure_output).to eq :full
+      end
+
+      it 'can be set to :full' do
+        config.pending_failure_output = :full
+        expect(config.pending_failure_output).to eq :full
+      end
+
+      it 'can be set to :no_backtrace' do
+        config.pending_failure_output = :no_backtrace
+        expect(config.pending_failure_output).to eq :no_backtrace
+      end
+
+      it 'can be set to :skip' do
+        config.pending_failure_output = :skip
+        expect(config.pending_failure_output).to eq :skip
+      end
+
+      it 'cannot be set to any other values' do
+        expect {
+          config.pending_failure_output = :another_value
+        }.to raise_error(
+          ArgumentError,
+          '`pending_failure_output` can be set to :full, :no_backtrace, or :skip'
+        )
+      end
+    end
+
     # assigns files_or_directories_to_run and triggers post-processing
     # via `files_to_run`.
     def assign_files_or_directories_to_run(*value)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,7 @@ module CommonHelpers
 end
 
 RSpec.configure do |c|
+  c.pending_failure_output = :no_backtrace
   c.example_status_persistence_file_path = "./spec/examples.txt"
   c.around(:example, :isolated_directory) do |ex|
     handle_current_dir_change(&ex)


### PR DESCRIPTION
fixes #2956

```ruby
# spec/spec_helper.rb
RSpec.configure do |c|
  c.pending_failure_output = :no_backtrace
  # ...
end
```

:tada:
```
$ rspec spec/a_spec.rb
Run options: exclude {:ruby=>#<Proc: ./spec/spec_helper.rb:111>}

Randomized with seed 9609


  pending (PENDING: No reason given)
  fails (FAILED - 1)

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) pending
     # No reason given
     Failure/Error: expect(1).to eq(2)

       expected: 2
            got: 1

       (compared using ==)

Failures:

  1) fails
     Failure/Error: expect(1).to eq(2)

       expected: 2
            got: 1

       (compared using ==)
     # /Users/pirj/source/rspec-dev/repos/rspec-support/lib/rspec/support.rb:102:in `block in <module:Support>'
     # /Users/pirj/source/rspec-dev/repos/rspec-support/lib/rspec/support.rb:111:in `notify_failure'
```