### PR TITLE
Introduce `full_cause_backtrace` configuration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@ Enhancements:
 * Allow specifying custom ordering strategies via `--order`. (Jon Rowe, #3025)
 * Use the improved `syntax_suggest` output for `SyntaxError` when available.
   (Richard Schneeman, #3015, #3026)
+* Add `full_cause_backtrace` config option to print the entire cause  backtrace.
+  (David Taylor, #3046)
 
 Bug fixes:
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -458,6 +458,12 @@ module RSpec
       # return [Integer]
       add_setting :max_displayed_failure_line_count
 
+      # @macro full_cause_backtrace
+      # Display the full backtrace of causing exceptions
+      # (default false).
+      # return [Boolean]
+      add_setting :full_cause_backtrace
+
       # @macro add_setting
       # Format the output for pending examples. Can be set to:
       #  - :full (default) - pending examples appear similarly to failures
@@ -571,6 +577,7 @@ module RSpec
         @derived_metadata_blocks = FilterableItemRepository::QueryOptimized.new(:any?)
         @threadsafe = true
         @max_displayed_failure_line_count = 10
+        @full_cause_backtrace = false
         @world = World::Null
         @shared_context_metadata_behavior = :trigger_inclusion
         @pending_failure_output = :full

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -56,7 +56,12 @@ module RSpec
               end
 
               unless last_cause.backtrace.nil? || last_cause.backtrace.empty?
-                cause << ("  #{backtrace_formatter.format_backtrace(last_cause.backtrace, example.metadata).first}")
+                lines = backtrace_formatter.format_backtrace(last_cause.backtrace, example.metadata)
+                lines = [lines[0]] unless RSpec.configuration.full_cause_backtrace # rubocop:disable Metrics/BlockNesting
+
+                lines.each do |line|
+                  cause << ("  #{line}")
+                end
               end
             end
 


### PR DESCRIPTION
By default, RSpec only prints the first line of a 'caused by' backtrace. This commit introduces a new 'full_cause_backtrace' config option which will enable printing the entire cause backtrace.

This feature has previously been requested and discussed in #3027. The outstanding questions there were:
- whether the config should be a boolean or an enum. Here I have implemented it as a boolean.
- if/how to expose this on the CLI. I have omitted this entirely, but am happy to work on this if it's a pre-requisite for merging