### PR TITLE
Use formatted_backtrace in JSON formatter

### DIFF
--- a/lib/rspec/core/formatters/json_formatter.rb
+++ b/lib/rspec/core/formatters/json_formatter.rb
@@ -33,14 +33,18 @@ module RSpec
         end
 
         def stop(notification)
-          @output_hash[:examples] = notification.examples.map do |example|
-            format_example(example).tap do |hash|
+          @output_hash[:examples] = notification.examples.reject(&:exception).map do |example|
+            format_example(example)
+          end
+
+          @output_hash[:examples] += notification.failure_notifications.map do |notification|
+            format_example(notification.example).tap do |hash|
               e = example.exception
               if e
-                hash[:exception] =  {
+                hash[:exception] = {
                   :class => e.class.name,
                   :message => e.message,
-                  :backtrace => e.backtrace,
+                  :backtrace => notification.formatted_backtrace,
                 }
               end
             end


### PR DESCRIPTION
Currently the JSON formatter does not respect the `--backtrace` flag (it will always print the full backtrace).

I believe this should behave the same as other formatters and respect the config.