### PR TITLE
Fix the build by relaxing rubocop rule

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,8 +59,10 @@ elsif RUBY_VERSION < '2.0'
   gem 'ffi', '< 1.9.19' # ffi dropped Ruby 1.8 support in 1.9.19
 elsif RUBY_VERSION < '2.3.0'
   gem 'ffi', '~> 1.12.0'
-else
+elsif RUBY_VERSION < '2.6.0'
   gem 'ffi', '~> 1.15.0'
+else
+  gem 'ffi', '~> 1.17.0'
 end
 
 if RUBY_VERSION < '2.3.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)

--- a/lib/rspec/core/formatters/exception_presenter.rb
+++ b/lib/rspec/core/formatters/exception_presenter.rb
@@ -11,7 +11,12 @@ module RSpec
       class ExceptionPresenter
         attr_reader :exception, :example, :description, :message_color,
                     :detail_formatter, :extra_detail_formatter, :backtrace_formatter
+
+        # We want private attr_reader but that issues a warning on older rubies, refactor later
+        #
+        # rubocop:disable Style/AccessModifierDeclarations
         private :message_color, :detail_formatter, :extra_detail_formatter, :backtrace_formatter
+        # rubocop:enable Style/AccessModifierDeclarations
 
         def initialize(exception, example, options={})
           @exception               = exception


### PR DESCRIPTION
Turn off a rubocop rule we can't easily satisfy (we can't use a private attr_reader on older rubies and we don't want these to be public) and relax FFI constraints