### PR TITLE
Allow config for rerun location as line number for shared or nested examples

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -477,6 +477,12 @@ module RSpec
         @pending_failure_output = mode
       end
 
+      # @macro location_rerun_failed_example_uses_line_number
+      # Display the line number (`my_spec.rb:10`), as opposed to the example id (`my_spec.rb[1:1:1]`)
+      # for shared or nested examples (defaults to `false`).
+      # return [Boolean]
+      add_setting :location_rerun_failed_example_uses_line_number
+
       # Determines which bisect runner implementation gets used to run subsets
       # of the suite during a bisection. Your choices are:
       #
@@ -580,6 +586,7 @@ module RSpec
         @world = World::Null
         @shared_context_metadata_behavior = :trigger_inclusion
         @pending_failure_output = :full
+        @location_rerun_failed_example_uses_line_number = false
 
         define_built_in_hooks
       end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -477,11 +477,11 @@ module RSpec
         @pending_failure_output = mode
       end
 
-      # @macro location_rerun_failed_example_uses_line_number
+      # @macro location_rerun_uses_line_number
       # Display the line number (`my_spec.rb:10`), as opposed to the example id (`my_spec.rb[1:1:1]`)
       # for shared or nested examples (defaults to `false`).
       # return [Boolean]
-      add_setting :location_rerun_failed_example_uses_line_number
+      add_setting :location_rerun_uses_line_number
 
       # Determines which bisect runner implementation gets used to run subsets
       # of the suite during a bisection. Your choices are:
@@ -586,7 +586,7 @@ module RSpec
         @world = World::Null
         @shared_context_metadata_behavior = :trigger_inclusion
         @pending_failure_output = :full
-        @location_rerun_failed_example_uses_line_number = false
+        @location_rerun_uses_line_number = false
 
         define_built_in_hooks
       end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -477,11 +477,11 @@ module RSpec
         @pending_failure_output = mode
       end
 
-      # @macro use_line_number_for_failed_spec_location_rerun
+      # @macro force_line_number_for_spec_rerun
       # Display the line number (`my_spec.rb:10`), as opposed to the example id (`my_spec.rb[1:1:1]`)
       # for shared or nested examples (defaults to `false`).
       # return [Boolean]
-      add_setting :use_line_number_for_failed_spec_location_rerun
+      add_setting :force_line_number_for_spec_rerun
 
       # Determines which bisect runner implementation gets used to run subsets
       # of the suite during a bisection. Your choices are:
@@ -586,7 +586,7 @@ module RSpec
         @world = World::Null
         @shared_context_metadata_behavior = :trigger_inclusion
         @pending_failure_output = :full
-        @use_line_number_for_failed_spec_location_rerun = false
+        @force_line_number_for_spec_rerun = false
 
         define_built_in_hooks
       end

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -477,11 +477,11 @@ module RSpec
         @pending_failure_output = mode
       end
 
-      # @macro location_rerun_uses_line_number
+      # @macro use_line_number_for_failed_spec_location_rerun
       # Display the line number (`my_spec.rb:10`), as opposed to the example id (`my_spec.rb[1:1:1]`)
       # for shared or nested examples (defaults to `false`).
       # return [Boolean]
-      add_setting :location_rerun_uses_line_number
+      add_setting :use_line_number_for_failed_spec_location_rerun
 
       # Determines which bisect runner implementation gets used to run subsets
       # of the suite during a bisection. Your choices are:
@@ -586,7 +586,7 @@ module RSpec
         @world = World::Null
         @shared_context_metadata_behavior = :trigger_inclusion
         @pending_failure_output = :full
-        @location_rerun_uses_line_number = false
+        @use_line_number_for_failed_spec_location_rerun = false
 
         define_built_in_hooks
       end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -402,7 +402,7 @@ module RSpec::Core
       def rerun_argument_for(example)
         location = example.location_rerun_argument
 
-        return location if RSpec.configuration.location_rerun_failed_example_uses_line_number
+        return location if RSpec.configuration.location_rerun_uses_line_number
         return location unless duplicate_rerun_locations.include?(location)
         conditionally_quote(example.id)
       end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -401,6 +401,8 @@ module RSpec::Core
 
       def rerun_argument_for(example)
         location = example.location_rerun_argument
+
+        return location if RSpec.configuration.location_rerun_failed_example_uses_line_number
         return location unless duplicate_rerun_locations.include?(location)
         conditionally_quote(example.id)
       end

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -402,8 +402,8 @@ module RSpec::Core
       def rerun_argument_for(example)
         location = example.location_rerun_argument
 
