### PR TITLE
Add `--only-pending` CLI option

### DIFF
--- a/features/command_line/only_failures.feature
+++ b/features/command_line/only_failures.feature
@@ -110,4 +110,4 @@ Feature: Using the `--only-failures` option
   Scenario: Clear error given when using `--only-failures` without configuring `example_status_persistence_file_path`
     Given I have not configured `example_status_persistence_file_path`
      When I run `rspec --only-failures`
-     Then it should fail with "To use `--only-failures`, you must first set `config.example_status_persistence_file_path`."
+     Then it should fail with "To use `--only-failures` or `--only-pending`, you must first set `config.example_status_persistence_file_path`."

--- a/features/command_line/only_pending.feature
+++ b/features/command_line/only_pending.feature
@@ -1,0 +1,94 @@
+Feature: Using the `--only-pending` option
+
+  The `--only-pending` option filters what examples are run so that only those that failed the last time they ran are executed. To use this option, you first have to configure `config.example_status_persistence_file_path`, which RSpec will use to store the status of each example the last time it ran.
+
+  Either of these options can be combined with another a directory or file name; RSpec will run just the failures from the set of loaded examples.
+
+  Background:
+    Given a file named "spec/spec_helper.rb" with:
+      """ruby
+      RSpec.configure do |c|
+        c.example_status_persistence_file_path = "examples.txt"
+      end
+      """
+    And a file named ".rspec" with:
+      """
+      --require spec_helper
+      --order random
+      --format documentation
+      """
+    And a file named "spec/array_spec.rb" with:
+      """ruby
+      RSpec.describe 'Array' do
+        it "checks for inclusion of 1" do
+          expect([1, 2]).to include(1)
+        end
+
+        it "checks for inclusion of 2", skip: "just not ready for this yet..." do
+          expect([1, 2]).to include(2)
+        end
+
+        it "checks for inclusion of 3" do
+          expect([1, 2]).to include(3) # failure
+        end
+      end
+      """
+    And a file named "spec/string_spec.rb" with:
+      """ruby
+      RSpec.describe 'String' do
+        it "checks for inclusion of 'foo'" do
+          expect("food").to include('foo')
+        end
+
+        it "checks for inclusion of 'bar'" do
+          expect("food").to include('bar') # failure
+        end
+
+        it "checks for inclusion of 'baz'" do
+          expect("bazzy").to include('baz')
+        end
+
+        it "checks for inclusion of 'foobar'" do
+          expect("food").to include('foobar') # failure
+        end
+
+        it "checks for inclusion of 'sum'", skip: "just not ready for this yet..." do
+          expect("lorem ipsum").to include('sum')
+        end
+
+        it "checks for inclusion of 'sit'", skip: "...nor am I ready for this..." do
+          expect("dolor sit").to include('sit')
+        end
+      end
+      """
+    And a file named "spec/passing_spec.rb" with:
+      """ruby
+      puts "Loading passing_spec.rb"
+
+      RSpec.describe "A passing spec" do
+        it "passes" do
+          expect(1).to eq(1)
+        end
+      end
+      """
+    And I have run `rspec` once, resulting in "10 examples, 3 failures, 3 pending"
+
+  Scenario: Running `rspec --only-pending` loads only spec files with failures and runs only the failures
+    When I run `rspec --only-pending`
+    Then the output from "rspec --only-pending" should contain "3 examples, 0 failures, 3 pending"
+     And the output from "rspec --only-pending" should not contain "Loading passing_spec.rb"
+
+  Scenario: Combine `--only-pending` with a file name
+    When I run `rspec spec/array_spec.rb --only-pending`
+    Then the output should contain "1 example, 0 failures, 1 pending"
+    When I run `rspec spec/string_spec.rb --only-pending`
+    Then the output should contain "2 examples, 0 failures, 2 pending"
+
+  Scenario: Running `rspec --only-pending` with spec files that pass doesn't run anything
+    When I run `rspec spec/passing_spec.rb --only-pending`
+    Then it should pass with "0 examples, 0 failures"
+
+  Scenario: Clear error given when using `--only-pending` without configuring `example_status_persistence_file_path`
+    Given I have not configured `example_status_persistence_file_path`
+     When I run `rspec --only-pending`
+     Then it should fail with "To use `--only-failures` or `--only-pending`, you must first set `config.example_status_persistence_file_path`."

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -179,7 +179,7 @@ module RSpec
 
       # @macro define_reader
       # The file path to use for persisting example statuses. Necessary for the
