### PR TITLE
Raise ArgumentError when doc_string is neither string nor nil

### DIFF
--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -147,7 +147,8 @@ module RSpec
           desc, *args = *all_args
 
           unless NilClass === desc || String === desc
-            RSpec.warning "`#{desc.inspect}` is used as example doc string. Use a string instead"
+            raise ArgumentError,
+              "`#{desc.inspect}` is not acceptable for doc_string.\nit must be a string."
           end
 
           options = Metadata.build_hash_from(args)

--- a/lib/rspec/core/example_group.rb
+++ b/lib/rspec/core/example_group.rb
@@ -147,8 +147,7 @@ module RSpec
           desc, *args = *all_args
 
           unless NilClass === desc || String === desc
-            raise ArgumentError,
-              "`#{desc.inspect}` is not acceptable for doc_string.\nit must be a string."
+            raise ArgumentError, "Examples must be described with a string, got: `#{desc.inspect}`"
           end
 
           options = Metadata.build_hash_from(args)

--- a/spec/rspec/core/example_group_spec.rb
+++ b/spec/rspec/core/example_group_spec.rb
@@ -1267,35 +1267,31 @@ module RSpec::Core
       let(:group) { RSpec.describe }
 
       it "accepts a string for an example doc string" do
-        expect { group.it('MyClass') { } }.not_to output.to_stderr
+        expect { group.it('MyClass') { } }.not_to raise_error
       end
 
       it "accepts example without a doc string" do
-        expect { group.it { } }.not_to output.to_stderr
+        expect { group.it { } }.not_to raise_error
       end
 
-      it "emits a warning when a Class is used as an example doc string" do
+      it "raises ArgumentError when a Class is used as an example doc string" do
         expect { group.it(Numeric) { } }
-          .to output(/`Numeric` is used as example doc string. Use a string instead/)
-          .to_stderr
+          .to raise_error(ArgumentError, /`Numeric` is not acceptable for doc_string.\nit must be a string./)
       end
 
-      it "emits a warning when a Module is used as an example doc string" do
+      it "raises ArgumentError when a Module is used as an example doc string" do
         expect { group.it(RSpec) { } }
-          .to output(/`RSpec` is used as example doc string. Use a string instead/)
-          .to_stderr
+          .to raise_error(ArgumentError, /`RSpec` is not acceptable for doc_string.\nit must be a string./)
       end
 
-      it "emits a warning when a Symbol is used as an example doc string" do
+      it "raises ArgumentError when a Symbol is used as an example doc string" do
         expect { group.it(:foo) { } }
-          .to output(/`:foo` is used as example doc string. Use a string instead/)
-          .to_stderr
+          .to raise_error(ArgumentError, /`:foo` is not acceptable for doc_string.\nit must be a string./)
       end
 
-      it "emits a warning when a Hash is used as an example doc string" do
+      it "raises ArgumentError when a Hash is used as an example doc string" do
         expect { group.it(foo: :bar) { } }
-          .to output(/`{:foo=>:bar}` is used as example doc string. Use a string instead/)
-          .to_stderr
+          .to raise_error(ArgumentError, /`{:foo=>:bar}` is not acceptable for doc_string.\nit must be a string./)
       end
     end
 


### PR DESCRIPTION
Related issue: #3072 

To keep the first argument a string object, it raises ArgumentError when non string object were given as doc_string.

```
ArgumentError:
  `:pending` is not acceptable for doc_string.
  it must be a string.
```

Currently example recognize its first argument as doc_string even if it is not a string object.
For example, 

```
  it :pending do
    expect(true).to eq false
  end
```

In the example above, `:pending` does not work and fails like below  

```
  1) pending
     Failure/Error: expect(true).to eq false
     
       expected: false
            got: true
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -false
       +true
       
     # ./test.rb:4:in `block (2 levels) in <top (required)>'
```

I suppose that if this PR is beneficial for RSpec, this breaking change will be released for upcoming new major version 4.0 or later. For preparing the change I created another PR #3073 to output deprecation warning in the same condition.