### PR TITLE
Re-raise SyntaxError for SyntaxSuggest help

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -2139,6 +2139,14 @@ module RSpec
         relative_file = Metadata.relative_path(file)
         reporter.notify_non_example_exception(ex, "An error occurred while loading #{relative_file}.")
         RSpec.world.wants_to_quit = true
+      rescue SyntaxError => ex
+        relative_file = Metadata.relative_path(file)
+        reporter.notify_non_example_exception(
+          ex,
+          "While loading #{relative_file} a `raise SyntaxError` occurred, RSpec will now quit."
+        )
+        RSpec.world.rspec_is_quitting = true
+        raise ex
       rescue SystemExit => ex
         relative_file = Metadata.relative_path(file)
         reporter.notify_non_example_exception(


### PR DESCRIPTION
Running with Ruby 3.2. Before:

```
$ be rspec spec

An error occurred while loading spec_helper.
Failure/Error: require_relative "cutlass/local_buildpack"

SyntaxError:
  /Users/rschneeman/Documents/projects/cutlass/lib/cutlass/local_buildpack.rb:121: syntax error, unexpected end-of-input
# ./lib/cutlass.rb:101:in `require_relative'
# ./lib/cutlass.rb:101:in `<top (required)>'
# ./spec/spec_helper.rb:3:in `<top (required)>'
No examples found.
No examples found.


Finished in 0.00004 seconds (files took 0.23611 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

Finished in 0.00004 seconds (files took 0.23611 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

After:

```
$ be rspec spec
No examples found.
bundler: failed to load command: rspec (/Users/rschneeman/.gem/ruby/3.2.1/bin/rspec)
/Users/rschneeman/Documents/projects/cutlass/lib/cutlass.rb:101:in `require_relative': --> /Users/rschneeman/Documents/projects/cutlass/lib/cutlass/local_buildpack.rb
Unmatched keyword, missing `end' ?
    3  module Cutlass
   21    class LocalBuildpack
   22      private
   24      attr_reader :image_name
>  28      def initialize(directory:)
>  35      def file_lock
>  41      end
  120    end
  121  end
/Users/rschneeman/Documents/projects/cutlass/lib/cutlass/local_buildpack.rb:121: syntax error, unexpected end-of-input (SyntaxError)
	from /Users/rschneeman/Documents/projects/cutlass/lib/cutlass.rb:101:in `<top (required)>'
	from <internal:/Users/rschneeman/.rubies/ruby-3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/Users/rschneeman/.rubies/ruby-3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/rschneeman/Documents/projects/cutlass/spec/spec_helper.rb:3:in `<top (required)>'
	from <internal:/Users/rschneeman/.rubies/ruby-3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/Users/rschneeman/.rubies/ruby-3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/configuration.rb:2132:in `load_file_handling_errors'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/configuration.rb:1591:in `block in requires='
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/configuration.rb:1591:in `each'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/configuration.rb:1591:in `requires='
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/configuration_options.rb:117:in `block in process_options_into'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/configuration_options.rb:116:in `each'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/configuration_options.rb:116:in `process_options_into'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/configuration_options.rb:22:in `configure'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/runner.rb:132:in `configure'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/runner.rb:99:in `setup'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/runner.rb:86:in `run'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/runner.rb:71:in `run'
	from /Users/rschneeman/Documents/projects/rspec-core/lib/rspec/core/runner.rb:45:in `invoke'
	from /Users/rschneeman/Documents/projects/rspec-core/exe/rspec:4:in `<top (required)>'
	from /Users/rschneeman/.gem/ruby/3.2.1/bin/rspec:25:in `load'
	from /Users/rschneeman/.gem/ruby/3.2.1/bin/rspec:25:in `<top (required)>'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/cli/exec.rb:58:in `load'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/cli/exec.rb:23:in `run'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/cli.rb:492:in `exec'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/cli.rb:34:in `dispatch'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/cli.rb:28:in `start'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/exe/bundle:45:in `block in <top (required)>'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
	from /Users/rschneeman/.gem/ruby/3.2.1/gems/bundler-2.4.7/exe/bundle:33:in `<top (required)>'
	from /Users/rschneeman/.gem/ruby/3.2.1/bin/bundle:25:in `load'
	from /Users/rschneeman/.gem/ruby/3.2.1/bin/bundle:25:in `<main>'
```

Close #2990