-        return location if RSpec.configuration.location_rerun_uses_line_number
         return location unless duplicate_rerun_locations.include?(location)
+        return location if RSpec.configuration.location_rerun_uses_line_number
         conditionally_quote(example.id)
       end
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -403,7 +403,7 @@ module RSpec::Core
         location = example.location_rerun_argument
 
         return location unless duplicate_rerun_locations.include?(location)
-        return location if RSpec.configuration.use_line_number_for_failed_spec_location_rerun
+        return location if RSpec.configuration.force_line_number_for_spec_rerun
         conditionally_quote(example.id)
       end
 

--- a/lib/rspec/core/notifications.rb
+++ b/lib/rspec/core/notifications.rb
@@ -403,7 +403,7 @@ module RSpec::Core
         location = example.location_rerun_argument
 
         return location unless duplicate_rerun_locations.include?(location)
-        return location if RSpec.configuration.location_rerun_uses_line_number
+        return location if RSpec.configuration.use_line_number_for_failed_spec_location_rerun
         conditionally_quote(example.id)
       end
 

--- a/spec/integration/bisect_runners_spec.rb
+++ b/spec/integration/bisect_runners_spec.rb
@@ -10,17 +10,6 @@ module RSpec::Core
 
     let(:shell_command) { Bisect::ShellCommand.new([]) }
 
-    def with_runner(&block)
-      handle_current_dir_change do
-        cd '.' do
-          options = ConfigurationOptions.new(shell_command.original_cli_args)
-          runner = Runner.new(options)
-          output = StringIO.new
-          runner.configure(output, output)
-          described_class.start(shell_command, runner, &block)
-        end
-      end
-    end
 
     it 'runs the specs in an isolated environment and reports the results' do
       RSpec.configuration.formatter = 'progress'

--- a/spec/integration/bisect_runners_spec.rb
+++ b/spec/integration/bisect_runners_spec.rb
@@ -10,6 +10,17 @@ module RSpec::Core
 
     let(:shell_command) { Bisect::ShellCommand.new([]) }
 
+    def with_runner(&block)
+      handle_current_dir_change do
+        cd '.' do
+          options = ConfigurationOptions.new(shell_command.original_cli_args)
+          runner = Runner.new(options)
+          output = StringIO.new
+          runner.configure(output, output)
+          described_class.start(shell_command, runner, &block)
+        end
+      end
+    end
 
     it 'runs the specs in an isolated environment and reports the results' do
       RSpec.configuration.formatter = 'progress'

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe 'Failed spec rerun location' do
     expect(last_cmd_stdout).to include("/failing_spec.rb[1:2:1:1]")
   end
 
-  context "when config.location_rerun_failed_example_uses_line_number is set to true" do
+  context "when config.location_rerun_uses_line_number is set to true" do
     before do
-      RSpec.configuration.location_rerun_failed_example_uses_line_number = true
+      RSpec.configuration.location_rerun_uses_line_number = true
     end
 
     it 'prints the line numbers' do

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -2,7 +2,6 @@ require 'support/aruba_support'
 
 RSpec.describe 'Failed spec rerun location' do
   include RSpecHelpers
-
   include_context "aruba support"
 
   before do

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Failed spec rerun location' do
 
   end
 
-  context "when config.location_rerun_uses_line_number is set to false" do
+  context "when config.use_line_number_for_failed_spec_location_rerun is set to false" do
     it 'prints the example id of the failed assertion' do
       run_command("#{Dir.pwd}/tmp/aruba/local_shared_examples_spec.rb")
 
@@ -95,9 +95,9 @@ rspec './non_local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context beh
     end
   end
 
-  context "when config.location_rerun_uses_line_number is set to true" do
+  context "when config.use_line_number_for_failed_spec_location_rerun is set to true" do
     before do
-      allow(RSpec.configuration).to receive(:location_rerun_uses_line_number).and_return(true)
+      allow(RSpec.configuration).to receive(:use_line_number_for_failed_spec_location_rerun).and_return(true)
     end
 
     context "when the shared examples are defined in the same file as the spec" do

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe 'Failed spec rerun location' do
           rspec './local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context behaves like a failing spec when you reverse it still fails
         EOS
     end
