### PR TITLE
Relax constraint for Ruby 3.4.0 in file load error spec

### DIFF
--- a/spec/integration/spec_file_load_errors_spec.rb
+++ b/spec/integration/spec_file_load_errors_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe 'Spec file load errors' do
                 5  end
             EOS
           end
-          expect(formatted_output).to include "./tmp/aruba/broken_file.rb:5: syntax error"
+          expect(formatted_output).to include %r{./tmp/aruba/broken_file.rb:\d: syntax error}
 
           expect(formatted_output).to include unindent(<<-EOS)
             Finished in n.nnnn seconds (files took n.nnnn seconds to load)


### PR DESCRIPTION
Fixes a spec on ruby-head