### PR TITLE
Call super in Formatter.close methods to ensure sync is reset

### DIFF
--- a/lib/rspec/core/formatters/base_formatter.rb
+++ b/lib/rspec/core/formatters/base_formatter.rb
@@ -23,6 +23,7 @@ module RSpec
         def initialize(output)
           @output = output || StringIO.new
           @example_group = nil
+          @sync_started = false
         end
 
         # @api public
@@ -48,21 +49,28 @@ module RSpec
         # @param _notification [NullNotification] (Ignored)
         # @see RSpec::Core::Formatters::Protocol#close
         def close(_notification)
-          restore_sync_output if output_supports_sync && !output.closed?
+          restore_sync_output
         end
 
       private
 
         def start_sync_output
-          @old_sync, output.sync = output.sync, true if output_supports_sync
+          if output_supports_sync
+            @sync_started = true
+            @old_sync, output.sync = output.sync, true
+          end
         end
 
         def restore_sync_output
-          output.sync = @old_sync if output_supports_sync && !output.closed?
+          output.sync = @old_sync if sync_started? && !output.closed?
         end
 
         def output_supports_sync
           output.respond_to?(:sync=)
+        end
+
+        def sync_started?
+          @sync_started
         end
       end
     end

--- a/lib/rspec/core/formatters/base_formatter.rb
+++ b/lib/rspec/core/formatters/base_formatter.rb
@@ -48,7 +48,7 @@ module RSpec
         # @param _notification [NullNotification] (Ignored)
         # @see RSpec::Core::Formatters::Protocol#close
         def close(_notification)
-          restore_sync_output
+          restore_sync_output if output_supports_sync && !output.closed?
         end
 
       private

--- a/lib/rspec/core/formatters/base_formatter.rb
+++ b/lib/rspec/core/formatters/base_formatter.rb
@@ -62,7 +62,10 @@ module RSpec
         end
 
         def restore_sync_output
-          output.sync = @old_sync if sync_started? && !output.closed?
+          if sync_started?
+            @sync_started = false
+            output.sync = @old_sync unless output.closed?
+          end
         end
 
         def output_supports_sync

--- a/lib/rspec/core/formatters/base_text_formatter.rb
+++ b/lib/rspec/core/formatters/base_text_formatter.rb
@@ -63,11 +63,11 @@ module RSpec
         #
         # @param _notification [NullNotification] (Ignored)
         def close(_notification)
-          return if output.closed?
-
-          output.puts
-
-          output.flush
+          unless output.closed?
+            output.puts
+            output.flush
+          end
+          super
         end
       end
     end

--- a/lib/rspec/core/formatters/json_formatter.rb
+++ b/lib/rspec/core/formatters/json_formatter.rb
@@ -55,6 +55,7 @@ module RSpec
 
         def close(_notification)
           output.write @output_hash.to_json
+          super
         end
 
         def dump_profile(profile)

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
 
     before do
       # Call `formatter.start` in order to initialize `@old_sync` before using in `BaseFormatter#close`
-      formatter.start(RSpec::Core::Notifications::StartNotification.new({count: 1}))
+      formatter.start(RSpec::Core::Notifications::StartNotification.new({:count => 1}))
     end
 
     after do

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
 
     before do
       # Call `formatter.start` in order to initialize `@old_sync` before using in `BaseFormatter#close`
-      formatter.start(RSpec::Core::Notifications::StartNotification.new(count: 1))
+      formatter.start(RSpec::Core::Notifications::StartNotification.new({count: 1}))
     end
 
     after do

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -37,9 +37,6 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     end
 
     it "restores the output's sync setting" do
-      if !output_to_close.respond_to?(:sync=)
-        skip "output_to_close does not support sync, so closing the formatter will not reset it"
-      end
       expect {
         formatter.close(RSpec::Core::Notifications::NullNotification)
       }.to change(output_to_close, :sync).from(true).to(false)

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
       if !output_to_close.respond_to?(:sync=)
         skip "output_to_close does not support sync, so closing the formatter will not reset it"
       end
-      # formatter.start(RSpec::Core::Notifications::StartNotification.new(count: 0))
       expect {
         formatter.close(RSpec::Core::Notifications::NullNotification)
       }.to change(output_to_close, :sync).from(true).to(false)

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -8,16 +8,13 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     let(:output_to_close) { File.new("./output_to_close", "w") }
     let(:formatter) { described_class.new(output_to_close) }
 