+
     context "and the shared examples are defined in a separate file" do
       it 'prints the example id of the failed assertion' do
         run_command("#{Dir.pwd}/tmp/aruba/non_local_shared_examples_spec.rb")
@@ -113,6 +114,7 @@ RSpec.describe 'Failed spec rerun location' do
         EOS
       end
     end
+
     context "and the shared examples are defined in a separate file" do
       it 'prints the line number where the `it_behaves_like` was called in the local file' do
         run_command("#{Dir.pwd}/tmp/aruba/non_local_shared_examples_spec.rb")

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -127,7 +127,6 @@ RSpec.describe 'Failed spec rerun location' do
           rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec fails
           rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec when you reverse it still fails
         EOS
-        
       end
     end
   end

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -1,0 +1,52 @@
+require 'support/aruba_support'
+
+RSpec.describe 'Failed spec rerun location' do
+  subject(:run_spec) do
+    file = cd('.') { "#{Dir.pwd}/failing_spec.rb" }
+    load file
+    run_command 'failing_spec.rb'
+  end
+
+  include_context "aruba support"
+
+  before do
+    setup_aruba
+    write_file "failing_spec.rb", "
+            RSpec.describe do
+                shared_examples_for 'a failing spec' do
+                    it 'fails' do
+                        expect(1).to eq(2)
+                    end
+                end
+
+                context 'the first context' do
+                    it_behaves_like 'a failing spec'
+                end
+
+                context 'the second context' do
+                    it_behaves_like 'a failing spec'
+                end
+            end
+        "
+  end
+
+  it 'prints the example ids' do
+    run_spec
+
+    expect(last_cmd_stdout).to include("/failing_spec.rb[1:1:1:1]")
+    expect(last_cmd_stdout).to include("/failing_spec.rb[1:2:1:1]")
+  end
+
+  context "when config.location_rerun_failed_example_uses_line_number is set to true" do
+    before do
+      RSpec.configuration.location_rerun_failed_example_uses_line_number = true
+    end
+
+    it 'prints the line numbers' do
+      run_spec
+
+      expect(last_cmd_stdout).to include("/failing_spec.rb:10")
+      expect(last_cmd_stdout).to include("/failing_spec.rb:14")
+    end
+  end
+end

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Failed spec rerun location' do
 
     # Setup some shared examples and call them in a separate file
     # from where they are called to demonstrate how nested example ids work
-    write_file "some_examples.rb", "
+    write_file_formatted "some_examples.rb", "
       RSpec.shared_examples_for 'a failing spec' do
         it 'fails' do
           expect(1).to eq(2)
@@ -26,7 +26,7 @@ RSpec.describe 'Failed spec rerun location' do
     file = cd('.') { "#{Dir.pwd}/some_examples.rb" }
     load file
 
-    write_file "non_local_shared_examples_spec.rb", "
+    write_file_formatted "non_local_shared_examples_spec.rb", "
       RSpec.describe do
         context 'the first context' do
           it_behaves_like 'a failing spec'
@@ -39,7 +39,7 @@ RSpec.describe 'Failed spec rerun location' do
     "
 
     # Setup some shared examples in the same file as where they are called
-    write_file "local_shared_examples_spec.rb", "
+    write_file_formatted "local_shared_examples_spec.rb", "
       RSpec.describe do
         shared_examples_for 'a failing spec' do
           it 'fails' do
@@ -107,10 +107,10 @@ RSpec.describe 'Failed spec rerun location' do
         expect(last_cmd_stdout).to include unindent(<<-EOS)
           Failed examples:
 
-          rspec ./local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
-          rspec ./local_shared_examples_spec.rb:9 #  the first context behaves like a failing spec when you reverse it still fails
-          rspec ./local_shared_examples_spec.rb:4 #  the second context behaves like a failing spec fails
-          rspec ./local_shared_examples_spec.rb:9 #  the second context behaves like a failing spec when you reverse it still fails
+          rspec ./local_shared_examples_spec.rb:3 #  the first context behaves like a failing spec fails
+          rspec ./local_shared_examples_spec.rb:8 #  the first context behaves like a failing spec when you reverse it still fails
+          rspec ./local_shared_examples_spec.rb:3 #  the second context behaves like a failing spec fails
+          rspec ./local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec when you reverse it still fails
         EOS
       end
     end
@@ -122,10 +122,10 @@ RSpec.describe 'Failed spec rerun location' do
         expect(last_cmd_stdout).to include unindent(<<-EOS)
           Failed examples:
 