-      # `--only-failures` and `--next-failure` CLI options.
+      # `--only-failures`, `--only-pending`, and `--next-failure` CLI options.
       #
       # @overload example_status_persistence_file_path
       #   @return [String] the file path
@@ -188,14 +188,14 @@ module RSpec
       define_reader :example_status_persistence_file_path
 
       # Sets the file path to use for persisting example statuses. Necessary for the
-      # `--only-failures` and `--next-failure` CLI options.
+      # `--only-failures`, `--only-pending`, and `--next-failure` CLI options.
       def example_status_persistence_file_path=(value)
         @example_status_persistence_file_path = value
         clear_values_derived_from_example_status_persistence_file_path
       end
 
       # @macro define_reader
-      # Indicates if the `--only-failures` (or `--next-failure`) flag is being used.
+      # Indicates if the `--only-failures`, `--only-pending` (or `--next-failure`) flag is being used.
       define_reader :only_failures
       alias_method :only_failures?, :only_failures
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -195,13 +195,18 @@ module RSpec
       end
 
       # @macro define_reader
-      # Indicates if the `--only-failures`, `--only-pending` (or `--next-failure`) flag is being used.
+      # Indicates if the `--only-failures` (or `--next-failure`) flag is being used.
       define_reader :only_failures
       alias_method :only_failures?, :only_failures
 
+      # @macro define_reader
+      # Indicates if the `--only-pending` flag is being used.
+      define_reader :only_pending
+      alias_method :only_pending?, :only_pending
+
       # @private
-      def only_failures_but_not_configured?
-        only_failures? && !example_status_persistence_file_path
+      def only_flag_but_not_configured?
+        (only_failures? || only_pending?) && !example_status_persistence_file_path
       end
 
       # @macro define_reader

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -89,7 +89,7 @@ module RSpec
 
         # `files_or_directories_to_run` uses `default_path` so it must be
         # set before it.
-        :default_path, :only_failures,
+        :default_path, :only_failures, :only_pending,
 
         # These must be set before `requires` to support checking
         # `config.files_to_run` from within `spec_helper.rb` when a

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -217,6 +217,10 @@ FILTERING
           options[:order] ||= 'defined'
         end
 
+        parser.on('--only-pending', "Filter to just the examples that were pending the last time they ran.") do
+          configure_only_pending(options)
+        end
+
         parser.on('-P', '--pattern PATTERN', 'Load files matching pattern (default: "spec/**/*_spec.rb").') do |o|
           if options[:pattern]
             options[:pattern] += ',' + o
@@ -318,6 +322,11 @@ FILTERING
     def configure_only_failures(options)
       options[:only_failures] = true
       add_tag_filter(options, :inclusion_filter, :last_run_status, 'failed')
+    end
+
+    def configure_only_pending(options)
+      options[:only_pending] = true
+      add_tag_filter(options, :inclusion_filter, :last_run_status, 'pending')
     end
   end
 end

--- a/lib/rspec/core/option_parser.rb
+++ b/lib/rspec/core/option_parser.rb
@@ -207,18 +207,18 @@ module RSpec::Core
 FILTERING
 
         parser.on('--only-failures', "Filter to just the examples that failed the last time they ran.") do
-          configure_only_failures(options)
+          configure_only(options, :only_failures, 'failed')
         end
 
         parser.on("-n", "--next-failure", "Apply `--only-failures` and abort after one failure.",
                   "  (Equivalent to `--only-failures --fail-fast --order defined`)") do
-          configure_only_failures(options)
+          configure_only(options, :only_failures, 'failed')
           set_fail_fast(options, 1)
           options[:order] ||= 'defined'
         end
 
         parser.on('--only-pending', "Filter to just the examples that were pending the last time they ran.") do
