### PR TITLE
Drop broken link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ can treat each RSpec repo as an independent project.
 
 ## Also see
 
+* [https://github.com/rspec/rspec-metagem](https://github.com/rspec/rspec-metagem)
 * [https://github.com/rspec/rspec-expectations](https://github.com/rspec/rspec-expectations)
 * [https://github.com/rspec/rspec-mocks](https://github.com/rspec/rspec-mocks)
 * [https://github.com/rspec/rspec-rails](https://github.com/rspec/rspec-rails)

--- a/README.md
+++ b/README.md
@@ -383,7 +383,6 @@ can treat each RSpec repo as an independent project.
 
 ## Also see
 
-* [https://github.com/rspec/rspec](https://github.com/rspec/rspec)
 * [https://github.com/rspec/rspec-expectations](https://github.com/rspec/rspec-expectations)
 * [https://github.com/rspec/rspec-mocks](https://github.com/rspec/rspec-mocks)
 * [https://github.com/rspec/rspec-rails](https://github.com/rspec/rspec-rails)


### PR DESCRIPTION
Just found broken link in README. I think you rearranged repository and now it is not available. I think you have forgotten to update readme