-          rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
-          rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec when you reverse it still fails
-          rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec fails
-          rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec when you reverse it still fails
+          rspec ./non_local_shared_examples_spec.rb:3 #  the first context behaves like a failing spec fails
+          rspec ./non_local_shared_examples_spec.rb:3 #  the first context behaves like a failing spec when you reverse it still fails
+          rspec ./non_local_shared_examples_spec.rb:7 #  the second context behaves like a failing spec fails
+          rspec ./non_local_shared_examples_spec.rb:7 #  the second context behaves like a failing spec when you reverse it still fails
         EOS
       end
     end

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Failed spec rerun location' do
     write_file "some_examples.rb", "
       RSpec.shared_examples_for 'a failing spec' do
         it 'fails' do
-            expect(1).to eq(2)
+          expect(1).to eq(2)
         end
 
         context 'when you reverse it' do
@@ -20,48 +20,48 @@ RSpec.describe 'Failed spec rerun location' do
             expect(2).to eq(1)
           end
         end
-    end
+      end
     "
 
     file = cd('.') { "#{Dir.pwd}/some_examples.rb" }
     load file
 
     write_file "non_local_shared_examples_spec.rb", "
-    RSpec.describe do
+      RSpec.describe do
         context 'the first context' do
-            it_behaves_like 'a failing spec'
+          it_behaves_like 'a failing spec'
         end
 
         context 'the second context' do
-            it_behaves_like 'a failing spec'
+          it_behaves_like 'a failing spec'
         end
-    end
-"
-    # Setup some shared examples in the same file as where they are called
-    write_file "local_shared_examples_spec.rb", "
-      RSpec.describe do
-          shared_examples_for 'a failing spec' do
-              it 'fails' do
-                  expect(1).to eq(2)
-              end
-
-              context 'when you reverse it' do
-                it 'still fails' do
-                  expect(2).to eq(1)
-                end
-              end
-          end
-
-          context 'the first context' do
-              it_behaves_like 'a failing spec'
-          end
-
-          context 'the second context' do
-              it_behaves_like 'a failing spec'
-          end
       end
     "
 
+    # Setup some shared examples in the same file as where they are called
+    write_file "local_shared_examples_spec.rb", "
+      RSpec.describe do
+        shared_examples_for 'a failing spec' do
+          it 'fails' do
+            expect(1).to eq(2)
+          end
+
+          context 'when you reverse it' do
+            it 'still fails' do
+              expect(2).to eq(1)
+            end
+          end
+        end
+
+        context 'the first context' do
+          it_behaves_like 'a failing spec'
+        end
+
+        context 'the second context' do
+          it_behaves_like 'a failing spec'
+        end
+      end
+    "
   end
 
   context "when config.force_line_number_for_spec_rerun is set to false" do

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -1,6 +1,7 @@
 require 'support/aruba_support'
 
 RSpec.describe 'Failed spec rerun location' do
+  include RSpecHelpers
 
   include_context "aruba support"
 
@@ -68,29 +69,27 @@ RSpec.describe 'Failed spec rerun location' do
     it 'prints the example id of the failed assertion' do
       run_command("#{Dir.pwd}/tmp/aruba/local_shared_examples_spec.rb")
 
-      expect(last_cmd_stdout).to include(<<-MSG
-Failed examples:
+      expect(last_cmd_stdout).to include unindent(<<-EOS)
+          Failed examples:
 
-rspec './local_shared_examples_spec.rb[1:1:1:1]' #  the first context behaves like a failing spec fails
-rspec './local_shared_examples_spec.rb[1:1:1:2:1]' #  the first context behaves like a failing spec when you reverse it still fails
-rspec './local_shared_examples_spec.rb[1:2:1:1]' #  the second context behaves like a failing spec fails
-rspec './local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context behaves like a failing spec when you reverse it still fails
-      MSG
-      )
+          rspec './local_shared_examples_spec.rb[1:1:1:1]' #  the first context behaves like a failing spec fails
+          rspec './local_shared_examples_spec.rb[1:1:1:2:1]' #  the first context behaves like a failing spec when you reverse it still fails
+          rspec './local_shared_examples_spec.rb[1:2:1:1]' #  the second context behaves like a failing spec fails
+          rspec './local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context behaves like a failing spec when you reverse it still fails
+        EOS
     end
     context "and the shared examples are defined in a separate file" do
       it 'prints the example id of the failed assertion' do
         run_command("#{Dir.pwd}/tmp/aruba/non_local_shared_examples_spec.rb")
 