-    before do
-      # Call `formatter.start` in order to initialize `@old_sync` before using in `BaseFormatter#close`
-      formatter.start(RSpec::Core::Notifications::StartNotification.new({:count => 1}))
-    end
-
     after do
       # Windows appears to not let the `:isolated_directory` shared group
       # cleanup if the file isn't closed.
       output_to_close.close unless output_to_close.closed?
     end
+
+    it_behaves_like "formatter stream reset sync on close"
 
     it 'does not error on an already closed output stream' do
       output_to_close.close
@@ -34,12 +31,6 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     it "does not close the stream so that it can be reused within a process" do
       formatter.close(RSpec::Core::Notifications::NullNotification)
       expect(output_to_close.closed?).to be(false)
-    end
-
-    it "restores the output's sync setting" do
-      expect {
-        formatter.close(RSpec::Core::Notifications::NullNotification)
-      }.to change(output_to_close, :sync).from(true).to(false)
     end
   end
 

--- a/spec/rspec/core/formatters/base_text_formatter_spec.rb
+++ b/spec/rspec/core/formatters/base_text_formatter_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     let(:output_to_close) { File.new("./output_to_close", "w") }
     let(:formatter) { described_class.new(output_to_close) }
 
+    before do
+      # Call `formatter.start` in order to initialize `@old_sync` before using in `BaseFormatter#close`
+      formatter.start(RSpec::Core::Notifications::StartNotification.new(count: 1))
+    end
+
     after do
       # Windows appears to not let the `:isolated_directory` shared group
       # cleanup if the file isn't closed.
@@ -29,6 +34,16 @@ RSpec.describe RSpec::Core::Formatters::BaseTextFormatter do
     it "does not close the stream so that it can be reused within a process" do
       formatter.close(RSpec::Core::Notifications::NullNotification)
       expect(output_to_close.closed?).to be(false)
+    end
+
+    it "restores the output's sync setting" do
+      if !output_to_close.respond_to?(:sync=)
+        skip "output_to_close does not support sync, so closing the formatter will not reset it"
+      end
+      # formatter.start(RSpec::Core::Notifications::StartNotification.new(count: 0))
+      expect {
+        formatter.close(RSpec::Core::Notifications::NullNotification)
+      }.to change(output_to_close, :sync).from(true).to(false)
     end
   end
 

--- a/spec/rspec/core/formatters/json_formatter_spec.rb
+++ b/spec/rspec/core/formatters/json_formatter_spec.rb
@@ -178,6 +178,20 @@ RSpec.describe RSpec::Core::Formatters::JsonFormatter do
       formatter.close(RSpec::Core::Notifications::NullNotification)
       expect(formatter_output.closed?).to be(false)
     end
+
+    context "file output", :isolated_directory => true do
+      # Use a File output because StringIO.sync is always true
+      let(:output_to_close) { File.new("./output_to_close", "w") }
+      let(:formatter) { described_class.new(output_to_close) }
+
+      after do
+        # Windows appears to not let the `:isolated_directory` shared group
+        # cleanup if the file isn't closed.
+        output_to_close.close unless output_to_close.closed?
+      end
+
+      it_behaves_like "formatter stream reset sync on close"
+    end
   end
 
   describe "#message" do

--- a/spec/support/shared_example_groups.rb
+++ b/spec/support/shared_example_groups.rb
@@ -45,3 +45,16 @@ RSpec.shared_examples_for "handling symlinked directories when loading spec file
     expect(loaded_files).to contain_files("spec/lib/DD/dd_foo_spec.rb")
   end
 end
+
+RSpec.shared_examples_for "formatter stream reset sync on close" do
+  before do
+    # Call `formatter.start` in order to initialize `@old_sync` before using in `BaseFormatter#close`
+    formatter.start(RSpec::Core::Notifications::StartNotification.new({:count => 1}))
+  end
+
+  it "restores the output's sync setting" do
+    expect {
+      formatter.close(RSpec::Core::Notifications::NullNotification)
+    }.to change(output_to_close, :sync).from(true).to(false)
+  end
+end


### PR DESCRIPTION
There were two instances (that I could find) of overridden methods in classes inheriting from `BaseFormatter` that likely should have called `super` to complete the cleanup.