### PR TITLE
docs: Add example of proc being acceptable as filter in config.include

### DIFF
--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1411,7 +1411,7 @@ module RSpec
       #       config.include(AuthenticationHelpers, :type => :request)
       #
       #       # included in examples where the `:type` metadata matches a proc condition
-      #       config.include(AuthenticationHelpers, :type => ->(type, _metadata) { [:request, :controller].include?(type) })
+      #       config.include(AuthenticationHelpers, :type => proc { |type, _metadata| [:request, :controller].include?(type) })
       #     end
       #
       #     describe "edit profile", :preferences, :type => :request do

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1409,6 +1409,9 @@ module RSpec
       #
       #       # included in examples with `:type => :request` metadata
       #       config.include(AuthenticationHelpers, :type => :request)
+      #
+      #       # included in examples where the `:type` metadata matches a proc condition
+      #       config.include(AuthenticationHelpers, :type => ->(type, _metadata) { [:request, :controller].include?(type) })
       #     end
       #
       #     describe "edit profile", :preferences, :type => :request do


### PR DESCRIPTION
While reading through [this issue discussion](https://github.com/rspec/rspec-core/issues/2890#issuecomment-825886660), I learned that Procs can be used as filters metadata.

In this PR, I am adding an example of using a Proc with the `config.include` method and the `:type` filter accepting proc as a value.