-        expect(last_cmd_stdout).to include(<<-MSG
-Failed examples:
+        expect(last_cmd_stdout).to include unindent(<<-EOS)
+          Failed examples:
 
-rspec './non_local_shared_examples_spec.rb[1:1:1:1]' #  the first context behaves like a failing spec fails
-rspec './non_local_shared_examples_spec.rb[1:1:1:2:1]' #  the first context behaves like a failing spec when you reverse it still fails
-rspec './non_local_shared_examples_spec.rb[1:2:1:1]' #  the second context behaves like a failing spec fails
-rspec './non_local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context behaves like a failing spec when you reverse it still fails
-        MSG
-        )
+          rspec './non_local_shared_examples_spec.rb[1:1:1:1]' #  the first context behaves like a failing spec fails
+          rspec './non_local_shared_examples_spec.rb[1:1:1:2:1]' #  the first context behaves like a failing spec when you reverse it still fails
+          rspec './non_local_shared_examples_spec.rb[1:2:1:1]' #  the second context behaves like a failing spec fails
+          rspec './non_local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context behaves like a failing spec when you reverse it still fails
+        EOS
       end
     end
   end
@@ -105,30 +104,29 @@ rspec './non_local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context beh
       it 'prints the line number where the assertion failed in the local file' do
         run_command("#{Dir.pwd}/tmp/aruba/local_shared_examples_spec.rb")
 
-        expect(last_cmd_stdout).to include(<<-MSG
-Failed examples:
+        expect(last_cmd_stdout).to include unindent(<<-EOS)
+          Failed examples:
 
-rspec ./local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
-rspec ./local_shared_examples_spec.rb:9 #  the first context behaves like a failing spec when you reverse it still fails
-rspec ./local_shared_examples_spec.rb:4 #  the second context behaves like a failing spec fails
-rspec ./local_shared_examples_spec.rb:9 #  the second context behaves like a failing spec when you reverse it still fails
-        MSG
-        )
+          rspec ./local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
+          rspec ./local_shared_examples_spec.rb:9 #  the first context behaves like a failing spec when you reverse it still fails
+          rspec ./local_shared_examples_spec.rb:4 #  the second context behaves like a failing spec fails
+          rspec ./local_shared_examples_spec.rb:9 #  the second context behaves like a failing spec when you reverse it still fails
+        EOS
       end
     end
     context "and the shared examples are defined in a separate file" do
       it 'prints the line number where the `it_behaves_like` was called in the local file' do
-
         run_command("#{Dir.pwd}/tmp/aruba/non_local_shared_examples_spec.rb")
-        expect(last_cmd_stdout).to include(<<-MSG
-Failed examples:
 
-rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
-rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec when you reverse it still fails
-rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec fails
-rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec when you reverse it still fails
-        MSG
-        )
+        expect(last_cmd_stdout).to include unindent(<<-EOS)
+          Failed examples:
+
+          rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
+          rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec when you reverse it still fails
+          rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec fails
+          rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec when you reverse it still fails
+        EOS
+        
       end
     end
   end

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -1,52 +1,111 @@
 require 'support/aruba_support'
 
 RSpec.describe 'Failed spec rerun location' do
-  subject(:run_spec) do
-    file = cd('.') { "#{Dir.pwd}/failing_spec.rb" }
-    load file
-    run_command 'failing_spec.rb'
-  end
 
   include_context "aruba support"
 
   before do
     setup_aruba
-    write_file "failing_spec.rb", "
-            RSpec.describe do
-                shared_examples_for 'a failing spec' do
-                    it 'fails' do
-                        expect(1).to eq(2)
-                    end
-                end
+    write_file "some_examples.rb", "
+      RSpec.shared_examples_for 'a failing spec' do
+          it 'fails' do
+              expect(1).to eq(2)
+          end
+      end
+    "
 
-                context 'the first context' do
-                    it_behaves_like 'a failing spec'
-                end
+    file = cd('.') { "#{Dir.pwd}/some_examples.rb" }
+    load file
 
