### PR TITLE
Change syntax error handling to print in cli

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -2139,6 +2139,14 @@ module RSpec
         relative_file = Metadata.relative_path(file)
         reporter.notify_non_example_exception(ex, "An error occurred while loading #{relative_file}.")
         RSpec.world.wants_to_quit = true
+      rescue SyntaxError => ex
+        relative_file = Metadata.relative_path(file)
+        reporter.notify_non_example_exception(
+          ex,
+          "While loading #{relative_file} a `raise SyntaxError` occurred, RSpec will now quit."
+        )
+        RSpec.world.rspec_is_quitting = true
+        raise ex
       rescue SystemExit => ex
         relative_file = Metadata.relative_path(file)
         reporter.notify_non_example_exception(

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -2135,10 +2135,6 @@ module RSpec
         suggestions = DidYouMean.new(relative_file).call
         reporter.notify_non_example_exception(ex, "An error occurred while loading #{relative_file}.#{suggestions}")
         RSpec.world.wants_to_quit = true
-      rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
-        relative_file = Metadata.relative_path(file)
-        reporter.notify_non_example_exception(ex, "An error occurred while loading #{relative_file}.")
-        RSpec.world.wants_to_quit = true
       rescue SyntaxError => ex
         relative_file = Metadata.relative_path(file)
         reporter.notify_non_example_exception(
@@ -2146,7 +2142,10 @@ module RSpec
           "While loading #{relative_file} a `raise SyntaxError` occurred, RSpec will now quit."
         )
         RSpec.world.rspec_is_quitting = true
-        raise ex
+      rescue Support::AllExceptionsExceptOnesWeMustNotRescue => ex
+        relative_file = Metadata.relative_path(file)
+        reporter.notify_non_example_exception(ex, "An error occurred while loading #{relative_file}.")
+        RSpec.world.wants_to_quit = true
       rescue SystemExit => ex
         relative_file = Metadata.relative_path(file)
         reporter.notify_non_example_exception(

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -175,10 +175,22 @@ module RSpec
         end
 
         # rubocop:disable Lint/RescueException
-        def exception_message_string(exception)
-          exception.message.to_s
-        rescue Exception => other
-          "A #{exception.class} for which `exception.message.to_s` raises #{other.class}."
+        if SyntaxError.instance_methods.include?(:detailed_message)
+          def exception_message_string(exception)
+            case exception
+            when SyntaxError then exception.detailed_message.to_s
+            else
+              exception.message.to_s
+            end
+          rescue Exception => other
+            "A #{exception.class} for which `exception.message.to_s` raises #{other.class}."
+          end
+        else
+          def exception_message_string(exception)
+            exception.message.to_s
+          rescue Exception => other
+            "A #{exception.class} for which `exception.message.to_s` raises #{other.class}."
+          end
         end
         # rubocop:enable Lint/RescueException
 

--- a/spec/support/aruba_support.rb
+++ b/spec/support/aruba_support.rb
@@ -49,7 +49,9 @@ RSpec.shared_context "aruba support" do
 
     handle_current_dir_change do
       cd '.' do
-        @last_cmd_exit_status = RSpec::Core::Runner.run(cmd_parts, temp_stderr, temp_stdout)
+        with_isolated_stderr do
+          @last_cmd_exit_status = RSpec::Core::Runner.run(cmd_parts, temp_stderr, temp_stdout)
+        end
       end
     end
   ensure


### PR DESCRIPTION
Building off @schneems work in #3015 this moves the error handling higher in priority (to fix the handling) and then rather than re-raising uses the `detailed_message` as part of our exception printing producing:

```
bundle exec rspec spec/syntax_spec.rb

While loading ./spec/syntax_spec.rb a `raise SyntaxError` occurred, RSpec will now quit.
Failure/Error: require './spec/syntax.rb'

SyntaxError:
  --> /Users/jon/Code/Scratch/RSpecSandbox/spec/syntax.rb
  Unmatched keyword, missing `end' ?
    1  module Cutlass
    2    class LocalBuildpack
  > 3      private
  > 4      attr_reader :image_name
  > 5      def initialize(directory:)
    8    end
    9  end
  /Users/jon/Code/Scratch/RSpecSandbox/spec/syntax.rb:9: syntax error, unexpected end-of-input (SyntaxError)
# ./spec/syntax_spec.rb:1:in `require'
# ./spec/syntax_spec.rb:1:in `<top (required)>'
# ./.bundle/gems/ruby/3.2.0/gems/bundler-2.3.7/exe/bundler:4:in `load'
# ./.bundle/gems/ruby/3.2.0/gems/bundler-2.3.7/exe/bundler:4:in `<top (required)>'


Finished in 0.00011 seconds (files took 0.04363 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```