### PR TITLE
Warn about at_exit hooks being skipped if you force quit.

### DIFF
--- a/lib/rspec/core/runner.rb
+++ b/lib/rspec/core/runner.rb
@@ -182,7 +182,11 @@ module RSpec
           exit!(1)
         else
           RSpec.world.wants_to_quit = true
-          $stderr.puts "\nRSpec is shutting down and will print the summary report... Interrupt again to force quit."
+
+          $stderr.puts(
+            "\nRSpec is shutting down and will print the summary report... Interrupt again to force quit " \
+            "(warning: at_exit hooks will be skipped if you force quit)."
+          )
         end
       end
 


### PR DESCRIPTION
If you force quit [issue a double interupt e.g CTRL-C CTRL-C] rspec, `at_exit` hooks will be skipped through our usage of `exit!(1)`, this is intended as an emergency get out [and not a "I'm done" with this run] quit as a normal exit finishes running the current spec and runs our hooks for clenaup, there is some confusion about this, so this is an attempt to improve the message.