-                context 'the second context' do
-                    it_behaves_like 'a failing spec'
-                end
+    write_file "local_shared_examples_spec.rb", "
+      RSpec.describe do
+          shared_examples_for 'a failing spec' do
+              it 'fails' do
+                  expect(1).to eq(2)
+              end
+          end
+
+          context 'the first context' do
+              it_behaves_like 'a failing spec'
+          end
+
+          context 'the second context' do
+              it_behaves_like 'a failing spec'
+          end
+      end
+    "
+
+    write_file "non_local_shared_examples_spec.rb", "
+        RSpec.describe do
+            context 'the first context' do
+                it_behaves_like 'a failing spec'
             end
-        "
+
+            context 'the second context' do
+                it_behaves_like 'a failing spec'
+            end
+        end
+    "
   end
 
-  it 'prints the example ids' do
-    run_spec
+  context "when config.location_rerun_uses_line_number is set to false" do
+    it 'prints the example id of the failed assertion' do
+      run_command("#{Dir.pwd}/tmp/aruba/local_shared_examples_spec.rb")
 
-    expect(last_cmd_stdout).to include("/failing_spec.rb[1:1:1:1]")
-    expect(last_cmd_stdout).to include("/failing_spec.rb[1:2:1:1]")
+      expect(last_cmd_stdout).to include(<<-MSG
+Failed examples:
+
+rspec './local_shared_examples_spec.rb[1:1:1:1]' #  the first context behaves like a failing spec fails
+rspec './local_shared_examples_spec.rb[1:2:1:1]' #  the second context behaves like a failing spec fails
+      MSG
+      )
+    end
+    context "and the shared examples are defined in a separate file" do
+      it 'prints the line number where the `it_behaves_like` was called in the local file' do
+        run_command("#{Dir.pwd}/tmp/aruba/non_local_shared_examples_spec.rb")
+
+        expect(last_cmd_stdout).to include(<<-MSG
+Failed examples:
+
+rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
+rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec fails
+        MSG
+        )
+      end
+    end
   end
 
   context "when config.location_rerun_uses_line_number is set to true" do
     before do
-      RSpec.configuration.location_rerun_uses_line_number = true
+      allow(RSpec.configuration).to receive(:location_rerun_uses_line_number).and_return(true)
     end
 
-    it 'prints the line numbers' do
-      run_spec
+    context "when the shared examples are defined in the same file as the spec" do
 
-      expect(last_cmd_stdout).to include("/failing_spec.rb:10")
-      expect(last_cmd_stdout).to include("/failing_spec.rb:14")
+      it 'prints the line number where the assertion failed in the local file' do
+        run_command("#{Dir.pwd}/tmp/aruba/local_shared_examples_spec.rb")
+
+        expect(last_cmd_stdout).to include(<<-MSG
+Failed examples:
+
+rspec ./local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
+rspec ./local_shared_examples_spec.rb:4 #  the second context behaves like a failing spec fails
+        MSG
+        )
+      end
+    end
+    context "and the shared examples are defined in a separate file" do
+      it 'prints the line number where the `it_behaves_like` was called in the local file' do
+
+        run_command("#{Dir.pwd}/tmp/aruba/non_local_shared_examples_spec.rb")
+        expect(last_cmd_stdout).to include(<<-MSG
+Failed examples:
+
+rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
+rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec fails
+        MSG
+        )
+      end
     end
   end
 end

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -6,22 +6,49 @@ RSpec.describe 'Failed spec rerun location' do
 
   before do
     setup_aruba
+
+    # Setup some shared examples and call them in a separate file
+    # from where they are called to demonstrate how nested example ids work
     write_file "some_examples.rb", "
       RSpec.shared_examples_for 'a failing spec' do
-          it 'fails' do
-              expect(1).to eq(2)
+        it 'fails' do
+            expect(1).to eq(2)
+        end
+
+        context 'when you reverse it' do
+          it 'still fails' do
+            expect(2).to eq(1)
           end
-      end
+        end
+    end
     "
 
     file = cd('.') { "#{Dir.pwd}/some_examples.rb" }
     load file
 
+    write_file "non_local_shared_examples_spec.rb", "
+    RSpec.describe do
+        context 'the first context' do
+            it_behaves_like 'a failing spec'
+        end
+
+        context 'the second context' do
+            it_behaves_like 'a failing spec'
+        end
+    end
+"
+    # Setup some shared examples in the same file as where they are called
     write_file "local_shared_examples_spec.rb", "
       RSpec.describe do
           shared_examples_for 'a failing spec' do
               it 'fails' do
                   expect(1).to eq(2)
+              end
+
+              context 'when you reverse it' do
+                it 'still fails' do
+                  expect(2).to eq(1)
+                end
               end
           end
 
