### PR TITLE
Attempt to switch to Ubuntu 20.04 to fix JRuby 9.1.17.0 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
               JRUBY_OPTS: "--dev"
           - ruby: jruby-9.1.17.0
             bundler: 1
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             env:
               JRUBY_OPTS: "--dev"
           - ruby: 2.7


### PR DESCRIPTION
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
https://github.com/rspec/rspec-core/actions/runs/4314616470/jobs/7527887352:

Run ruby/setup-ruby@v1
Error: Error: Unsupported platform ubuntu-18.04
    at Module.getAvailableVersions (/home/runner/work/_actions/ruby/setup-ruby/v1/dist/index.js:67995:11)