### PR TITLE
Add deprecate warning when example doc string is not a string object

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -146,6 +146,11 @@ module RSpec
         idempotently_define_singleton_method(name) do |*all_args, &block|
           desc, *args = *all_args
 
+          unless NilClass === desc || String === desc
+            RSpec.deprecate("#{desc.class} object `#{desc.inspect}` as example doc string",
+                            :replacement => 'a string')
+          end
+
           options = Metadata.build_hash_from(args)
           options.update(:skip => RSpec::Core::Pending::NOT_YET_IMPLEMENTED) unless block
           options.update(extra_options)

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1257,7 +1257,28 @@ module RSpec::Core
         expect(group.examples[1].description).to eq('should 2')
         expect(group.examples[2].description).to eq('should 3')
       end
+    end
 
+    describe "deprecation warnings for example" do
+      it "does not output deprecation warning when description is a string" do
+        expect_no_deprecation
+        RSpec.describe.it('hoge')
+      end
+
+      it "does not output deprecation warning when description is nil" do
+        expect_no_deprecation
+        RSpec.describe.it
+      end
+
+      it "outputs deprecation warining when description is a symbol" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Symbol object `:symbol` as example doc string/)
+        RSpec.describe.it(:symbol)
+      end
+
+      it "outputs deprication warning when description is a hash" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Hash object `{"foo"=>"bar"}` as example doc string/)
+        RSpec.describe.it({ "foo" => "bar" })
+      end
     end
 
     describe Object, "describing nested example_groups", :little_less_nested => 'yep' do


### PR DESCRIPTION
Preparing for upcoming new specification mentioned rspec/rspec#40 , added deprecated warning when example doc string is not a string object

### What is changed

When execute rspec below

```ruby
context do
  it :pending do
    # Only pending option without reason
    expect(true).to eq false
  end

  it pending: 'only pending option' do
    expect(true).to eq false   
  end  

  it 'description with option', pending: 'some reason' do
    expect(true).to eq false
  end
end
```

Output deprecate warning like

```
Deprecation Warnings:

Hash object `{:pending=>"only pending option"}` as example doc string is deprecated. Use a string instead. Called from /home/username/test.rb:7:in `block in <top (required)>'.

Symbol object `:pending` as example doc string is deprecated. Use a string instead. Called from /home/username/test.rb:2:in `block in <top (required)>'.
```

<details>
<summary>Entire output is here</summary>

```
$ bundle exec rspec test.rb --format documentation


  pending (FAILED - 1)
  {:pending=>"only pending option"} (FAILED - 2)
  description with option (PENDING: some reason)

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) description with option
     # some reason
     Failure/Error: expect(true).to eq false
     
       expected: false
            got: true
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -false
       +true
       
     # ./test.rb:12:in `block (2 levels) in <top (required)>'

Failures:

  1) pending
     Failure/Error: expect(true).to eq false
     
       expected: false
            got: true
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -false
       +true
       
     # ./test.rb:4:in `block (2 levels) in <top (required)>'

  2) {:pending=>"only pending option"}
     Failure/Error: expect(true).to eq false
     
       expected: false
            got: true
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -false
       +true
       
     # ./test.rb:8:in `block (2 levels) in <top (required)>'

Deprecation Warnings:

Hash object `{:pending=>"only pending option"}` as example doc string is deprecated. Use a string instead. Called from /home/username/test.rb:7:in `block in <top (required)>'.

Symbol object `:pending` as example doc string is deprecated. Use a string instead. Called from /home/username/test.rb:2:in `block in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

2 deprecation warnings total

Finished in 0.01384 seconds (files took 0.08949 seconds to load)
3 examples, 2 failures, 1 pending

Failed examples:

rspec ./test.rb:2 # pending
rspec ./test.rb:7 # {:pending=>"only pending option"}

```

</details>
