### PR TITLE
Skip adding whitespace around extrafailure lines when already present

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### Development
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.12.0...main)
 
+Bug fixes:
+
+* Prevent multiple calls to `extra_failure_lines` from adding additional whitespace
+  around them when the lines already contain whitespace. (Jon Rowe, #3006)
+
 Enhancements:
 
 * Support the `--backtrace` flag when using the JSON formatter. (Matt Larraz, #2980)

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -197,8 +197,8 @@ module RSpec
           @extra_failure_lines ||= begin
             lines = Array(example.metadata[:extra_failure_lines])
             unless lines.empty?
-              lines.unshift('')
-              lines.push('')
+              lines.unshift('') unless lines.first == ''
+              lines.push('') unless lines.last == ''
             end
             lines
           end

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -341,6 +341,25 @@ module RSpec::Core
         EOS
       end
 
+      it "wont add extra blank lines around extra failure lines when lines are already padded" do
+        extra_example = example.clone
+        failure_line = 'http://www.example.com/job_details/123'
+        extra_example.metadata[:extra_failure_lines] = ['', failure_line, '']
+        the_presenter = Formatters::ExceptionPresenter.new(exception, extra_example, :indentation => 4)
+        expect(the_presenter.fully_formatted(1)).to eq(<<-EOS.gsub(/^ +\|/, ''))
+          |
+          |    1) Example
+          |       Failure/Error: # The failure happened here!#{ encoding_check }
+          |
+          |         Boom
+          |         Bam
+          |
+          |       #{failure_line}
+          |
+          |       # ./spec/rspec/core/formatters/exception_presenter_spec.rb:#{line_num}
+        EOS
+      end
+
       describe 'line format' do
         let(:exception) do
           begin


### PR DESCRIPTION
Previously wrapped lines would keep adding whitespace when called, fixes #3005 