### PR TITLE
As each file is required in RSpec::Core::Configuration, push it onto `requires`.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,11 @@ Enhancements:
   allways print a line number rather than an example id when the line number is ambiguous.
   (Baden Ashford, #3085)
 
+Bug fixes:
+
+* `RSpec::Configuration#requires` will reflect files already required, whilst requiring
+  them. (Jon Rowe, #3117)
+
 ### 3.13.1 / 2024-09-02
 [Full Changelog](http://github.com/rspec/rspec-core/compare/v3.13.0...v3.13.1)
 

--- a/lib/rspec/core/configuration.rb
+++ b/lib/rspec/core/configuration.rb
@@ -1604,8 +1604,10 @@ module RSpec
       def requires=(paths)
         directories = ['lib', default_path].select { |p| File.directory? p }
         RSpec::Core::RubyProject.add_to_load_path(*directories)
-        paths.each { |path| load_file_handling_errors(:require, path) }
-        @requires += paths
+        paths.each { |path|
+          load_file_handling_errors(:require, path)
+          @requires << path
+        }
       end
 
       # @private

--- a/spec/rspec/core/configuration_spec.rb
+++ b/spec/rspec/core/configuration_spec.rb
@@ -237,6 +237,16 @@ module RSpec::Core
         expect(config.requires).to eq ['a/path']
       end
 
+      it 'stores required paths "per file"' do
+        allow(config).to receive(:require).with('a/path')
+        expect(config).to receive(:require).with('another/path') do
+          expect(config.requires).to eq ['a/path']
+        end
+
+        config.requires = ['a/path', 'another/path']
+        expect(config.requires).to eq ['a/path', 'another/path']
+      end
+
       context "when `default_path` refers to a file rather than a directory" do
         it 'does not add it to the load path' do
           config.default_path = 'Rakefile'


### PR DESCRIPTION
We expose `RSpec::Core::Configuration#requires` to show the list of files configured to be required, but currently if you were to look at those files during the require process they would be empty, or partially complete based on any previous config passes, this is an attempt to make this slightly more transparent, I think recording the file as required after we have required it is the best compromise?

Fixes #3116 