### PR TITLE
Fixed rspec --bisect to sort ids_to_run as the original order

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 ### Development
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.13.0...main)
 
+Bug fixes:
+
+* Sort ids to run as the original order to fix `--bisect`. (Maki Kawahara, #3093)
+
 ### 3.13.0 / 2024-02-04
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.12.3...v3.13.0)
 

--- a/lib/rspec/core/bisect/example_minimizer.rb
+++ b/lib/rspec/core/bisect/example_minimizer.rb
@@ -136,7 +136,7 @@ module RSpec
         end
 
         def get_expected_failures_for?(ids)
-          ids_to_run = ids + failed_example_ids
+          ids_to_run = all_example_ids & (ids + failed_example_ids)
           notify(
             :bisect_individual_run_start,
             :command => shell_command.repro_command_from(ids_to_run),

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -35,6 +35,19 @@ module RSpec::Core
       end
     end
 
+    context "when the spec ordering is consistent" do
+      it 'returns the minimal reproduction command' do
+        output = bisect(%w[
+          --order defined
+          spec/rspec/core/resources/bisect/consistently_ordered_1_specs.rb
+          spec/rspec/core/resources/bisect/consistently_ordered_2_specs.rb
+          spec/rspec/core/resources/bisect/consistently_ordered_3_specs.rb
+          spec/rspec/core/resources/bisect/consistently_ordered_4_specs.rb
+        ])
+        expect(output).to include("Bisect complete!", "rspec ./spec/rspec/core/resources/bisect/consistently_ordered_2_specs.rb[1:1] ./spec/rspec/core/resources/bisect/consistently_ordered_3_specs.rb[1:1]")
+      end
+    end
+
     context "when the bisect command saturates the pipe" do
       # On OSX and Linux a file descriptor limit meant that the bisect process got stuck at a certain limit.
       # This test demonstrates that we can run large bisects above this limit (found to be at time of commit).

--- a/spec/rspec/core/resources/bisect/consistently_ordered_1_specs.rb
+++ b/spec/rspec/core/resources/bisect/consistently_ordered_1_specs.rb
@@ -1,0 +1,5 @@
+# Deliberately named _specs.rb to avoid being loaded except when specified
+
+RSpec.describe "Order1" do
+  it("passes") { expect(1).to eq 1 }
+end

--- a/spec/rspec/core/resources/bisect/consistently_ordered_2_specs.rb
+++ b/spec/rspec/core/resources/bisect/consistently_ordered_2_specs.rb
@@ -1,0 +1,9 @@
+# Deliberately named _specs.rb to avoid being loaded except when specified
+
+require "rspec/core/resources/bisect/frieren_quote"
+
+RSpec.describe "Order2" do
+  before { FrierenQuote.change }
+
+  it("passes") { expect(1).to eq 1 }
+end

--- a/spec/rspec/core/resources/bisect/consistently_ordered_3_specs.rb
+++ b/spec/rspec/core/resources/bisect/consistently_ordered_3_specs.rb
@@ -1,0 +1,7 @@
+# Deliberately named _specs.rb to avoid being loaded except when specified
+
+require "rspec/core/resources/bisect/frieren_quote"
+
+RSpec.describe "Order3" do
+  it("fails order-dependency")  { expect(FrierenQuote.one).to eq "That is what hero Himmel would have done." }
+end

--- a/spec/rspec/core/resources/bisect/consistently_ordered_4_specs.rb
+++ b/spec/rspec/core/resources/bisect/consistently_ordered_4_specs.rb
@@ -1,0 +1,5 @@
+# Deliberately named _specs.rb to avoid being loaded except when specified
+
+RSpec.describe "Order4" do
+  it("passes") { expect(1).to eq 1 }
+end

--- a/spec/rspec/core/resources/bisect/frieren_quote.rb
+++ b/spec/rspec/core/resources/bisect/frieren_quote.rb
@@ -1,0 +1,12 @@
+class FrierenQuote
+  class << self
+    def one
+      @@one ||= "That is what hero Himmel would have done."
+    end
+
+    def change
+      @@one = "The greatest enjoyment comes only during the pursuit of magic, you know."
+    end
+  end
+end
+

--- a/spec/support/fake_bisect_runner.rb
+++ b/spec/support/fake_bisect_runner.rb
@@ -16,7 +16,7 @@ FakeBisectRunner = Struct.new(:all_ids, :always_failures, :dependent_failures) d
       failures << failing_example if dependency_satisfied?(depends_upon, ids)
     end
 
-    RSpec::Core::Bisect::ExampleSetDescriptor.new(ids.sort, failures.sort)
+    RSpec::Core::Bisect::ExampleSetDescriptor.new(ids, failures.sort)
   end
 
 private


### PR DESCRIPTION
In `RSpec::Core::Bisect::ExampleMinimizer#abort_if_ordering_inconsistent`, minimizer checks the execution order of the devided ids are the same as the original order. So we need to sort them as the original order before run.

For example,
When we have 4 examples: 1.rb, 2.rb, 3.rb, 4.rb and 3.rb is failure order-dependent with 2.rb.
We expect to minimizer reproduce command `rspec 2.rb[1] 3.rb[1]`, but minimizer raises 'The example ordering is inconsistent.'
This is because the ids to run are in the order 4.rb 2.rb (diffrent from the original), so fixed to sort them in the same order as the original error.