### PR TITLE
Remove old regression check

### DIFF
--- a/spec/rspec/core_spec.rb
+++ b/spec/rspec/core_spec.rb
@@ -300,14 +300,6 @@ RSpec.describe RSpec do
     end
   end
 
-  it 'uses only one thread local variable', :run_last do
-    # Trigger features that use thread locals...
-    aggregate_failures { }
-    RSpec.shared_examples_for("something") { }
-
-    expect(Thread.current.keys.map(&:to_s).grep(/rspec/i).count).to eq(1)
-  end
-
   describe "::Core.path_to_executable" do
     it 'returns the absolute location of the exe/rspec file' do
       expect(File.exist? RSpec::Core.path_to_executable).to be(true)
@@ -346,4 +338,3 @@ RSpec.describe RSpec do
     expect(status.exitstatus).to eq(0)
   end
 end
-


### PR DESCRIPTION
rspec/rspec-support#581 makes this fail, but its an old "safety" check and not really needed...