### PR TITLE
Fix minor typo in `around(:example)` warning (unbalanced backtick)

### DIFF
--- a/lib/rspec/core/hooks.rb
+++ b/lib/rspec/core/hooks.rb
@@ -461,7 +461,7 @@ module RSpec
             # TODO: consider making this an error in RSpec 4. For SemVer reasons,
             # we are only warning in RSpec 3.
             RSpec.warn_with "WARNING: `around(:context)` hooks are not supported and " \
-                            "behave like `around(:example)."
+                            "behave like `around(:example)`."
           end
 
           hook = HOOK_TYPES[position][scope].new(block, options)


### PR DESCRIPTION
I encountered this warning in a codebase, and copy/pasted the message into my fix commit. Then I noticed a missing backtick and assumed I had copy/pasted wrong, but found it missing in the source. So, here's a one-byte patch for that 😁

Related:
- #2687