@@ -35,17 +62,6 @@ RSpec.describe 'Failed spec rerun location' do
       end
     "
 
-    write_file "non_local_shared_examples_spec.rb", "
-        RSpec.describe do
-            context 'the first context' do
-                it_behaves_like 'a failing spec'
-            end
-
-            context 'the second context' do
-                it_behaves_like 'a failing spec'
-            end
-        end
-    "
   end
 
   context "when config.location_rerun_uses_line_number is set to false" do
@@ -56,19 +72,23 @@ RSpec.describe 'Failed spec rerun location' do
 Failed examples:
 
 rspec './local_shared_examples_spec.rb[1:1:1:1]' #  the first context behaves like a failing spec fails
+rspec './local_shared_examples_spec.rb[1:1:1:2:1]' #  the first context behaves like a failing spec when you reverse it still fails
 rspec './local_shared_examples_spec.rb[1:2:1:1]' #  the second context behaves like a failing spec fails
+rspec './local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context behaves like a failing spec when you reverse it still fails
       MSG
       )
     end
     context "and the shared examples are defined in a separate file" do
-      it 'prints the line number where the `it_behaves_like` was called in the local file' do
+      it 'prints the example id of the failed assertion' do
         run_command("#{Dir.pwd}/tmp/aruba/non_local_shared_examples_spec.rb")
 
         expect(last_cmd_stdout).to include(<<-MSG
 Failed examples:
 
-rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
-rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec fails
+rspec './non_local_shared_examples_spec.rb[1:1:1:1]' #  the first context behaves like a failing spec fails
+rspec './non_local_shared_examples_spec.rb[1:1:1:2:1]' #  the first context behaves like a failing spec when you reverse it still fails
+rspec './non_local_shared_examples_spec.rb[1:2:1:1]' #  the second context behaves like a failing spec fails
+rspec './non_local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context behaves like a failing spec when you reverse it still fails
         MSG
         )
       end
@@ -89,7 +109,9 @@ rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a
 Failed examples:
 
 rspec ./local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
+rspec ./local_shared_examples_spec.rb:9 #  the first context behaves like a failing spec when you reverse it still fails
 rspec ./local_shared_examples_spec.rb:4 #  the second context behaves like a failing spec fails
+rspec ./local_shared_examples_spec.rb:9 #  the second context behaves like a failing spec when you reverse it still fails
         MSG
         )
       end
@@ -102,7 +124,9 @@ rspec ./local_shared_examples_spec.rb:4 #  the second context behaves like a fai
 Failed examples:
 
 rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec fails
+rspec ./non_local_shared_examples_spec.rb:4 #  the first context behaves like a failing spec when you reverse it still fails
 rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec fails
+rspec ./non_local_shared_examples_spec.rb:8 #  the second context behaves like a failing spec when you reverse it still fails
         MSG
         )
       end

--- a/spec/integration/location_rerun_spec.rb
+++ b/spec/integration/location_rerun_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Failed spec rerun location' do
 
   end
 
-  context "when config.use_line_number_for_failed_spec_location_rerun is set to false" do
+  context "when config.force_line_number_for_spec_rerun is set to false" do
     it 'prints the example id of the failed assertion' do
       run_command("#{Dir.pwd}/tmp/aruba/local_shared_examples_spec.rb")
 
@@ -95,9 +95,9 @@ rspec './non_local_shared_examples_spec.rb[1:2:1:2:1]' #  the second context beh
     end
   end
 
-  context "when config.use_line_number_for_failed_spec_location_rerun is set to true" do
+  context "when config.force_line_number_for_spec_rerun is set to true" do
     before do
-      allow(RSpec.configuration).to receive(:use_line_number_for_failed_spec_location_rerun).and_return(true)
+      allow(RSpec.configuration).to receive(:force_line_number_for_spec_rerun).and_return(true)
     end
 
     context "when the shared examples are defined in the same file as the spec" do

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -1,6 +1,5 @@
 require 'tmpdir'
 require 'rspec/support/spec/in_sub_process'
-
 module RSpec::Core
   RSpec.describe Configuration do
     include RSpec::Support::InSubProcess
@@ -2976,6 +2975,18 @@ module RSpec::Core
           ArgumentError,
           '`pending_failure_output` can be set to :full, :no_backtrace, or :skip'
         )
