### PR TITLE
Remove redundant require ostruct

### DIFF
--- a/spec/rspec/core/configuration_options_spec.rb
+++ b/spec/rspec/core/configuration_options_spec.rb
@@ -1,4 +1,3 @@
-require 'ostruct'
 require 'rspec/core/drb'
 
 RSpec.describe RSpec::Core::ConfigurationOptions, :isolated_directory => true, :isolated_home => true do


### PR DESCRIPTION
requiring ostruct was introduced at https://github.com/rspec/rspec-core/commit/5cd41d3420cd277c1132fba5ce4cff7a0a1367a3 and removed using OpenStruct at https://github.com/rspec/rspec-core/commit/d7e40339e9b329c661f9326407aea94c705dc223 .
ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0.

Related https://bugs.ruby-lang.org/issues/20309 https://github.com/ruby/ruby/pull/10428