### PR TITLE
Modified example not to recognize first non string object of argument as description

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -144,7 +144,8 @@ module RSpec
       #
       def self.define_example_method(name, extra_options={})
         idempotently_define_singleton_method(name) do |*all_args, &block|
-          desc, *args = *all_args
+          desc = all_args.shift if all_args.first.is_a? String
+          args = all_args
 
           options = Metadata.build_hash_from(args)
           options.update(:skip => RSpec::Core::Pending::NOT_YET_IMPLEMENTED) unless block


### PR DESCRIPTION
If this patch is unnecessary and non string object is acceptable for description, I'll close this PR.
But I think it is not and I created this PR because with this patch, RSpec seems better behavior.

**a case of rspec below**

```ruby
context do
  it do
    # without description nor option
    expect(true).to eq true
  end

  it 'only description' do
    expect(true).to eq true
  end

  it :pending do
    # Only pending option without reason
    expect(true).to eq false
  end

  it pending: 'only pending option' do
    expect(true).to eq false   
  end  

  it 'description with option', pending: 'some reason' do
    expect(true).to eq false
  end
end
```

**before** 

Two examples failed because pending option was recognized as description and invalid.

```
$ rspec test.rb --format documentation


  is expected to eq true
  only description
  pending (FAILED - 1)
  {:pending=>"only pending option"} (FAILED - 2)
  description with option (PENDING: some reason)

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) description with option
     # some reason
     Failure/Error: expect(true).to eq false

       expected: false
            got: true

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -false
       +true

     # ./test.rb:21:in `block (2 levels) in <top (required)>'

Failures:

  1) pending
     Failure/Error: expect(true).to eq false

       expected: false
            got: true

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -false
       +true

     # ./test.rb:13:in `block (2 levels) in <top (required)>'

  2) {:pending=>"only pending option"}
     Failure/Error: expect(true).to eq false

       expected: false
            got: true

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -false
       +true

     # ./test.rb:17:in `block (2 levels) in <top (required)>'

Finished in 0.01111 seconds (files took 0.06421 seconds to load)
5 examples, 2 failures, 1 pending

Failed examples:

rspec ./test.rb:11 # pending
rspec ./test.rb:16 # {:pending=>"only pending option"}
```

**after**

Every pending option is valid because example recognized description only if the first argument is string object.

```
$ rspec test.rb --format documentation


  is expected to eq true
  only description
  is expected to eq false (PENDING: No reason given)
  is expected to eq false (PENDING: only pending option)
  description with option (PENDING: some reason)

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) is expected to eq false
     # No reason given
     Failure/Error: expect(true).to eq false

       expected: false
            got: true

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -false
       +true

     # ./test.rb:13:in `block (2 levels) in <top (required)>'

  2) is expected to eq false
     # only pending option
     Failure/Error: expect(true).to eq false

       expected: false
            got: true

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -false
       +true

     # ./test.rb:17:in `block (2 levels) in <top (required)>'

  3) description with option
     # some reason
     Failure/Error: expect(true).to eq false

       expected: false
            got: true

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -false
       +true

     # ./test.rb:21:in `block (2 levels) in <top (required)>'

Finished in 0.01149 seconds (files took 0.07832 seconds to load)
5 examples, 0 failures, 3 pending


```
