### PR TITLE
Move dry_run option higher in ordered option list

### DIFF
--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -79,6 +79,10 @@ module RSpec
         # deprecation (or otherwise access the reporter).
         :deprecation_stream,
 
+        # Dry run was passed through CLI args and must be set before `requires`
+        # to ensure RSpec.configuration.dry_run? is availble in all configure block.
+        :dry_run,
+
         # load paths depend on nothing, but must be set before `requires`
         # to support load-path-relative requires.
         :libs,

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -79,8 +79,8 @@ module RSpec
         # deprecation (or otherwise access the reporter).
         :deprecation_stream,
 
-        # Dry run was passed through CLI args and must be set before `requires`
-        # to ensure RSpec.configuration.dry_run? is availble in all configure block.
+        # In order for `RSpec.configuration.dry_run?` to return `true` during
+        # processing the `requires` option, it must be parsed before it.
         :dry_run,
 
         # load paths depend on nothing, but must be set before `requires`

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
     it "sets dry_run before libs and requires" do
       opts = config_options_object(*%w[--dry-run --require a/path -I a/lib])
       configuration = double("config").as_null_object
-      expect(configuration).to receive(:dry_run=).ordered
+      expect(configuration).to receive(:force).with({:dry_run => true}).ordered
       expect(configuration).to receive(:libs=).ordered
       expect(configuration).to receive(:requires=).ordered
       opts.configure(configuration)

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
       expect(configuration).to have_received(:add_formatter).ordered
     end
 
+    it "sets dry_run before libs and requires" do
+      opts = config_options_object(*%w[--dry-run --require a/path -I a/lib])
+      configuration = double("config").as_null_object
+      expect(configuration).to receive(:dry_run=).ordered
+      expect(configuration).to receive(:libs=).ordered
+      expect(configuration).to receive(:requires=).ordered
+      opts.configure(configuration)
+    end
+
     it "sends libs before requires" do
       opts = config_options_object(*%w[--require a/path -I a/lib])
       configuration = double("config").as_null_object


### PR DESCRIPTION
Currently `dry_run` option was set at the end of the options list, which makes `RSpec.configuration.dry_run?` always return `false` while processing required libs, especially `spec_helper.rb`.

For example in `spec_helper.rb`

```ruby
RSpec.configure do |config|
  puts "Dry?: #{config.dry_run?}"
end
```

```
$ rspec --dry-run

Dry? false
```

