### PR TITLE
Fix the bisect runner breaking the `output` expectation

### DIFF
--- a/lib/rspec/core/bisect/fork_runner.rb
+++ b/lib/rspec/core/bisect/fork_runner.rb
@@ -81,7 +81,8 @@ module RSpec
             @runner = runner
             @channel = channel
 
-            @spec_output = StringIO.new
+            require "tempfile"
+            @spec_output = Tempfile.new
 
             runner.configuration.tap do |c|
               c.reset_reporter
@@ -122,7 +123,7 @@ module RSpec
             latest_run_results = formatter.results
 
             if latest_run_results.nil? || latest_run_results.all_example_ids.empty?
-              @channel.send(@spec_output.string)
+              @channel.send(@spec_output.tap(&:rewind).read)
             else
               @channel.send(latest_run_results)
             end

--- a/spec/integration/bisect_spec.rb
+++ b/spec/integration/bisect_spec.rb
@@ -68,6 +68,13 @@ module RSpec::Core
       end
     end
 
+    context "when specs use the `output` expectation" do
+      it 'does not break the capture helper' do
+        output = bisect(%w[spec/rspec/core/resources/bisect/output_capture_specs.rb])
+        expect(output).to include("No failures found")
+      end
+    end
+
     class RSpecChildProcess
       Ps = Struct.new(:pid, :ppid, :state, :command)
 

--- a/spec/rspec/core/resources/bisect/output_capture_specs.rb
+++ b/spec/rspec/core/resources/bisect/output_capture_specs.rb
@@ -1,0 +1,7 @@
+# Deliberately named _specs.rb to avoid being loaded except when specified
+
+RSpec.describe "output capture" do
+  it "can still capture output when running under --bisect" do
+    expect { puts "hi" }.to output("hi\n").to_stdout_from_any_process
+  end
+end


### PR DESCRIPTION
The bisect runner sets $stdout & $stderr to a StringIO. If your specs include `output.to_stdout_from_any_process` or `output.to_stderr_from_any_process`, CaptureStreamToTempfile would then introduce new errors during the bisect run, failing with `can't convert Tempfile into StringIO` [here](https://github.com/rspec/rspec-expectations/blob/838952dc1416c943e7933684c47249a77481e7f5/lib/rspec/matchers/built_in/output.rb#L231)

Here's one approach, which instead sets $stdout & $stderr to a Tempfile. WDYT? I know [previously](https://github.com/rspec/rspec-expectations/commit/8fa0535c60728a8bee06a6b19ea399ad1d44e51d) we've wanted to avoid adding a dependency on tempfile ... we could instead try fixing this at the rspec-expectations level, though not sure how feasible that is.