+      end
+    end
+
+    describe "#location_rerun_failed_example_uses_line_number" do
+
+      it "defaults to false" do
+        expect(config.location_rerun_failed_example_uses_line_number).to eq false
+      end
+
+      it "is configurable" do
+        config.location_rerun_failed_example_uses_line_number = true
+        expect(config.location_rerun_failed_example_uses_line_number).to eq true
       end
     end
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -2978,15 +2978,15 @@ module RSpec::Core
       end
     end
 
-    describe "#location_rerun_failed_example_uses_line_number" do
+    describe "#location_rerun_uses_line_number" do
 
       it "defaults to false" do
-        expect(config.location_rerun_failed_example_uses_line_number).to eq false
+        expect(config.location_rerun_uses_line_number).to eq false
       end
 
       it "is configurable" do
-        config.location_rerun_failed_example_uses_line_number = true
-        expect(config.location_rerun_failed_example_uses_line_number).to eq true
+        config.location_rerun_uses_line_number = true
+        expect(config.location_rerun_uses_line_number).to eq true
       end
     end
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -2979,7 +2979,6 @@ module RSpec::Core
     end
 
     describe "#force_line_number_for_spec_rerun" do
-
       it "defaults to false" do
         expect(config.force_line_number_for_spec_rerun).to eq false
       end

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -2978,15 +2978,15 @@ module RSpec::Core
       end
     end
 
-    describe "#use_line_number_for_failed_spec_location_rerun" do
+    describe "#force_line_number_for_spec_rerun" do
 
       it "defaults to false" do
-        expect(config.use_line_number_for_failed_spec_location_rerun).to eq false
+        expect(config.force_line_number_for_spec_rerun).to eq false
       end
 
       it "is configurable" do
-        config.use_line_number_for_failed_spec_location_rerun = true
-        expect(config.use_line_number_for_failed_spec_location_rerun).to eq true
+        config.force_line_number_for_spec_rerun = true
+        expect(config.force_line_number_for_spec_rerun).to eq true
       end
     end
 

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -2978,15 +2978,15 @@ module RSpec::Core
       end
     end
 
-    describe "#location_rerun_uses_line_number" do
+    describe "#use_line_number_for_failed_spec_location_rerun" do
 
       it "defaults to false" do
-        expect(config.location_rerun_uses_line_number).to eq false
+        expect(config.use_line_number_for_failed_spec_location_rerun).to eq false
       end
 
       it "is configurable" do
-        config.location_rerun_uses_line_number = true
-        expect(config.location_rerun_uses_line_number).to eq true
+        config.use_line_number_for_failed_spec_location_rerun = true
+        expect(config.use_line_number_for_failed_spec_location_rerun).to eq true
       end
     end
 


### PR DESCRIPTION
Related to https://github.com/rspec/rspec/issues/16

## What is the change?
The out of the box behaviour has **not** changed, but a new configuration option has been added ✨ 
```
config.use_line_number_for_failed_spec_location_rerun
```
The end result is an output which is easier for humans and non-rspec computers (like `vim` or `vscode`) to jump to the location of the failure 🧑‍💻 

Say you use a `shared_example` (or setup your specs inside a loop):
```
# spec/temp_spec.rb

RSpec.describe do
    shared_examples_for 'a failing spec' do
        it 'fails' do
            expect(1).to eq(2)
        end
    end

    context 'the first context' do
        it_behaves_like 'a failing spec'
    end

    context 'the second context' do
        it_behaves_like 'a failing spec'
    end
end
```
The default output will look something like:
```
rspec './spec/temp_spec.rb[1:1:1:1]' #  the first context behaves like a failing spec fails
rspec './spec/temp_spec.rb[1:2:1:1]' #  the second context behaves like a failing spec fails
```

This PR adds the ability to instead print the failure line number:
```
rspec './spec/temp_spec.rb:10' #  the first context behaves like a failing spec fails
rspec './spec/temp_spec.rb:14' #  the second context behaves like a failing spec fails
```

### What if the shared example is defined in another file?
As you can see in the above, the failure line number is the line where `it_behaves_like` is called from, and this is the case if the `shared_example` is defined elsewhere (see new specs).

**Note** that there is no 'ideal' situation which will match the perfect amount of information in the CLI output to the ease of re-running and subsequent debugging of specs. The current solution allows for easy re-running of tests, but is not human readable, and the solution implemented in this PR is still easily re-runnable, and a bit more readable, but at the cost of requiring a little bit more inspection in your text editor 😄 

