### PR TITLE
Disable color mode by default when on dumb terminal

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -939,7 +939,12 @@ module RSpec
         when :on then true
         when :off then false
         else # automatic
-          output_to_tty?(output) || (color && tty?)
+          case
+          when ENV["TERM"] == "dumb"
+            false
+          else
+            output_to_tty?(output) || (color && tty?)
+          end
         end
       end
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -942,6 +942,8 @@ module RSpec
           case
           when ENV["TERM"] == "dumb"
             false
+          when (nc = ENV["NO_COLOR"]) and !nc.empty?
+            false
           else
             output_to_tty?(output) || (color && tty?)
           end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1312,6 +1312,7 @@ module RSpec::Core
       context ":automatic" do
         before do
           config.color_mode = :automatic
+          allow(ENV).to receive_messages("TERM" => nil)
         end
 
         context "with output.tty?" do
@@ -1326,6 +1327,15 @@ module RSpec::Core
           it "sets !color_enabled?" do
             config.output_stream = StringIO.new
             allow(config.output_stream).to receive_messages(:tty? => false)
+            expect(config.color_enabled?).to be false
+          end
+        end
+
+        context "with TERM=dumb" do
+          it "sets !color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => true)
+            allow(ENV).to receive_messages("TERM" => "dumb")
             expect(config.color_enabled?).to be false
           end
         end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1312,7 +1312,7 @@ module RSpec::Core
       context ":automatic" do
         before do
           config.color_mode = :automatic
-          allow(ENV).to receive_messages("TERM" => nil)
+          allow(ENV).to receive_messages("TERM" => nil, "NO_COLOR" => nil)
         end
 
         context "with output.tty?" do
@@ -1336,6 +1336,15 @@ module RSpec::Core
             config.output_stream = StringIO.new
             allow(config.output_stream).to receive_messages(:tty? => true)
             allow(ENV).to receive_messages("TERM" => "dumb")
+            expect(config.color_enabled?).to be false
+          end
+        end
+
+        context "with NO_COLOR" do
+          it "sets !color_enabled?" do
+            config.output_stream = StringIO.new
+            allow(config.output_stream).to receive_messages(:tty? => true)
+            allow(ENV).to receive_messages("NO_COLOR" => "1")
             expect(config.color_enabled?).to be false
           end
         end


### PR DESCRIPTION
The compliation-mode of Emacs sets TERM to "dumb", and does not support coloring.