-          configure_only_pending(options)
+          configure_only(options, :only_pending, 'pending')
         end
 
         parser.on('-P', '--pattern PATTERN', 'Load files matching pattern (default: "spec/**/*_spec.rb").') do |o|
@@ -319,14 +319,9 @@ FILTERING
       options[:fail_fast] = value
     end
 
-    def configure_only_failures(options)
-      options[:only_failures] = true
-      add_tag_filter(options, :inclusion_filter, :last_run_status, 'failed')
-    end
-
-    def configure_only_pending(options)
-      options[:only_pending] = true
-      add_tag_filter(options, :inclusion_filter, :last_run_status, 'pending')
+    def configure_only(options, type, value)
+      options[type] = true
+      add_tag_filter(options, :inclusion_filter, :last_run_status, value)
     end
   end
 end

--- a/lib/rspec/core/project_initializer/spec/spec_helper.rb
+++ b/lib/rspec/core/project_initializer/spec/spec_helper.rb
@@ -55,8 +55,8 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
 
   # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
+  # the `--only-failures`, `--only-pending`, and `--next-failure` CLI options.
+  # We recommend you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -183,7 +183,7 @@ module RSpec
           end
         end
 
-        if @configuration.run_all_when_everything_filtered? && example_count.zero? && !@configuration.only_failures?
+        if @configuration.run_all_when_everything_filtered? && example_count.zero? && !@configuration.only_flag_set?
           report_filter_message("#{everything_filtered_message}; ignoring #{inclusion_filter.description}")
           filtered_examples.clear
           inclusion_filter.clear
@@ -250,13 +250,21 @@ module RSpec
       end
 
       def fail_if_config_and_cli_options_invalid
-        return unless @configuration.only_flag_but_not_configured?
+        if @configuration.only_flag_but_not_configured?
+          reporter.abort_with(
+            "\nTo use `--only-failures` or `--only-pending`, you must first set " \
+            "`config.example_status_persistence_file_path`.",
+            1 # exit code
+          )
+        end
 
-        reporter.abort_with(
-          "\nTo use `--only-failures` or `--only-pending`, you must first set " \
-          "`config.example_status_persistence_file_path`.",
-          1 # exit code
-        )
+        if @configuration.multiple_only_flags?
+          reporter.abort_with(
+            "\nYou cannot use `--only-failures` and `--only-pending` together. " \
+            "Please set one or the other.",
+            1 # exit code
+          )
+        end
       end
 
       # @private

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -250,7 +250,7 @@ module RSpec
       end
 
       def fail_if_config_and_cli_options_invalid
