### PR TITLE
Use __send__ instead of send

### DIFF
--- a/lib/rspec/core/output_wrapper.rb
+++ b/lib/rspec/core/output_wrapper.rb
@@ -15,13 +15,13 @@ module RSpec
       end
 
       def method_missing(name, *args, &block)
-        output.send(name, *args, &block)
+        output.__send__(name, *args, &block)
       end
 
       # Redirect calls for IO interface methods
       IO.instance_methods(false).each do |method|
         define_method(method) do |*args, &block|
-          output.send(method, *args, &block)
+          output.__send__(method, *args, &block)
         end
       end
     end

--- a/spec/rspec/core/output_wrapper_spec.rb
+++ b/spec/rspec/core/output_wrapper_spec.rb
@@ -1,12 +1,21 @@
+require 'socket'
+
 module RSpec::Core
   RSpec.describe OutputWrapper do
-    let(:output) { StringIO.new }
+    let(:socket_pair) { UNIXSocket.pair }
+    let(:output) { socket_pair.first }
+    let(:destination) {socket_pair.last}
     let(:wrapper) { OutputWrapper.new(output) }
 
-    it 'redirects calls to the wrapped object' do
+    it 'redirects IO method calls to the wrapped object' do
       wrapper.puts('message')
       wrapper.print('another message')
-      expect(output.string).to eq("message\nanother message").and eq(wrapper.string)
+      expect(destination.recv(32)).to eq("message\nanother message")
+    end
+
+    it 'redirects unknown method calls to the wrapped object' do
+      expect(output).to receive(:addr).with(no_args)
+      wrapper.addr
     end
 
     describe '#output=' do


### PR DESCRIPTION
RSpec::Core::OutputWrapper uses `send` to call class methods on `IO` objects, but some `IO` objects (e.g. `TCPSocket`) redefine `send`.  Use the equivalent  `__send__` method instead.

https://apidock.com/ruby/BasicObject/__send__
