### PR TITLE
Restore 100% test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   RSPEC_CI: true
   # This tells rspec-rails what branch to run in ci
   RSPEC_VERSION: '= 3.14.0.pre'
-  COVERAGE_ONLY_ON: "3.3"
+  ENFORCE_COVERAGE_AFTER: "3.1"
 jobs:
   rubocop:
     name: Rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   RSPEC_CI: true
   # This tells rspec-rails what branch to run in ci
   RSPEC_VERSION: '= 3.14.0.pre'
-  ENFORCE_COVERAGE_AFTER: "3.1"
+  ENFORCE_COVERAGE_AFTER: "3.2"
 jobs:
   rubocop:
     name: Rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,13 @@ jobs:
       - run: bundle install --standalone
       - run: bundle binstubs --all
       - run: script/run_build
+      - name: Store coverage output for reference
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: coverage-report-${{ matrix.ruby }}
+          path: coverage/index.html
+          retention-days: 14
 
   legacy:
     name: Legacy Ruby Builds (${{ matrix.container.version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ env:
   RSPEC_CI: true
   # This tells rspec-rails what branch to run in ci
   RSPEC_VERSION: '= 3.14.0.pre'
+  COVERAGE_ONLY_ON: "3.3"
 jobs:
   rubocop:
     name: Rubocop
@@ -129,6 +130,7 @@ jobs:
             options: "--add-host rubygems.org:151.101.129.227 --add-host api.rubygems.org:151.101.129.227"
     env:
       LEGACY_CI: true
+      NO_COVERAGE: true
       JRUBY_OPTS: ${{ matrix.container.jruby_opts || '--dev' }}
     steps:
       - uses: actions/checkout@v3

--- a/lib/rspec/core/bisect/fork_runner.rb
+++ b/lib/rspec/core/bisect/fork_runner.rb
@@ -102,6 +102,7 @@ module RSpec
         private
 
           def run_specs(run_descriptor)
+            # :nocov: - Executed in a forked process, by integration/bisect_spec
             $stdout = $stderr = @spec_output
             formatter = CaptureFormatter.new(run_descriptor.failed_example_ids)
 
@@ -125,6 +126,7 @@ module RSpec
             else
               @channel.send(latest_run_results)
             end
+            # :nocov:
           end
         end
 

--- a/lib/rspec/core/configuration_options.rb
+++ b/lib/rspec/core/configuration_options.rb
@@ -181,7 +181,9 @@ module RSpec
         if RUBY_VERSION >= '2.6'
           ERB.new(File.read(path), :trim_mode => '-').result(binding)
         else
+          # :nocov:
           ERB.new(File.read(path), nil, '-').result(binding)
+          # :nocov:
         end
       end
 

--- a/lib/rspec/core/did_you_mean.rb
+++ b/lib/rspec/core/did_you_mean.rb
@@ -20,9 +20,11 @@ module RSpec
         end
       else
         # return a hint if API for ::DidYouMean::SpellChecker not supported
+        # :nocov:
         def call
           "\nHint: Install the `did_you_mean` gem in order to provide suggestions for similarly named files."
         end
+        # :nocov:
       end
 
       private

--- a/lib/rspec/core/did_you_mean.rb
+++ b/lib/rspec/core/did_you_mean.rb
@@ -11,6 +11,7 @@ module RSpec
 
       if defined?(::DidYouMean::SpellChecker)
         # provide probable suggestions
+        # :nocov: - not installed on CI
         def call
           checker = ::DidYouMean::SpellChecker.new(:dictionary => Dir["spec/**/*.rb"])
           probables = checker.correct(relative_file_name.sub('./', ''))[0..2]
@@ -18,6 +19,7 @@ module RSpec
 
           formats probables
         end
+        # :nocov:
       else
         # return a hint if API for ::DidYouMean::SpellChecker not supported
         # :nocov:
@@ -29,6 +31,7 @@ module RSpec
 
       private
 
+      # :nocov:
       def formats(probables)
         rspec_format = probables.map { |s, _| "rspec ./#{s}" }
         red_font(top_and_tail rspec_format)
@@ -43,6 +46,7 @@ module RSpec
         colorizer = ::RSpec::Core::Formatters::ConsoleCodes
         colorizer.wrap mytext, :failure
       end
+      # :nocov:
     end
   end
 end

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -254,7 +254,9 @@ module RSpec
         rescue SnippetExtractor::NoSuchLineError
           ["Unable to find matching line in #{file_path}"]
         rescue SecurityError
+          # :nocov: - SecurityError is no longer produced starting in ruby 2.7
           ["Unable to read failed line"]
+          # :nocov:
         end
 
         def find_failed_line

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -191,11 +191,13 @@ module RSpec
             "A #{exception.class} for which `exception.message.to_s` raises #{other.class}."
           end
         else
+          # :nocov:
           def exception_message_string(exception)
             exception.message.to_s
           rescue Exception => other
             "A #{exception.class} for which `exception.message.to_s` raises #{other.class}."
           end
+          # :nocov:
         end
         # rubocop:enable Lint/RescueException
 
@@ -284,9 +286,11 @@ module RSpec
             encoded_string(description)
           end
         else # for 1.8.7
+          # :nocov:
           def encoded_description(description)
             description
           end
+          # :nocov:
         end
 
         def exception_backtrace

--- a/lib/rspec/core/formatters/html_snippet_extractor.rb
+++ b/lib/rspec/core/formatters/html_snippet_extractor.rb
@@ -93,7 +93,9 @@ module RSpec
             "# Couldn't get snippet for #{file}"
           end
         rescue SecurityError
+          # :nocov: - SecurityError is no longer produced starting in ruby 2.7
           "# Couldn't get snippet for #{file}"
+          # :nocov:
         end
 
         # @api private

--- a/lib/rspec/core/metadata.rb
+++ b/lib/rspec/core/metadata.rb
@@ -47,7 +47,7 @@ module RSpec
         return nil if line == '-e:1'.freeze
         line
       rescue SecurityError
-        # :nocov:
+        # :nocov: - SecurityError is no longer produced starting in ruby 2.7
         nil
         # :nocov:
       end

--- a/lib/rspec/core/rake_task.rb
+++ b/lib/rspec/core/rake_task.rb
@@ -47,6 +47,7 @@ module RSpec
 
       if RUBY_VERSION < "1.9.0" || Support::Ruby.jruby?
         # Run RSpec with a clean (empty) environment is not supported
+        # :nocov:
         def with_clean_environment=(_value)
           raise ArgumentError, "Running in a clean environment is not supported on Ruby versions before 1.9.0"
         end
@@ -55,6 +56,7 @@ module RSpec
         def with_clean_environment
           false
         end
+        # :nocov:
       else
         # Run RSpec with a clean (empty) environment.
         attr_accessor :with_clean_environment

--- a/script/rspec_with_simplecov
+++ b/script/rspec_with_simplecov
@@ -24,10 +24,7 @@ begin
   # Simplecov emits some ruby warnings when loaded, so silence them.
   old_verbose, $VERBOSE = $VERBOSE, false
 
-  skip_because_no_coverage = ENV['NO_COVERAGE']
-  skip_because_wrong_version = ENV['COVERAGE_ONLY_ON'] && ENV['COVERAGE_ONLY_ON'].to_f != RUBY_VERSION.to_f
-
-  unless skip_because_no_coverage || skip_because_wrong_version
+  unless ENV['NO_COVERAGE'] || RUBY_VERSION.to_f < 2.1
     require 'simplecov'
 
     SimpleCov.start do
@@ -35,7 +32,7 @@ begin
       add_filter %r{/bundle/}
       add_filter %r{/tmp/}
       add_filter %r{/spec/}
-      minimum_coverage(100) if RUBY_VERSION.to_f >= 3.1
+      minimum_coverage(100) if RUBY_VERSION.to_f >= ENV['ENFORCE_COVERAGE_AFTER'].to_f
     end
   end
 rescue LoadError # rubocop:disable Lint/SuppressedException

--- a/script/rspec_with_simplecov
+++ b/script/rspec_with_simplecov
@@ -24,7 +24,11 @@ begin
   # Simplecov emits some ruby warnings when loaded, so silence them.
   old_verbose, $VERBOSE = $VERBOSE, false
 
-  unless ENV['NO_COVERAGE'] || RUBY_VERSION.to_f < 2.1
+  skip_because_no_coverage = ENV['NO_COVERAGE']
+  skip_because_ruby_too_low = RUBY_VERSION.to_f < 2.1
+  skip_because_wrong_version = ENV['COVERAGE_ONLY_ON'] && ENV['COVERAGE_ONLY_ON'].to_f != RUBY_VERSION.to_f
+
+  unless skip_because_no_coverage || skip_because_ruby_too_low || skip_because_wrong_version
     require 'simplecov'
 
     SimpleCov.start do

--- a/script/rspec_with_simplecov
+++ b/script/rspec_with_simplecov
@@ -25,10 +25,9 @@ begin
   old_verbose, $VERBOSE = $VERBOSE, false
 
   skip_because_no_coverage = ENV['NO_COVERAGE']
-  skip_because_ruby_too_low = RUBY_VERSION.to_f < 2.1
   skip_because_wrong_version = ENV['COVERAGE_ONLY_ON'] && ENV['COVERAGE_ONLY_ON'].to_f != RUBY_VERSION.to_f
 
-  unless skip_because_no_coverage || skip_because_ruby_too_low || skip_because_wrong_version
+  unless skip_because_no_coverage || skip_because_wrong_version
     require 'simplecov'
 
     SimpleCov.start do
@@ -36,7 +35,7 @@ begin
       add_filter %r{/bundle/}
       add_filter %r{/tmp/}
       add_filter %r{/spec/}
-      minimum_coverage(100)
+      minimum_coverage(100) if RUBY_VERSION.to_f >= 3.1
     end
   end
 rescue LoadError # rubocop:disable Lint/SuppressedException

--- a/script/rspec_with_simplecov
+++ b/script/rspec_with_simplecov
@@ -32,7 +32,7 @@ begin
       add_filter %r{/bundle/}
       add_filter %r{/tmp/}
       add_filter %r{/spec/}
-      minimum_coverage(99)
+      minimum_coverage(100)
     end
   end
 rescue LoadError # rubocop:disable Lint/SuppressedException

--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -30,6 +30,23 @@ RSpec.describe 'Spec file load errors' do
     end
   end
 
+  it 'nicely handles load errors from --require files' do
+    run_command "--require ./helper_with_load_error"
+    expect(last_cmd_exit_status).to eq(error_exit_code)
+    output = normalize_durations(last_cmd_stdout)
+    expect(output).to include("An error occurred while loading ./helper_with_load_error.")
+    expect(output).to include("LoadError:")
+  end
+
+  it 'nicely handles syntax errors from --require files' do
+    write_file_formatted "helper_with_syntax_error.rb", "3 = hello"
+
+    run_command "--require ./helper_with_syntax_error"
+    expect(last_cmd_exit_status).to eq(error_exit_code)
+    output = normalize_durations(last_cmd_stdout)
+    expect(output).to include("While loading ./helper_with_syntax_error a `raise SyntaxError` occurred, RSpec will now quit.")
+  end
+
   it 'nicely handles load-time errors from --require files' do
     write_file_formatted "helper_with_error.rb", "raise 'boom'"
 

--- a/spec/rspec/core/bisect/shell_runner_spec.rb
+++ b/spec/rspec/core/bisect/shell_runner_spec.rb
@@ -8,6 +8,10 @@ module RSpec::Core
     let(:shell_command) { Bisect::ShellCommand.new(original_cli_args) }
     let(:runner) { described_class.new(server, shell_command) }
 
+    it "has the expected name" do
+      expect(described_class.name).to eq(:shell)
+    end
+
     describe "#run" do
       let(:original_cli_args) { %w[ spec/1_spec.rb ] }
       let(:target_specs) { %w[ spec/1_spec.rb[1:1] spec/1_spec.rb[1:2] ] }

--- a/spec/rspec/core/drb_spec.rb
+++ b/spec/rspec/core/drb_spec.rb
@@ -138,6 +138,10 @@ RSpec.describe RSpec::Core::DRbOptions, :isolated_directory => true, :isolated_h
       expect(drb_argv_for(%w[--failure-exit-code 2])).to include("--failure-exit-code", "2")
     end
 
+    it "includes --error-exit-code" do
+      expect(drb_argv_for(%w[--error-exit-code 5])).to include("--error-exit-code", "5")
+    end
+
     it "includes --options" do
       expect(drb_argv_for(%w[--options custom.opts])).to include("--options", "custom.opts")
     end

--- a/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -633,7 +633,7 @@ module RSpec::Core
         end
       end
 
-      context "when backtrace will generate a security error" do
+      context "when backtrace will generate a security error", :skip => !RSpec::Support::RubyFeatures.supports_taint? do
         let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"]) }
 
         it "is handled gracefully" do

--- a/spec/rspec/core/memoized_helpers_spec.rb
+++ b/spec/rspec/core/memoized_helpers_spec.rb
@@ -670,6 +670,28 @@ module RSpec::Core
     end
   end
 
+  RSpec.describe 'custom matcher that does not specify if it supports value expectations' do
+    let(:value_matcher_class) do
+      Class.new do
+        def matches?(_actual); true; end
+        def failure_message_when_negated; "oops"; end
+      end
+    end
+    let(:value_matcher) { value_matcher_class.new }
+
+    before { expect(value_matcher).not_to respond_to(:supports_value_expectations?) }
+
+    it '`should` does not print a deprecation warning when given a value' do
+      expect_no_deprecations
+      expect { should value_matcher }.not_to raise_error
+    end
+
+    it '`should_not` does not print a deprecation warning when given a value' do
+      expect_no_deprecations
+      expect { should_not value_matcher }.to raise_error(Exception)
+    end
+  end
+
   RSpec.describe 'Module#define_method' do
     it 'retains its normal private visibility on Ruby versions where it is normally private', :if => RUBY_VERSION < '2.5' do
       a_module = Module.new

--- a/spec/rspec/core/metadata_spec.rb
+++ b/spec/rspec/core/metadata_spec.rb
@@ -13,8 +13,9 @@ module RSpec
         it "returns nil if passed an unparseable file:line combo" do
           expect(Metadata.relative_path("-e:1")).to be_nil
         end
+
         # I have no idea what line = line.sub(/\A([^:]+:\d+)$/, '\\1') is supposed to do
-        it "gracefully returns nil if run in a secure thread" do
+        it "gracefully returns nil if run in a secure thread", :skip => !RSpec::Support::RubyFeatures.supports_taint? do
           # Ensure our call to `File.expand_path` is not cached as that is the insecure operation.
           Metadata.instance_eval { @relative_path_regex = nil }
 


### PR DESCRIPTION
This is _mostly_ annotational, but there were a few minor tests missing from however long the coverage-check was busted.
The larger items:

* Add :nocov: annotations to some version-specific code
* Mark all SecurityError-related code as :nocov:, and conditionalize a few of the specs related to it based on `RSpec::Support::RubyFeatures.supports_taint?`. They were passing anyway, since they were just checking for "doesn't raise an error", but they weren't actually testing what they said they were testing, when run against anything after ruby-2.6
* Mark the `ForkRunner#run_specs` method as :nocov: - it actually _is_ fully covered, but it only executes _in a forked process_, when run by the `integration/bisect_spec.rb`, and the Coverage run in the main process doesn't hear about it. But I manually checked, and both conditional branches are getting exercised.
* Mark the DidYouMean wrapper as `:nocov:`, since the gem isn't installed on CI - none of the code inside this file can be exercised there (though it is covered anywhere it can run)
* Add a few obvious specs, based on existing adjacent specs
* Add a silly spec for `Bisect::ShellRunner.name` which maybe should just be deleted instead? It's not clear that this method is necessary - if anyone can be confident that it's _not_, I'd be just as happy to remove it. (But probably in another PR - I like keeping these kinds of things comment/test-only)
* Start requiring 100% coverage again, now that it's true.
* If the tests fail, store the coverage output as an artifact. This was because tracking down what lines were uncovered _on CI_ turned out to be fairly annoying; this will make it easy next time.