-        return unless @configuration.only_failures_but_not_configured?
+        return unless @configuration.only_flag_but_not_configured?
 
         reporter.abort_with(
           "\nTo use `--only-failures` or `--only-pending`, you must first set " \

--- a/lib/rspec/core/world.rb
+++ b/lib/rspec/core/world.rb
@@ -253,7 +253,7 @@ module RSpec
         return unless @configuration.only_failures_but_not_configured?
 
         reporter.abort_with(
-          "\nTo use `--only-failures`, you must first set " \
+          "\nTo use `--only-failures` or `--only-pending`, you must first set " \
           "`config.example_status_persistence_file_path`.",
           1 # exit code
         )

--- a/spec/rspec/core/configuration/only_pending_support_spec.rb
+++ b/spec/rspec/core/configuration/only_pending_support_spec.rb
@@ -1,0 +1,235 @@
+module RSpec::Core
+  RSpec.describe Configuration, "--only-pending support" do
+    let(:config) { Configuration.new }
+
+    def simulate_persisted_examples(*examples)
+      config.example_status_persistence_file_path = "examples.txt"
+      persister = class_double(ExampleStatusPersister).as_stubbed_const
+
+      allow(persister).to receive(:load_from).with("examples.txt").and_return(examples.flatten)
+    end
+
+    describe "#last_run_statuses" do
+      def last_run_statuses
+        config.last_run_statuses
+      end
+
+      context "when `example_status_persistence_file_path` is configured" do
+        before do
+          simulate_persisted_examples(
+            { :example_id => "id_1", :status => "passed"  },
+            { :example_id => "id_2", :status => "failed"  },
+            { :example_id => "id_3", :status => "pending" }
+          )
+        end
+
+        it 'gets the last run statuses from the ExampleStatusPersister' do
+          expect(last_run_statuses).to eq(
+            'id_1' => 'passed', 'id_2' => 'failed', 'id_3' => 'pending'
+          )
+        end
+
+        it 'returns a memoized value' do
+          expect(last_run_statuses).to be(last_run_statuses)
+        end
+
+        specify 'the hash returns `unknown` for unknown example ids for consistency' do
+          expect(last_run_statuses["foo"]).to eq(Configuration::UNKNOWN_STATUS)
+          expect(last_run_statuses["bar"]).to eq(Configuration::UNKNOWN_STATUS)
+        end
+      end
+
+      context "when `example_status_persistence_file_path` is not configured" do
+        before do
+          config.example_status_persistence_file_path = nil
+        end
+
+        it 'returns a memoized value' do
+          expect(last_run_statuses).to be(last_run_statuses)
+        end
+
+        it 'returns a blank hash without attempting to load the persisted statuses' do
+          persister = class_double(ExampleStatusPersister).as_stubbed_const
+          expect(persister).not_to receive(:load_from)
+
+          expect(last_run_statuses).to eq({})
+        end
+
+        specify 'the hash returns `unknown` for all ids for consistency' do
+          expect(last_run_statuses["foo"]).to eq(Configuration::UNKNOWN_STATUS)
+          expect(last_run_statuses["bar"]).to eq(Configuration::UNKNOWN_STATUS)
+        end
+      end
+
+      def allows_value_to_change_when_updated
+        simulate_persisted_examples(
+          { :example_id => "id_1", :status => "passed"  },
+          { :example_id => "id_2", :status => "failed"  },
+          { :example_id => "id_3", :status => "pending" }
+        )
+
+        config.example_status_persistence_file_path = nil
+
+        expect {
+          yield
+        }.to change { last_run_statuses }.to('id_1' => 'passed', 'id_2' => 'failed', 'id_3' => 'pending')
+      end
+
+      it 'allows the value to be updated when `example_status_persistence_file_path` is set after first access' do
+        allows_value_to_change_when_updated do
+          config.example_status_persistence_file_path = "examples.txt"
+        end
+      end
+
+      it 'allows the value to be updated when `example_status_persistence_file_path` is forced after first access' do
+        allows_value_to_change_when_updated do
+          config.force(:example_status_persistence_file_path => "examples.txt")
+        end
+      end
+    end
+
+    describe "#spec_files_with_pending" do
+      def spec_files_with_pending
+        config.spec_files_with_pending
+      end
+
+      context "when `example_status_persistence_file_path` is configured" do
+        it 'returns a memoized array of unique spec files that contain failed examples' do
+          simulate_persisted_examples(
+            { :example_id => "./spec_1.rb[1:1]", :status => "failed"  },
+            { :example_id => "./spec_1.rb[1:2]", :status => "pending" },
+            { :example_id => "./spec_1.rb[1:3]", :status => "failed"  },
+            { :example_id => "./spec_2.rb[1:2]", :status => "passed"  },
+            { :example_id => "./spec_3.rb[1:2]", :status => "pending" },
+            { :example_id => "./spec_4.rb[1:2]", :status => "unknown" },
+            { :example_id => "./spec_5.rb[1:2]", :status => "failed"  }
+          )
+
+          expect(spec_files_with_pending).to(
+            be_an(Array) &
+            be(spec_files_with_pending) &
+            contain_exactly("./spec_1.rb", "./spec_3.rb")
+          )
+        end
+      end
+
+      context 'when the file at `example_status_persistence_file_path` has corrupted `status` values' do
+        before do
+          simulate_persisted_examples(
+            { :example_id => "./spec_1.rb[1:1]" },
+            { :example_id => "./spec_1.rb[1:2]", :status => ""  },
+            { :example_id => "./spec_2.rb[1:2]", :status => nil },
+            { :example_id => "./spec_3.rb[1:2]", :status => "wrong" },
+            { :example_id => "./spec_4.rb[1:2]", :status => "unknown" },
+            { :example_id => "./spec_5.rb[1:2]", :status => "failed" },
+            { :example_id => "./spec_6.rb[1:2]", :status => "pending" },
+            :example_id => "./spec_7.rb[1:2]", :status => "passed"
+          )
+        end
+
+        it 'defaults invalid statuses to unknown' do
+          expect(spec_files_with_pending).to(
+            be_an(Array) &
+            contain_exactly("./spec_6.rb")
+          )
+          # Check that each example has the correct status
+          expect(config.last_run_statuses).to eq(
+            './spec_1.rb[1:1]' => 'unknown',
+            './spec_1.rb[1:2]' => 'unknown',
+            './spec_2.rb[1:2]' => 'unknown',
+            './spec_3.rb[1:2]' => 'unknown',
+            './spec_4.rb[1:2]' => 'unknown',
+            './spec_5.rb[1:2]' => 'failed',
+            './spec_6.rb[1:2]' => 'pending',
+            './spec_7.rb[1:2]' => 'passed'
+          )
+        end
+      end
+
+      context "when `example_status_persistence_file_path` is not configured" do
+        it "returns a memoized blank array" do
+          config.example_status_persistence_file_path = nil
+
+          expect(spec_files_with_pending).to(
+            eq([]) & be(spec_files_with_pending)
+          )
+        end
+      end
+
+      def allows_value_to_change_when_updated
+        simulate_persisted_examples({ :example_id => "./spec_1.rb[1:1]", :status => "pending" })
+
+        config.example_status_persistence_file_path = nil
+
+        expect {
+          yield
+        }.to change { spec_files_with_pending }.to(["./spec_1.rb"])
+      end
+
+      it 'allows the value to be updated when `example_status_persistence_file_path` is set after first access' do
+        allows_value_to_change_when_updated do
+          config.example_status_persistence_file_path = "examples.txt"
+        end
+      end
+
+      it 'allows the value to be updated when `example_status_persistence_file_path` is forced after first access' do
+        allows_value_to_change_when_updated do
+          config.force(:example_status_persistence_file_path => "examples.txt")
+        end
+      end
+    end
+
+    describe "#files_to_run, when `only_pending` is set" do
+      around do |ex|
+        handle_current_dir_change do
+          Dir.chdir("spec/rspec/core", &ex)
+        end
+      end
+
+      let(:default_path) { "resources" }
+      let(:files_with_pending) { ["./resources/a_spec.rb"] }
+      let(:files_loaded_via_default_path) do
+        configuration = Configuration.new
+        configuration.default_path = default_path
+        configuration.files_or_directories_to_run = []
+        configuration.files_to_run
+      end
+
+      before do
+        expect(files_loaded_via_default_path).not_to eq(files_with_pending)
+        config.default_path = default_path
+
+        simulate_persisted_examples(files_with_pending.map do |file|
+          { :example_id => "#{file}[1:1]", :status => "pending" }
+        end)
+
+        config.force(:only_pending => true)
+      end
+
+      context "and no explicit paths have been set" do
+        it 'loads only the files that have pending' do
+          config.files_or_directories_to_run = []
+          expect(config.files_to_run).to eq(files_with_pending)
+        end
+
+        it 'loads the default path if there are no files with pending' do
+          simulate_persisted_examples([])
+          config.files_or_directories_to_run = []
+          expect(config.files_to_run).to eq(files_loaded_via_default_path)
+        end
+      end
+
+      context "and a path has been set" do
+        it "loads the intersection of files matching the path and files with pending" do
+          config.files_or_directories_to_run = ["resources"]
+          expect(config.files_to_run).to eq(files_with_pending)
+        end
+
+        it "loads all files matching the path when there are no intersecting files" do
+          config.files_or_directories_to_run = ["resources/acceptance"]
+          expect(config.files_to_run).to contain_files("resources/acceptance/foo_spec.rb")
+        end
+      end
+    end
+  end
+end

--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -124,6 +124,13 @@ RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :
       opts.configure(config)
     end
 
+    it 'configures `only_pending` before `files_or_directories_to_run` since it affects loaded files' do
+      opts = config_options_object(*%w[ --only-pending ])
+      expect(config).to receive(:force).with({:only_pending => true}).ordered
+      expect(config).to receive(:files_or_directories_to_run=).ordered
+      opts.configure(config)
+    end
+
     { "pattern" => :pattern, "exclude-pattern" => :exclude_pattern }.each do |flag, attr|
       it "sets #{attr} before `requires` so users can check `files_to_run` in a `spec_helper` loaded by `--require`" do
         opts = config_options_object(*%W[--require spec_helper --#{flag} **/*.spec])

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -206,6 +206,15 @@ module RSpec::Core
       end
     end
 
+    describe "--only-pending" do
+      it 'is equivalent to `--tag last_run_status:failed`' do
+        tag = Parser.parse(%w[ --tag last_run_status:pending ])
+        only_failures = Parser.parse(%w[ --only-pending ])
+
+        expect(only_failures).to include(tag)
+      end
+    end
+
     %w[--example -e].each do |option|
       describe option do
         it "escapes the arg" do

--- a/spec/rspec/core/option_parser_spec.rb
+++ b/spec/rspec/core/option_parser_spec.rb
@@ -207,7 +207,7 @@ module RSpec::Core
     end
 
     describe "--only-pending" do
-      it 'is equivalent to `--tag last_run_status:failed`' do
+      it 'is equivalent to `--tag last_run_status:pending`' do
         tag = Parser.parse(%w[ --tag last_run_status:pending ])
         only_failures = Parser.parse(%w[ --only-pending ])
 

--- a/spec/rspec/core/world_spec.rb
+++ b/spec/rspec/core/world_spec.rb
@@ -267,6 +267,59 @@ module RSpec::Core
         end
       end
 
+      context "when --only-pending is passed" do
+        before { configuration.force(:only_pending => true) }
+
+        context "and all examples are filtered out" do
+          before do
+            configuration.filter_run_including :foo => 'bar'
+          end
+
+          it 'will ignore run_all_when_everything_filtered' do
+            configuration.run_all_when_everything_filtered = true
+            expect(world.filtered_examples).to_not receive(:clear)
+            expect(world.inclusion_filter).to_not receive(:clear)
+            world.announce_filters
+          end
+        end
+
+        context "and `example_status_persistence_file_path` is not configured" do
+          it 'aborts with a message explaining the config option must be set first' do
+            configuration.example_status_persistence_file_path = nil
+            world.announce_filters
+            expect(reporter).to have_received(:abort_with).with(/example_status_persistence_file_path/, 1)
+          end
+        end
+
+        context "and `example_status_persistence_file_path` is configured" do
+          it 'does not abort' do
+            configuration.example_status_persistence_file_path = "foo.txt"
+            world.announce_filters
+            expect(reporter).not_to have_received(:abort_with)
+          end
+        end
+      end
+
+      context "when --only-pending is not passed" do
+        before { expect(configuration.only_pending?).not_to eq true }
+
+        context "and `example_status_persistence_file_path` is not configured" do
+          it 'does not abort' do
+            configuration.example_status_persistence_file_path = nil
+            world.announce_filters
+            expect(reporter).not_to have_received(:abort_with)
+          end
+        end
+
+        context "and `example_status_persistence_file_path` is configured" do
+          it 'does not abort' do
+            configuration.example_status_persistence_file_path = "foo.txt"
+            world.announce_filters
+            expect(reporter).not_to have_received(:abort_with)
+          end
+        end
+      end
+
       context "with no examples" do
         before { allow(world).to receive(:example_count) { 0 } }
 


### PR DESCRIPTION
As requested on issue [#3066](https://github.com/rspec/rspec/issues/54), this work adds the CLI option filter `--only-pending`.  This is similar to `--only-failures`.  

If `example_status_persistence_file_path` is not configured, it will fail with a message.  

If both this new flag and `--only-failures` are set, it will fail with a message.